### PR TITLE
Proposal for line wrap - ^[[7h and ^[[7l (private)

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -247,6 +247,8 @@ pub enum Mode {
     CursorKeys = 1,
     /// ?6
     Origin = 6,
+    /// ?7
+    LineWrap = 7,
     /// ?12
     BlinkingCursor = 12,
     /// ?25
@@ -272,6 +274,7 @@ impl Mode {
             Some(match num {
                 1 => Mode::CursorKeys,
                 6 => Mode::Origin,
+                7 => Mode::LineWrap,
                 12 => Mode::BlinkingCursor,
                 25 => Mode::ShowCursor,
                 1000 => Mode::ReportMouseClicks,


### PR DESCRIPTION
These changes provide support for disabling auto line wrap which is
currently default to on.

'tput rman' will now disable auto line wrap and alacritty will now not
automatically wrap lines.

'tput sman' will now (re)enable auto line wrap and alacritty will now
automatically wrap lines once it reaches the end of the line.

My testing showed this to work the same as gnome-terminal.

I should note that simply having ^[[7h or ^[[7l in a recording does not
enable and disable line wrapping. This is the same behavior as
gnome-terminal and xterm. Those cape codes come through as private
which are not handled yet. I behave this is the correct behavior.

** I fixed vim to trim trailing whitespace on save, just about every line I committed in the past had trailing white space. This is also corrected here. ** 

Fixes #282