### PR TITLE
Fixing panic on cat /dev/urandom

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1002,7 +1002,7 @@ impl ansi::Handler for Term {
         if self.cursor.line == self.scroll_region.start {
             self.scroll_down(Line(1));
         } else {
-            self.cursor.line -= 1;
+            self.cursor.line -= min(self.cursor.line, Line(1));
         }
     }
 


### PR DESCRIPTION
- Checks to make sure lines count coming from the pty are within a proper
range before doing scrolling.

- Sanitizes scroll region when being set.

- Changes panic for unimplemented screen clear to a print statement.

The first two changes ensure scrolling won't crash us. By sanitizing the
region on set we don't have to complicate the scroll code with limits,
mins, or maxes to ensure the scroll operation is within the range.
Checking if the lines is greater than the total region allows us to
simply clear the region and avoid subtracting large numbers from small
ones.

Fixes #63

