### PR TITLE
set option as meta

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -188,9 +188,13 @@ pub struct Config {
     #[serde(default)]
     colors: ColorList,
 
+    #[serde(default)]
+    option_as_meta: bool,
+
     /// Keybindings
     #[serde(default="default_key_bindings")]
     key_bindings: Vec<KeyBinding>,
+
 
     /// Bindings for the mouse
     #[serde(default="default_mouse_bindings")]
@@ -232,6 +236,7 @@ impl Default for Config {
             key_bindings: Vec::new(),
             mouse_bindings: Vec::new(),
             shell: None,
+            option_as_meta: false,
             config_path: None,
         }
     }
@@ -906,6 +911,11 @@ impl Config {
         self.shell
             .as_ref()
             .map(PathBuf::as_path)
+    }
+
+    #[inline]
+    pub fn option_as_meta(&self) -> bool {
+        self.option_as_meta
     }
 
     fn load_from<P: Into<PathBuf>>(path: P) -> Result<Config> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
     // Need the Rc<RefCell<_>> here since a ref is shared in the resize callback
     let mut processor = event::Processor::new(
         event_loop::Notifier(loop_tx),
+        event::ModTranslator(Mods::empty(), Mods::empty()),
         display.resize_channel(),
         &options,
         &config,


### PR DESCRIPTION
@jwilm I picked this up from https://github.com/jwilm/alacritty/issues/62. I got (I think) most of the way there, but would love to hear feedback about the approach I used. The rough pattern is that there's an `event_translator` that can be passed this config, and it is called in the `events::Processor`.

I'm struggling a bit with why the build fails with this error:

```

error[E0282]: unable to infer enough type information about `E`
   --> src/event.rs:197:21
    |
197 |                     Processor::handle_event(
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `E`
...
224 |                     process!(translated);
    |                     --------------------- in this macro invocation
    |
    = note: type annotations or generic parameter binding required

error: aborting due to previous error

error: Could not compile `alacritty`.

To learn more, run the command again with --verbose.
```

I'd be happy to take a different approach than this - you could hardcode everything into the processor, but it seemed like a reasonable place to put a new thing in.