### PR TITLE
Allow arguments in shell option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use std::env;
 use index::{Line, Column};
+use std::ffi::CString;
 
 /// Options specified on the command line
 pub struct Options {
@@ -20,7 +21,8 @@ pub struct Options {
     pub ref_test: bool,
     pub columns: Column,
     pub lines: Line,
-    pub title: String
+    pub title: String,
+    pub shell: Option<Vec<CString>>,
 }
 
 impl Default for Options {
@@ -30,7 +32,8 @@ impl Default for Options {
             ref_test: false,
             columns: Column(80),
             lines: Line(24),
-            title: "Alacritty".to_owned()
+            title: "Alacritty".to_owned(),
+            shell: None,
         }
     }
 }
@@ -55,6 +58,16 @@ impl Options {
                 },
                 "-t" | "--title" => {
                     args_iter.next().map(|t| options.title = t);
+                },
+                // Shell, all arguments after -e are passed to the shell
+                "-e" => {
+                    let mut shell_args = Vec::new();
+                    while let Some(earg) = args_iter.next() {
+                        if let Ok(s) = CString::new(earg) {
+                            shell_args.push(s)
+                        }
+                    }
+                    options.shell = Some(shell_args);
                 },
                 // ignore unexpected
                 _ => (),

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use std::sync::mpsc;
 use std::ops::{Index, IndexMut};
 use std::fs::File;
+use std::ffi::CString;
 
 use ::Rgb;
 use font::Size;
@@ -196,8 +197,8 @@ pub struct Config {
     #[serde(default="default_mouse_bindings")]
     mouse_bindings: Vec<MouseBinding>,
 
-    /// Path to a shell program to run on startup
-    shell: Option<PathBuf>,
+    /// Whitespace separated string of arguments to execute
+    shell: Option<String>,
 
     /// Path where config was loaded from
     config_path: Option<PathBuf>,
@@ -896,10 +897,12 @@ impl Config {
             .map(|p| p.as_path())
     }
 
-    pub fn shell(&self) -> Option<&Path> {
-        self.shell
-            .as_ref()
-            .map(PathBuf::as_path)
+    /// Get the arguments to execute
+    pub fn shell(&self) -> Option<Vec<CString>> {
+        if let Some(ref shell) = self.shell {
+            return parse_shell(shell)
+        }
+        None
     }
 
     fn load_from<P: Into<PathBuf>>(path: P) -> Result<Config> {
@@ -918,6 +921,34 @@ impl Config {
 
         Ok(contents)
     }
+}
+
+fn parse_shell(raw: &String) -> Option<Vec<CString>> {
+    let mut argv = Vec::new();
+    let mut st = 0; // Single tick '
+    let mut dt = 0; // Double tick "
+    let mut current_arg = String::new();
+    for c in raw.chars() {
+        match c {
+            '\'' => st = (st + 1) % 2,
+            '"' => dt = (dt + 1) % 2,
+            ' ' | '\t' => {
+                if st == 0 && dt == 0 {
+                    if let Ok(arg) = CString::new(current_arg.as_bytes()) {
+                        argv.push(arg);
+                    }
+                    current_arg = String::new();
+                } else {
+                    current_arg.push(c);
+                }
+            },
+            _ => current_arg.push(c),
+        }
+    }
+    if let Ok(arg) = CString::new(current_arg.as_bytes()) {
+        argv.push(arg);
+    }
+    Some(argv)
 }
 
 /// Pixels per inch

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
     // The pty forks a process to run the shell on the slave side of the
     // pseudoterminal. A file descriptor for the master side is retained for
     // reading/writing to the shell.
-    let mut pty = tty::new(&config, display.size());
+    let mut pty = tty::new(&config, &options, display.size());
 
     // Create the pseudoterminal I/O loop
     //

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -207,13 +207,30 @@ fn execsh(config: &Config) -> ! {
     let mut buf = [0; 1024];
     let pw = get_pw_entry(&mut buf);
 
-    let shell = match config.shell() {
-        Some(shell) => match shell.to_str() {
-            Some(shell) => shell,
-            None => die!("Invalid shell value")
-        },
-        None => pw.shell
-    };
+    // We construct a string with the shell path and an array of C-string
+    // pointers to pass to execv.
+    // Shells are searched in the following order:
+    //   Alacritty's Configuration
+    //   User's shell from passwd
+    // Config _cannot_ return a reference, therefore it has to be stored in
+    // this scope.
+    let argv_conf = config.shell();
+    let shell;
+    let mut argv = Vec::new();
+    if let Some(ref argv_conf) = argv_conf {
+        shell = argv_conf
+            .first().expect("Internal error: argv should never be empty")
+            .to_str().expect("Failed to parse shell option");
+        for a in argv_conf.iter() {
+            argv.push(a.as_ptr());
+        }
+        argv.push(ptr::null());
+    }
+    else {
+        shell = pw.shell;
+        argv.push(pw.shell.as_ptr() as *const i8);
+        argv.push(ptr::null());
+    }
 
     // setup environment
     env::set_var("LOGNAME", pw.name);
@@ -231,13 +248,9 @@ fn execsh(config: &Config) -> ! {
         libc::signal(libc::SIGALRM, libc::SIG_DFL);
     }
 
-    // pw.shell is null terminated
-    let shell = unsafe { CStr::from_ptr(shell.as_ptr() as *const _) };
-
-    let argv = [shell.as_ptr(), ptr::null()];
 
     let res = unsafe {
-        libc::execvp(shell.as_ptr(), argv.as_ptr())
+        libc::execvp(shell.as_ptr() as *const i8, argv.as_ptr())
     };
 
     if res < 0 {


### PR DESCRIPTION
I added support for arguments to the shell option. This is convenient when debugging, e.g. `shell: /bin/bash --norc --noprofile` can be used to avoid loading everything when running bash.

I'm a bit of a rookie when it comes to rust so please review.

Cheers

EDIT: I've also added the -e command line argument so that you temporarily can launch alacritty with another shell.