### PR TITLE
add toggle for subpixel rendering

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -48,6 +48,9 @@ font:
 # Should display the render timer
 render_timer: false
 
+# Should apply subpixel rendering
+subpixel_render: true
+
 # Colors (Tomorrow Night Bright)
 colors:
   # Default colors

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -48,6 +48,9 @@ font:
 # Should display the render timer
 render_timer: false
 
+# Should apply subpixel rendering
+subpixel_render: true
+
 # Colors (Tomorrow Night Bright)
 colors:
   # Default colors

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -199,7 +199,13 @@ pub trait Rasterize {
     type Err: ::std::error::Error + Send + Sync + 'static;
 
     /// Create a new Rasterize
-    fn new(dpi_x: f32, dpi_y: f32, device_pixel_ratio: f32, use_thin_strokes: bool) -> Result<Self, Self::Err>
+    fn new(
+        dpi_x: f32,
+        dpi_y: f32,
+        device_pixel_ratio: f32,
+        use_thin_strokes: bool,
+        subpixel_render: bool
+    ) -> Result<Self, Self::Err>
         where Self: Sized;
 
     /// Get `Metrics` for the given `FontKey` and `Size`

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,10 @@ pub struct Config {
 
     /// Path where config was loaded from
     config_path: Option<PathBuf>,
+
+    /// Subpixel rendering toggle
+    #[serde(default="true_bool")]
+    subpixel_render: bool,
 }
 
 #[cfg(not(target_os="macos"))]
@@ -228,6 +232,7 @@ impl Default for Config {
             dpi: Default::default(),
             font: Default::default(),
             render_timer: Default::default(),
+            subpixel_render: Default::default(),
             colors: Default::default(),
             key_bindings: Vec::new(),
             mouse_bindings: Vec::new(),
@@ -890,6 +895,13 @@ impl Config {
         self.render_timer
     }
 
+
+    /// Show subpixel rendering setting
+    #[inline]
+    pub fn subpixel_render(&self) -> bool {
+        self.subpixel_render
+    }
+
     #[inline]
     pub fn use_thin_strokes(&self) -> bool {
         self.font.use_thin_strokes
@@ -1546,4 +1558,3 @@ impl Key {
         }
     }
 }
-

--- a/src/display.rs
+++ b/src/display.rs
@@ -148,7 +148,8 @@ impl Display {
 
         println!("device_pixel_ratio: {}", dpr);
 
-        let rasterizer = font::Rasterizer::new(dpi.x(), dpi.y(), dpr, config.use_thin_strokes())?;
+        let rasterizer = font::Rasterizer::new(dpi.x(), dpi.y(), dpr, config.use_thin_strokes(),
+            config.subpixel_render())?;
 
         // Create renderer
         let mut renderer = QuadRenderer::new(config, size)?;


### PR DESCRIPTION
As we talked about in issue #101 just removing the lcd filter flag on linux is sufficient to turn subpixel rendering off. I am unable to test the mac changes at the moment.