### PR TITLE
print glutin events if --print-events is passed

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,7 @@ use index::{Line, Column};
 
 /// Options specified on the command line
 pub struct Options {
+    pub print_events: bool,
     pub ref_test: bool,
     pub columns: Column,
     pub lines: Line,
@@ -25,6 +26,7 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Options {
         Options {
+            print_events: false,
             ref_test: false,
             columns: Column(80),
             lines: Line(24),
@@ -43,6 +45,7 @@ impl Options {
             match &arg[..] {
                 // Generate ref test
                 "--ref-test" => options.ref_test = true,
+                "--print-events" => options.print_events = true,
                 // Set dimensions
                 "-d" | "--dimensions" => {
                     args_iter.next()

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,6 +9,7 @@ use parking_lot::MutexGuard;
 use glutin::{self, ElementState};
 
 use config::Config;
+use cli::Options;
 use display::OnResize;
 use index::{Line, Column, Side};
 use input::{self, ActionContext, MouseBinding, KeyBinding};
@@ -58,6 +59,7 @@ impl Default for Mouse {
 pub struct Processor<N> {
     key_bindings: Vec<KeyBinding>,
     mouse_bindings: Vec<MouseBinding>,
+    print_events: bool,
     notifier: N,
     mouse: Mouse,
     resize_tx: mpsc::Sender<(u32, u32)>,
@@ -83,6 +85,7 @@ impl<N: Notify> Processor<N> {
     pub fn new(
         notifier: N,
         resize_tx: mpsc::Sender<(u32, u32)>,
+        options: &Options,
         config: &Config,
         ref_test: bool,
         size_info: SizeInfo,
@@ -90,6 +93,7 @@ impl<N: Notify> Processor<N> {
         Processor {
             key_bindings: config.key_bindings().to_vec(),
             mouse_bindings: config.mouse_bindings().to_vec(),
+            print_events: options.print_events,
             notifier: notifier,
             resize_tx: resize_tx,
             ref_test: ref_test,
@@ -184,6 +188,9 @@ impl<N: Notify> Processor<N> {
             // Convenience macro which curries most arguments to handle_event.
             macro_rules! process {
                 ($event:expr) => {
+                    if self.print_events {
+                        err_println!("glutin event: {:?}", $event);
+                    }
                     Processor::handle_event(
                         &mut processor,
                         $event,

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,7 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
     let mut processor = event::Processor::new(
         event_loop::Notifier(loop_tx),
         display.resize_channel(),
+        &options,
         &config,
         options.ref_test,
         display.size().to_owned(),


### PR DESCRIPTION
When debugging many issues, it's often very helpful to have the raw
glutin events printed out to stderr as they come in. This does that.

Note that since `glutin::Event` doesn't implement `Display`, we just use
rust's debugging output for now via `{:?}`.