### PR TITLE
Add alpha option to set background transparency

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -158,6 +158,9 @@ visual_bell:
   animation: EaseOutExpo
   duration: 0
 
+# Background opacity
+background_opacity: 1.0
+
 # Key bindings
 #
 # Each binding is defined as an object with some properties. Most of the

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -158,6 +158,9 @@ visual_bell:
   animation: EaseOutExpo
   duration: 0
 
+# Background opacity
+background_opacity: 1.0
+
 # Key bindings
 #
 # Each binding is defined as an object with some properties. Most of the

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -21,15 +21,17 @@ flat in int background;
 layout(location = 0, index = 0) out vec4 color;
 layout(location = 0, index = 1) out vec4 alphaMask;
 
+uniform float bgOpacity;
 uniform sampler2D mask;
 
 void main()
 {
     if (background != 0) {
-        alphaMask = vec4(1.0, 1.0, 1.0, 1.0);
-        color = vec4(bg + vb, 1.0);
+        alphaMask = vec4(1.0);
+        color = vec4(bg + vb, 1.0) * bgOpacity;
     } else {
-        alphaMask = vec4(texture(mask, TexCoords).rgb, 1.0);
+        vec3 textColor = texture(mask, TexCoords).rgb;
+        alphaMask = vec4(textColor, textColor.r);
         color = vec4(fg, 1.0);
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -186,7 +186,8 @@ impl Window {
 
         Window::platform_window_init();
         let window = WindowBuilder::new()
-            .with_title(title);
+            .with_title(title)
+            .with_transparency(true);
         let context = ContextBuilder::new()
             .with_vsync(true);
         let window = ::glutin::GlWindow::new(window, context, &event_loop)?;


### PR DESCRIPTION
Works on OS X, but not on Linux due to a glutin bug: https://github.com/tomaka/glutin/issues/639.

There are a few things I'd like to clean up/look into, but I figure I can put it out to start review. Things I'd like to do:
* Add a validation check to the alpha read from the config file to make sure it's within 0.0 and 1.0, inclusive.
* Not sure if `alpha` is the best config option name for this, so decide on the best name.
* Not sure if `alpha` values should be a float from 0.0 to 1.0, or integers or whatever.

Addresses issue #232.