### PR TITLE
Clear only new lines on resize.

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -512,11 +512,13 @@ impl Term {
             .collect::<Vec<bool>>();
 
         self.tabs[0] = false;
-
-        // Make sure bottom of terminal is clear
-        let template = self.empty_cell.clone();
-        self.grid.clear_region((self.cursor.line).., |c| c.reset(&template));
-        self.alt_grid.clear_region((self.cursor.line).., |c| c.reset(&template));
+        
+        // Make sure new lines at the bottom of terminal are clear
+        if num_lines > old_lines {
+            let template = self.empty_cell.clone();
+            self.grid.clear_region((self.cursor.line + 1).., |c| c.reset(&template));
+            self.alt_grid.clear_region((self.cursor.line + 1).., |c| c.reset(&template));
+        }
 
         // Reset scrolling region to new size
         self.scroll_region = Line(0)..self.grid.num_lines();


### PR DESCRIPTION
I found that resize was clearing lines from current line to end on resize. In my setup with a 2 line prompt the second line would be cleared if the window resize happened after printing the second line of the prompt. This mostly happened on startup. 

* This also fixes a crash/panic when you resize the window to zero lines. (half of a fix for #12, the other half is fixed in #154).
