### PR TITLE
Add non-ASCII font

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1349,6 +1349,9 @@ pub struct Font {
     #[serde(default="default_bold_desc")]
     pub bold: FontDescription,
 
+    #[serde(default="default_non_ascii_desc")]
+    pub non_ascii: FontDescription,
+
     // Font size in points
     #[serde(deserialize_with="DeserializeFromF32::deserialize_from_f32")]
     size: Size,
@@ -1370,6 +1373,10 @@ fn default_bold_desc() -> FontDescription {
 
 fn default_italic_desc() -> FontDescription {
     Font::default().italic
+}
+
+fn default_non_ascii_desc() -> FontDescription {
+    Font::default().non_ascii
 }
 
 /// Description of a single font
@@ -1415,6 +1422,7 @@ impl Default for Font {
             normal: FontDescription::new_with_family("Menlo"),
             bold: FontDescription::new_with_family("Menlo"),
             italic: FontDescription::new_with_family("Menlo"),
+            non_ascii: FontDescription::new_with_family("Menlo"),
             size: Size::new(11.0),
             use_thin_strokes: true,
             offset: Default::default(),
@@ -1430,6 +1438,7 @@ impl Default for Font {
             normal: FontDescription::new_with_family("monospace"),
             bold: FontDescription::new_with_family("monospace"),
             italic: FontDescription::new_with_family("monospace"),
+            non_ascii: FontDescription::new_with_family("monospace"),
             size: Size::new(11.0),
             use_thin_strokes: false,
             offset: Default::default(),

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -803,12 +803,12 @@ impl<'a> RenderApi<'a> {
             // Get font key for cell
             // FIXME this is super inefficient.
             let mut font_key = glyph_cache.font_key;
-            if cell.flags.contains(cell::BOLD) {
+            if !cell.c.is_ascii() {
+                font_key = glyph_cache.non_ascii_key;
+            } else if cell.flags.contains(cell::BOLD) {
                 font_key = glyph_cache.bold_key;
             } else if cell.flags.contains(cell::ITALIC) {
                 font_key = glyph_cache.italic_key;
-            } else if !cell.c.is_ascii() {
-                font_key = glyph_cache.non_ascii_key;
             }
 
             let glyph_key = GlyphKey {


### PR DESCRIPTION
Add a configurable non-ASCII font so that non-ASCII characters can be displayed when the normal font does not include non-ASCII glyphs.