### PR TITLE
Conform to XDG spec for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,15 @@ cp Alacritty.desktop ~/.local/share/applications
 ### Configuration
 
 Although it's possible the default configuration would work on your system,
-you'll probably end up wanting to customize it anyhow. There is an
-`alacritty.yml` at the git repository root. Copy this to either
-`$HOME/.alacritty.yml` or `$XDG_CONFIG_HOME/alacritty.yml` and run Alacritty.
+you'll probably end up wanting to customize it anyhow. There is a default
+`alacritty.yml` at the git repository root. Alacritty looks for the configuration
+file as the following paths:
+
+1. `$XDG_CONFIG_HOME/alacritty/alacritty.yml`
+2. `$HOME/.config/alacritty/alacritty.yml`
+
+If these files are not found then one is created as `$HOME/.config/alacritty/alacritty.yml`
+once alacritty is first run.
 
 Many configuration options will take effect immediately upon saving changes to
 the config file. The only exception is the `font` and `dpi` section which

--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ file as the following paths:
 1. `$XDG_CONFIG_HOME/alacritty/alacritty.yml`
 2. `$XDG_CONFIG_HOME/alacritty.yml`
 3. `$HOME/.config/alacritty/alacritty.yml`
+4. `$HOME/.alacritty.yml`
 
-If neither path 1 or 2 are found then `$HOME/.config/alacritty/alacritty.yml`
-is created as or once alacritty is first run.
+If neither of these paths are found then `$XDG_CONFIG_HOME/alacritty/alacritty.yml`
+is created once alacritty is first run. On most systems this often defaults
+to `$HOME/.config/alacritty/alacritty.yml`.
 
 Many configuration options will take effect immediately upon saving changes to
 the config file. The only exception is the `font` and `dpi` section which

--- a/README.md
+++ b/README.md
@@ -142,10 +142,11 @@ you'll probably end up wanting to customize it anyhow. There is a default
 file as the following paths:
 
 1. `$XDG_CONFIG_HOME/alacritty/alacritty.yml`
-2. `$HOME/.config/alacritty/alacritty.yml`
+2. `$XDG_CONFIG_HOME/alacritty.yml`
+3. `$HOME/.config/alacritty/alacritty.yml`
 
-If these files are not found then one is created as `$HOME/.config/alacritty/alacritty.yml`
-once alacritty is first run.
+If neither path 1 or 2 are found then `$HOME/.config/alacritty/alacritty.yml`
+is created as or once alacritty is first run.
 
 Many configuration options will take effect immediately upon saving changes to
 the config file. The only exception is the `font` and `dpi` section which

--- a/src/config.rs
+++ b/src/config.rs
@@ -812,7 +812,8 @@ impl Config {
     /// The config file is loaded from the first file it finds in this list of paths
     ///
     /// 1. $XDG_CONFIG_HOME/alacritty/alacritty.yml
-    /// 2. $HOME/.config/alacritty/alacritty.yml
+    /// 2. $XDG_CONFIG_HOME/alacritty.yml
+    /// 3. $HOME/.config/alacritty/alacritty.yml
     pub fn load() -> Result<Config> {
         let home = env::var("HOME")?;
 
@@ -820,6 +821,11 @@ impl Config {
         let path = ::xdg::BaseDirectories::with_prefix("alacritty")
             .ok()
             .and_then(|xdg| xdg.find_config_file("alacritty.yml"))
+            .or_else(|| {
+                ::xdg::BaseDirectories::new().ok().and_then(|fallback| {
+                    fallback.find_config_file("alacritty.yml")
+                })
+            })
             .unwrap_or_else(|| {
                 // Fallback path: $HOME/.config/alacritty/alacritty.yml
                 let mut alt_path = PathBuf::from(&home);

--- a/src/config.rs
+++ b/src/config.rs
@@ -811,19 +811,19 @@ impl Config {
     ///
     /// The config file is loaded from the first file it finds in this list of paths
     ///
-    /// 1. `$HOME/.config/alacritty.yml`
-    /// 2. `$HOME/.alacritty.yml`
+    /// 1. $XDG_CONFIG_HOME/alacritty/alacritty.yml
+    /// 2. $HOME/.config/alacritty/alacritty.yml
     pub fn load() -> Result<Config> {
         let home = env::var("HOME")?;
 
         // Try using XDG location by default
-        let path = ::xdg::BaseDirectories::new()
+        let path = ::xdg::BaseDirectories::with_prefix("alacritty")
             .ok()
             .and_then(|xdg| xdg.find_config_file("alacritty.yml"))
             .unwrap_or_else(|| {
-                // Fallback path: $HOME/.alacritty.yml
+                // Fallback path: $HOME/.config/alacritty/alacritty.yml
                 let mut alt_path = PathBuf::from(&home);
-                alt_path.push(".alacritty.yml");
+                alt_path.push(".config/alacritty/alacritty.yml");
                 alt_path
             });
 
@@ -831,7 +831,7 @@ impl Config {
     }
 
     pub fn write_defaults() -> io::Result<PathBuf> {
-        let path = ::xdg::BaseDirectories::new()
+        let path = ::xdg::BaseDirectories::with_prefix("alacritty")
             .map_err(|err| io::Error::new(io::ErrorKind::NotFound, ::std::error::Error::description(&err)))
             .and_then(|p| p.place_config_file("alacritty.yml"))?;
         File::create(&path)?.write_all(DEFAULT_ALACRITTY_CONFIG.as_bytes())?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -814,6 +814,7 @@ impl Config {
     /// 1. $XDG_CONFIG_HOME/alacritty/alacritty.yml
     /// 2. $XDG_CONFIG_HOME/alacritty.yml
     /// 3. $HOME/.config/alacritty/alacritty.yml
+    /// 4. $HOME/.alacritty.yml
     pub fn load() -> Result<Config> {
         let home = env::var("HOME")?;
 
@@ -826,11 +827,17 @@ impl Config {
                     fallback.find_config_file("alacritty.yml")
                 })
             })
-            .unwrap_or_else(|| {
+            .or_else(|| {
                 // Fallback path: $HOME/.config/alacritty/alacritty.yml
-                let mut alt_path = PathBuf::from(&home);
-                alt_path.push(".config/alacritty/alacritty.yml");
-                alt_path
+                let fallback = PathBuf::from(&home).join(".config/alacritty/alacritty.yml");
+                match fallback.exists() {
+                    true => Some(fallback),
+                    false => None
+                }
+            })
+            .unwrap_or_else(|| {
+                // Fallback path: $HOME/.alacritty.yml
+                PathBuf::from(&home).join(".alacritty.yml")
             });
 
         Config::load_from(path)


### PR DESCRIPTION
Use `$XDG_CONFIG_HOME/alacritty/alacritty.yml` for loading the configuration file falling back to first `$XDG_CONFIG_HOME/alacritty.yml` then finally `$HOME/.config/alacritty/alacritty.yml`

Closes #203