### PR TITLE
Fix compilation on ARM/AARCH64

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1039,7 +1039,7 @@ impl ShaderProgram {
 
         let shader = unsafe {
             let shader = gl::CreateShader(kind);
-            gl::ShaderSource(shader, 1, &(source.as_ptr() as *const i8), len.as_ptr());
+            gl::ShaderSource(shader, 1, &(source.as_ptr() as *const _), len.as_ptr());
             gl::CompileShader(shader);
             shader
         };

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -171,7 +171,7 @@ fn get_pw_entry(buf: &mut [i8; 1024]) -> Passwd {
     // Try and read the pw file.
     let uid = unsafe { libc::getuid() };
     let status = unsafe {
-        libc::getpwuid_r(uid, &mut entry, buf.as_mut_ptr(), buf.len(), &mut res)
+        libc::getpwuid_r(uid, &mut entry, buf.as_mut_ptr() as *mut _, buf.len(), &mut res)
     };
 
     if status < 0 {


### PR DESCRIPTION
```rust
error[E0308]: mismatched types
    --> src/renderer/mod.rs:1042:41
     |
1042 |             gl::ShaderSource(shader, 1, &(source.as_ptr() as *const i8), len.as_ptr());
     |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u8, found i8
     |
     = help: here are some functions which might fulfill your needs:
 - .offset(...)
 - .wrapping_offset(...)

error[E0308]: mismatched types
   --> src/tty.rs:174:43
    |
174 |         libc::getpwuid_r(uid, &mut entry, buf.as_mut_ptr(), buf.len(), &mut res)
    |                                           ^^^^^^^^^^^^^^^^ expected u8, found i8
    |
    = help: here are some functions which might fulfill your needs:
 - .offset(...)
 - .wrapping_offset(...)
````

Not exactly cross-platform, eh?

https://github.com/rust-lang/rust/issues/29867