### PR TITLE
macOS: cmake is not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ apt-get install cmake libfreetype6-dev libfontconfig1-dev xclip
 If you build Alacritty on another Linux distribution, we would love some help
 filling in this section of the README.
 
-#### Additional macOS Prerequisites
-
-It's possible `cmake` is needed on macOS to build Alacritty. If someone can
-verify this and make a PR clarifying either way, it would be greatly
-appreciated!
-
 ### Building
 
 Once all the prerequisites are installed, compiling Alacritty should be easy:


### PR DESCRIPTION
The build Works On My Machine (tm) without cmake. OSX 10.9.5

```
Alexs-MacBook-Air-3:alacritty alex$ brew unlink cmake
Unlinking /usr/local/Cellar/cmake/3.7.1... 426 symlinks removed
Alexs-MacBook-Air-3:alacritty alex$ which cmake
Alexs-MacBook-Air-3:alacritty alex$ cargo build --release
    [...]
    Finished release [optimized + debuginfo] target(s) in 209.75 secs
```