### PR TITLE
Implement save/restore cursor position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "serde_derive 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vte 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vte 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1098,7 +1098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vte"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "utf8parse 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1344,7 +1344,7 @@ dependencies = [
 "checksum utf8parse 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a15ea87f3194a3a454c78d79082b4f5e85f6956ddb6cb86bbfbe4892aa3c0323"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum vte 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0221cd88a06e81dea3ef4dcad02a881b19c03c48b6e6a34875cb301ec8de78d9"
+"checksum vte 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8abafc42c98c6e9f8ee68f3b55daf55d2af7047052facec9f6ac08f4e2addfa1"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
 "checksum wayland-client 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ced3094c157b5cc0a08d40530e1a627d9f88b9a436971338d2646439128a559e"
 "checksum wayland-kbd 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "73bc10e84c1da90777beffecd24742baea17564ffc2a9918af41871c748eb050"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ parking_lot = { version = "0.3.1", features = ["nightly"] }
 serde = "0.9"
 serde_yaml = "0.6"
 serde_derive = "0.9"
-vte = "0.2.1"
+vte = "0.2.2"
 mio = "0.6"
 serde_json = "0.9"
 copypasta = { path = "./copypasta" }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -462,11 +462,23 @@ pub enum CharsetIndex {
     G3,
 }
 
+impl Default for CharsetIndex {
+    fn default() -> Self {
+        CharsetIndex::G0
+    }
+}
+
 /// Standard or common character sets which can be designated as G0-G3
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StandardCharset {
     Ascii,
     SpecialCharacterAndLineDrawing,
+}
+
+impl Default for StandardCharset {
+    fn default() -> Self {
+        StandardCharset::Ascii
+    }
 }
 
 impl<'a, H, W> vte::Perform for Performer<'a, H, W>


### PR DESCRIPTION
This passes the vttest for save and restore cursor position. The
implementation was done according to:

    http://www.vt100.net/docs/vt510-rm/DECSC.html

As of yet, there are a few things not supported by the terminal which
should otherwise be saved/restored.

![image](https://cloud.githubusercontent.com/assets/4285147/22519473/3999ce1e-e865-11e6-8e3e-e429feff6b4d.png)

Supercedes #319 