### PR TITLE
Fix rendering of underline spanning multiple words

### DIFF
--- a/src/term/cell.rs
+++ b/src/term/cell.rs
@@ -88,7 +88,7 @@ impl Cell {
     pub fn is_empty(&self) -> bool {
         self.c == ' ' &&
             self.bg == Color::Named(NamedColor::Background) &&
-            !self.flags.contains(INVERSE)
+            !self.flags.intersects(INVERSE | UNDERLINE)
     }
 
     #[inline]

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -152,7 +152,7 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                     .unwrap_or(false);
 
                 // Skip empty cells
-                if cell.is_empty() && !selected {
+                if cell.is_empty() && !cell.flags.contains(cell::UNDERLINE) && !selected {
                     continue;
                 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -152,7 +152,7 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                     .unwrap_or(false);
 
                 // Skip empty cells
-                if cell.is_empty() && !cell.flags.contains(cell::UNDERLINE) && !selected {
+                if cell.is_empty() && !selected {
                     continue;
                 }
 


### PR DESCRIPTION
Before this change there were gaps between words. To fix this underline is
rendering also on those empty cells.