### PR TITLE
Enabled Rustc's Link Time Optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,4 +46,5 @@ rev = "af7fe340bd4a2af53ea521defcb4f377cdc588cf"
 
 
 [profile.release]
+lto = true
 debug = true


### PR DESCRIPTION
Changed:

Turned on LTO

Why:

Rust's Link Time Optimization forces all compiled code + dependencies to share the same LLVM codegen module which greatly increases the scope of optimization the LLVM can perform. As its no longer linking together separate libraries as `.o` files but as native llvm-ir. 

This normally shows a ~20% performance gain. Alacritty does aim for performance. 

Issues:

I've been running a build with this flag compiled for most of today with no issues.