### PR TITLE
Change README.md to reflect the current compiler situation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,14 @@ will walk you through how to build from source on both macOS and Ubuntu.
    cd alacritty
    ```
 
-3. Make sure you have the right Rust compiler installed. Alacritty is currently
-   pinned to a certain Rust nightly, and the compiler/nightly dependencies are
-   updated as needed. To install the correct compiler, run:
+3. Make sure you have the right Rust compiler installed. Alacritty requires nightly Rust. Run
 
+   ```sh
+   rustup override set nightly
+   ```
+   
+   If you run into problems, you can try a known-good version of the compiler by running
+   
    ```sh
    rustup override set $(cat rustc-version)
    ```


### PR DESCRIPTION
Suggesting that `alacritty` only works on one version of the compiler is not something new users will want to hear, and it doesn't seem to be true. It compiles and runs just fine on the nightly from last night, and the nightly before that.