### PR TITLE
Corrected default alacritty.yml path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cp Alacritty.desktop ~/.local/share/applications
 Although it's possible the default configuration would work on your system,
 you'll probably end up wanting to customize it anyhow. There is an
 `alacritty.yml` at the git repository root. Copy this to either
-`$HOME/.alacritty.yml` or `$XDG_CONFIG_HOME/alacritty.yml` and run Alacritty.
+`$HOME/.config/alacritty.yml` or `$XDG_CONFIG_HOME/alacritty.yml` and run Alacritty.
 
 Many configuration options will take effect immediately upon saving changes to
 the config file. The only exception is the `font` and `dpi` section which


### PR DESCRIPTION
I can confirm that `$HOME/.alacritty.yml` is not found, while `$HOME/.config/alacritty.yml` is found per https://github.com/jwilm/alacritty/issues/172