### PR TITLE
Better bounds checking.

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -641,7 +641,6 @@ impl ansi::Handler for Term {
             self.wrap = false;
         }
 
-
         {
             let cell = &mut self.grid[&self.cursor];
             *cell = self.template_cell;
@@ -653,9 +652,6 @@ impl ansi::Handler for Term {
         } else {
             self.wrap = true;
         }
-
-        // TODO handle auto wrap if auto wrap is enabled. 
-        // ESC[?h 57 code 104 
 
     }
 


### PR DESCRIPTION
- Remove the use of limit.
- Reduce the number of comparisons.

When using numbers provided by the PTY for subtractions there is a extra
step of ensuring that we won't trigger failure on testing when trying to
subtract form zero.
