### PR TITLE
Fix bug with restore cursor

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1086,6 +1086,8 @@ impl ansi::Handler for Term {
         };
 
         self.cursor = *holder;
+        self.cursor.point.line = min(self.cursor.point.line, self.grid.num_lines() - 1);
+        self.cursor.point.col = min(self.cursor.point.col, self.grid.num_cols() - 1);
     }
 
     #[inline]


### PR DESCRIPTION
The saved cursor position could previously end up outside of the grid if
the terminal was resized to be smaller and then calling a restore.
Restore now ensures the cursor line and column are within grid bounds.