### PR TITLE
make thin stroke rendering configurable

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -40,6 +40,11 @@ font:
     x: 2.0
     y: -7.0
 
+  # OS X only: use thin stroke font rendering. Thin strokes are suitable
+  # for retina displays, but for non-retina you probably want this set to
+  # false.
+  use_thin_strokes: true
+
 # Should display the render timer
 render_timer: false
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -40,6 +40,11 @@ font:
     x: 0.0
     y: 0.0
 
+  # OS X only: use thin stroke font rendering. Thin strokes are suitable
+  # for retina displays, but for non-retina you probably want this set to
+  # false.
+  use_thin_strokes: true
+
 # Should display the render timer
 render_timer: false
 

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -41,7 +41,7 @@ fn to_freetype_26_6(f: f32) -> isize {
 impl ::Rasterize for FreeTypeRasterizer {
     type Err = Error;
 
-    fn new(dpi_x: f32, dpi_y: f32, device_pixel_ratio: f32) -> Result<FreeTypeRasterizer, Error> {
+    fn new(dpi_x: f32, dpi_y: f32, device_pixel_ratio: f32, _: bool) -> Result<FreeTypeRasterizer, Error> {
         let library = Library::init()?;
 
         Ok(FreeTypeRasterizer {

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -199,7 +199,7 @@ pub trait Rasterize {
     type Err: ::std::error::Error + Send + Sync + 'static;
 
     /// Create a new Rasterize
-    fn new(dpi_x: f32, dpi_y: f32, device_pixel_ratio: f32) -> Result<Self, Self::Err>
+    fn new(dpi_x: f32, dpi_y: f32, device_pixel_ratio: f32, use_thin_strokes: bool) -> Result<Self, Self::Err>
         where Self: Sized;
 
     /// Get `Metrics` for the given `FontKey` and `Size`

--- a/src/config.rs
+++ b/src/config.rs
@@ -890,6 +890,12 @@ impl Config {
         self.render_timer
     }
 
+    #[inline]
+    pub fn use_thin_strokes(&self) -> bool {
+        self.font.use_thin_strokes
+    }
+
+
     pub fn path(&self) -> Option<&Path> {
         self.config_path
             .as_ref()
@@ -1034,6 +1040,9 @@ pub struct Font {
 
     /// Extra spacing per character
     offset: FontOffset,
+
+    #[serde(default="true_bool")]
+    use_thin_strokes: bool
 }
 
 fn default_bold_desc() -> FontDescription {
@@ -1082,6 +1091,7 @@ impl Default for Font {
             bold: FontDescription::new_with_family("Menlo"),
             italic: FontDescription::new_with_family("Menlo"),
             size: Size::new(11.0),
+            use_thin_strokes: true,
             offset: FontOffset {
                 x: 0.0,
                 y: 0.0
@@ -1098,6 +1108,7 @@ impl Default for Font {
             bold: FontDescription::new_with_family("monospace"),
             italic: FontDescription::new_with_family("monospace"),
             size: Size::new(11.0),
+            use_thin_strokes: false,
             offset: FontOffset {
                 // TODO should improve freetype metrics... shouldn't need such
                 // drastic offsets for the default!

--- a/src/display.rs
+++ b/src/display.rs
@@ -148,7 +148,7 @@ impl Display {
 
         println!("device_pixel_ratio: {}", dpr);
 
-        let rasterizer = font::Rasterizer::new(dpi.x(), dpi.y(), dpr)?;
+        let rasterizer = font::Rasterizer::new(dpi.x(), dpi.y(), dpr, config.use_thin_strokes())?;
 
         // Create renderer
         let mut renderer = QuadRenderer::new(config, size)?;


### PR DESCRIPTION
Makes thin stroke rendering for darwin configurable by a new toplevel
key under `font:` in the config file. Defaults to false, has no impact
on non macos.