### PR TITLE
Make it run on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ will walk you through how to build from source on both macOS and Ubuntu.
    ```sh
    rustup override set nightly
    ```
-   
+
    If you run into problems, you can try a known-good version of the compiler by running
-   
+
    ```sh
    rustup override set $(<rustc-version)
    ```
@@ -105,6 +105,16 @@ On [Void Linux](https://voidlinux.eu), install following packages before compili
 
 ```sh
 xbps-install cmake freetype-devel freetype expat-devel fontconfig xclip
+```
+
+##### FreeBSD
+
+On FreeBSD, you need a few extra libraries to build Alacritty. Here's a `pkg`
+command that should install all of them. If something is still found to be
+missing, please open an issue.
+
+```sh
+pkg install cmake freetype2 fontconfig xclip
 ```
 
 ##### Other

--- a/copypasta/src/lib.rs
+++ b/copypasta/src/lib.rs
@@ -40,13 +40,12 @@ pub trait Store : Load {
         where S: Into<String>;
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 mod x11;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub use x11::{Clipboard, Error};
 
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "macos")]
 pub use macos::{Clipboard, Error};
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -1090,7 +1090,7 @@ impl Default for Font {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux",target_os = "freebsd"))]
 impl Default for Font {
     fn default() -> Font {
         Font {
@@ -1535,4 +1535,3 @@ impl Key {
         }
     }
 }
-

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -21,7 +21,7 @@ use std::mem;
 use std::os::unix::io::FromRawFd;
 use std::ptr;
 
-use libc::{self, winsize, c_int, pid_t, WNOHANG, WIFEXITED, WEXITSTATUS, SIGCHLD};
+use libc::{self, winsize, c_int, pid_t, WNOHANG, WIFEXITED, WEXITSTATUS, SIGCHLD, TIOCSCTTY};
 
 use term::SizeInfo;
 use display::OnResize;
@@ -113,7 +113,7 @@ fn openpty(rows: u8, cols: u8) -> (c_int, c_int) {
     (master, slave)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos",target_os = "freebsd"))]
 fn openpty(rows: u8, cols: u8) -> (c_int, c_int) {
     let mut master: c_int = 0;
     let mut slave: c_int = 0;
@@ -139,7 +139,7 @@ fn openpty(rows: u8, cols: u8) -> (c_int, c_int) {
 /// Really only needed on BSD, but should be fine elsewhere
 fn set_controlling_terminal(fd: c_int) {
     let res = unsafe {
-        libc::ioctl(fd, libc::TIOCSCTTY as _, 0)
+        libc::ioctl(fd, TIOCSCTTY as _, 0)
     };
 
     if res < 0 {


### PR DESCRIPTION
Changes to code:

- Added FreeBSD paragraph in README.md
- Added "freebsd" to target_os cfg's in macOS's openpty() function
- Added "freebsd" to target_os cfg's in Linux's copypasta
- Added "freebsd" to target_os cfg's in Linux's default font
- Apparently TIOCSCTTY is missing from FreeBSD's libc. Added a separate function for that ioctl until libc crate can be fixed.