### PR TITLE
Fix crash when exiting `top`

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -643,9 +643,10 @@ impl ansi::Handler for Term {
 
     #[inline]
     fn goto(&mut self, line: Line, col: Column) {
+        use std::cmp::min;
         debug_println!("goto: line={}, col={}", line, col);
-        self.cursor.line = line;
-        self.cursor.col = col;
+        self.cursor.line = min(line, self.grid.num_lines() - 1);
+        self.cursor.col = min(col, self.grid.num_cols() - 1);
     }
 
     #[inline]


### PR DESCRIPTION
This is a small change that fixes a highly-reproducible (at least on my end) crash that would occur when exiting `top`. The cursor would be set one line after the end of the screen, and then `clear_line` would be called. This would result in a panic on the self.grid `IndexMut` call.

Now, the visual behavior is identical to what I experience in other terminal emulators. When exiting `top`, the contents should remain behind, but a new line pops up at the bottom to allow you to continue interacting with the terminal.

This probably fixes other situations as well. It might be good to add some similar limiting to `goto_line` and similar functions.