### PR TITLE
Make sure we have at least one column.

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -511,7 +511,9 @@ impl Term {
             .map(|i| (*i as usize) % TAB_SPACES == 0)
             .collect::<Vec<bool>>();
 
-        self.tabs[0] = false;
+        if num_cols > Column(0) {
+            self.tabs[0] = false;
+        }
 
         // Make sure bottom of terminal is clear
         let template = self.empty_cell.clone();


### PR DESCRIPTION
Prevents a panic when the window is resized to 0 columns width. 

* Final fix for #12 