### PR TITLE
Add visual bell support

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -118,6 +118,32 @@ colors:
 #     cyan:    '0x93a1a1'
 #     white:   '0xfdf6e3'
 
+# Visual Bell
+#
+# Any time the BEL code is received, Alacritty "rings" the visual bell. Once
+# rung, the terminal background will be set to white and transition back to the
+# default background color. You can control the rate of this transition by
+# setting the `duration` property (represented in milliseconds). You can also
+# configure the transition function by setting the `animation` property.
+#
+# Possible values for `animation`
+# `Ease`
+# `EaseOut`
+# `EaseOutSine`
+# `EaseOutQuad`
+# `EaseOutCubic`
+# `EaseOutQuart`
+# `EaseOutQuint`
+# `EaseOutExpo`
+# `EaseOutCirc`
+# `Linear`
+#
+# To completely disable the visual bell, set its duration to 0.
+#
+#visual_bell:
+#  animation: EaseOutExpo
+#  duration: 150
+
 # Key bindings
 #
 # Each binding is defined as an object with some properties. Most of the

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -15,6 +15,7 @@
 in vec2 TexCoords;
 in vec3 fg;
 in vec3 bg;
+flat in float vb;
 flat in int background;
 
 layout(location = 0, index = 0) out vec4 color;
@@ -26,7 +27,7 @@ void main()
 {
     if (background != 0) {
         alphaMask = vec4(1.0, 1.0, 1.0, 1.0);
-        color = vec4(bg, 1.0);
+        color = vec4(bg + vb, 1.0);
     } else {
         alphaMask = vec4(texture(mask, TexCoords).rgb, 1.0);
         color = vec4(fg, 1.0);

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -36,10 +36,12 @@ out vec3 bg;
 uniform vec2 termDim;
 uniform vec2 cellDim;
 
+uniform float visualBell;
 uniform int backgroundPass;
 
 // Orthographic projection
 uniform mat4 projection;
+flat out float vb;
 flat out int background;
 
 void main()
@@ -72,6 +74,7 @@ void main()
         TexCoords = uvOffset + vec2(position.x, 1 - position.y) * uvSize;
     }
 
+    vb = visualBell;
     background = backgroundPass;
     bg = backgroundColor / vec3(255.0, 255.0, 255.0);
     fg = textColor / vec3(255.0, 255.0, 255.0);

--- a/src/display.rs
+++ b/src/display.rs
@@ -272,7 +272,7 @@ impl Display {
     /// This call may block if vsync is enabled
     pub fn draw(&mut self, mut terminal: MutexGuard<Term>, config: &Config, selection: &Selection) {
         // Clear dirty flag
-        terminal.dirty = false;
+        terminal.dirty = !terminal.visual_bell.completed();
 
         if let Some(title) = terminal.get_next_title() {
             self.window.set_title(&title);
@@ -291,6 +291,8 @@ impl Display {
                 // mutable borrow
                 let size_info = *terminal.size_info();
                 self.renderer.with_api(config, &size_info, |mut api| {
+                    api.set_visual_bell(terminal.visual_bell.intensity() as f32);
+
                     api.clear();
 
                     // Draw the grid

--- a/src/event.rs
+++ b/src/event.rs
@@ -110,6 +110,7 @@ pub struct Processor<N> {
     key_bindings: Vec<KeyBinding>,
     mouse_bindings: Vec<MouseBinding>,
     print_events: bool,
+    wait_for_event: bool,
     notifier: N,
     mouse: Mouse,
     resize_tx: mpsc::Sender<(u32, u32)>,
@@ -144,6 +145,7 @@ impl<N: Notify> Processor<N> {
             key_bindings: config.key_bindings().to_vec(),
             mouse_bindings: config.mouse_bindings().to_vec(),
             print_events: options.print_events,
+            wait_for_event: true,
             notifier: notifier,
             resize_tx: resize_tx,
             ref_test: ref_test,
@@ -219,7 +221,8 @@ impl<N: Notify> Processor<N> {
         }
     }
 
-    /// Process at least one event and handle any additional queued events.
+    /// Process events. When `wait_for_event` is set, this method is guaranteed
+    /// to process at least one event.
     pub fn process_events<'a>(
         &mut self,
         term: &'a FairMutex<Term>,
@@ -250,33 +253,38 @@ impl<N: Notify> Processor<N> {
                 }
             }
 
-            match window.wait_events().next() {
-                Some(event) => {
-                    terminal = term.lock();
-                    context = ActionContext {
-                        terminal: &mut terminal,
-                        notifier: &mut self.notifier,
-                        selection: &mut self.selection,
-                        mouse: &mut self.mouse,
-                        size_info: &self.size_info,
-                    };
+            let event = if self.wait_for_event {
+                window.wait_events().next()
+            } else {
+                None
+            };
 
-                    processor = input::Processor {
-                        ctx: context,
-                        key_bindings: &self.key_bindings[..],
-                        mouse_bindings: &self.mouse_bindings[..]
-                    };
+            terminal = term.lock();
 
-                    process!(event);
-                },
-                // Glutin guarantees the WaitEventsIterator never returns None.
-                None => unreachable!(),
+            context = ActionContext {
+                terminal: &mut terminal,
+                notifier: &mut self.notifier,
+                selection: &mut self.selection,
+                mouse: &mut self.mouse,
+                size_info: &self.size_info,
+            };
+
+            processor = input::Processor {
+                ctx: context,
+                key_bindings: &self.key_bindings[..],
+                mouse_bindings: &self.mouse_bindings[..]
+            };
+
+            if let Some(event) = event {
+                process!(event);
             }
 
             for event in window.poll_events() {
                 process!(event);
             }
         }
+
+        self.wait_for_event = !terminal.dirty;
 
         terminal
     }


### PR DESCRIPTION
Hi @jwilm,

This project is awesome 👍. I haven't written Rust before, but I wanted to try my hand at a small feature. I think this change is not quite ready, since `draw` is called lazily (so the bell will not be smooth). If you are interested in accepting this feature, perhaps you could share some tips on how to make the right changes? Commit message below.

Thanks,
Mark

***

This commit adds support for a visual bell. Although the Handler in src/ansi.rs warns "Hopefully this is never implemented", I wanted to give it a try. Two new config options are added, with sensible defaults:

* `visual_bell`, which defaults to `true`, and
* `visual_bell_duration`, which defaults to 150 ms.

The visual bell is modeled by VisualBell in src/display.rs. It has a method to ring the bell, `ring`, and another method, `value`. Both return the "value" of the bell, which ramps down from 1.0 to 0.0 at a rate set by `duration`.