### PR TITLE
Optimize glyph cache access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "clippy 0.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "copypasta 0.0.1",
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "font 0.1.0",
  "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.6.1 (git+https://github.com/jwilm/glutin?rev=af7fe340bd4a2af53ea521defcb4f377cdc588cf)",
@@ -271,6 +272,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "font"
@@ -1240,6 +1246,7 @@ dependencies = [
 "checksum euclid 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7b555729225fcc2aabc1ac951f9346967b35c901f4f03a480c31b6a45824109"
 "checksum expat-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cef36cd1a8a02d28b91d97347c63247b9e4cb8a8e36df36f8201dc87a1c0859c"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
+"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum freetype-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8c93a141b156862ab58d0206fa44a9b20d899c86c3e6260017ab748029aa42"
 "checksum freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccfb6d96cac99921f0c2142a91765f6c219868a2c45bdfe7d65a08775f18127"
 "checksum fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcd414e5a1a979b931bb92f41b7a54106d3f6d2e6c253e9ce943b7cd468251ef"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ copypasta = { path = "./copypasta" }
 xdg = "2.0.0"
 log = "0.3"
 clap = "2.20"
+fnv = "1.0.5"
 
 clippy = { version = "0.0.104", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ extern crate clap;
 extern crate copypasta;
 extern crate errno;
 extern crate font;
+extern crate fnv;
 extern crate glutin;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Loading a glyph from the cache is a very hot operation in the renderer.
The original implementation would first check if a glyph was loaded and
then call `get()` which would have to search a second time. This showed
up as a very slow point in profiles.

This patch addresses glyph cache access in two ways: by using a faster
hasher optimized for small keys (fnv), and by using the entry API for
fetching a cached glyph. The `fnv` hasher is faster than the default and
is very efficient for small keys. Using the entry API on the HashMap
means only 1 lookup instead of two. The entry API has a downside where
the key needs to get cloned on fetches.

Reducing the GlyphKey width to 64-bits helps in both areas. Copying an
8-byte wide type is very cheap and thus limits downside of the entry
API. The small width also helps with the hasher performance.

Over all, this patch reduced typical render times by several hundred
microseconds on a 2013 MacBook Pro with a full screen terminal full of
text.