### PR TITLE
Stop cursor from moving past right screen edge

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -703,7 +703,12 @@ impl ansi::Handler for Term {
     #[inline]
     fn move_forward(&mut self, cols: Column) {
         debug_println!("move_forward: {}", cols);
-        self.cursor.col += cols;
+        if self.cursor.col + cols > self.grid.num_cols() - 1 {
+            self.cursor.col = self.grid.num_cols() - 1;
+        }
+        else {
+            self.cursor.col += cols;
+        }
     }
 
     #[inline]


### PR DESCRIPTION
This fixes #133.

See discussion on #133 about whether or not this is the right way to fix #133. Naturally, if it isn't feel free to close this pull request.