### PR TITLE
Fix yml errors from uncommenting solarized block in config

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -73,33 +73,33 @@ colors:
     white:   '0x2a2a2a'
 
 # Colors (Solarized Dark)
-# colors:
-#   # Default colors
-#   primary:
-#     background: '0x002b36'
-#     foreground: '0x839496'
+#colors:
+#  # Default colors
+#  primary:
+#    background: '0x002b36'
+#    foreground: '0x839496'
 #
 #   # Normal colors
-#   normal:
-#     black:   '0x073642'
-#     red:     '0xdc322f'
-#     green:   '0x859900'
-#     yellow:  '0xb58900'
-#     blue:    '0x268bd2'
-#     magenta: '0xd33682'
-#     cyan:    '0x2aa198'
-#     white:   '0xeee8d5'
+#  normal:
+#    black:   '0x073642'
+#    red:     '0xdc322f'
+#    green:   '0x859900'
+#    yellow:  '0xb58900'
+#    blue:    '0x268bd2'
+#    magenta: '0xd33682'
+#    cyan:    '0x2aa198'
+#    white:   '0xeee8d5'
 #
 #   # Bright colors
-#   bright:
-#     black:   '0x002b36'
-#     red:     '0xcb4b16'
-#     green:   '0x586e75'
-#     yellow:  '0x657b83'
-#     blue:    '0x839496'
-#     magenta: '0x6c71c4'
-#     cyan:    '0x93a1a1'
-#     white:   '0xfdf6e3'
+#  bright:
+#    black:   '0x002b36'
+#    red:     '0xcb4b16'
+#    green:   '0x586e75'
+#    yellow:  '0x657b83'
+#    blue:    '0x839496'
+#    magenta: '0x6c71c4'
+#    cyan:    '0x93a1a1'
+#    white:   '0xfdf6e3'
 
 # Key bindings
 #


### PR DESCRIPTION
Very small and simple change. The solarized dark example block has one additional space, which causes yml related errors when you uncomment the block without removing the extra space. This can be confusing to new users and doesn't really add to the overall readability.