### PR TITLE
Configurable window dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ is created once alacritty is first run. On most systems this often defaults
 to `$HOME/.config/alacritty/alacritty.yml`.
 
 Many configuration options will take effect immediately upon saving changes to
-the config file. The only exception is the `font` and `dpi` section which
-requires Alacritty to be restarted. For further explanation of the config file,
-please consult the comments in the default config file.
+the config file. The only exception is the `font`, `dimensions` and `dpi` sections
+which requires Alacritty to be restarted. For further explanation of the config
+file, please consult the comments in the default config file.
 
 ## Issues (known, unknown, feature requests, etc)
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -1,4 +1,9 @@
 # Configuration for Alacritty, the GPU enhanced terminal emulator
+# Window dimensions in character columns and lines
+# (changes require restart)
+dimensions:
+  columns: 80
+  lines: 40
 
 # The FreeType rasterizer needs to know the device DPI for best results
 # (changes require restart)

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -1,4 +1,9 @@
 # Configuration for Alacritty, the GPU enhanced terminal emulator
+# Window dimensions in character columns and lines
+# (changes require restart)
+dimensions:
+  columns: 80
+  lines: 40
 
 # The FreeType rasterizer needs to know the device DPI for best results
 # (changes require restart)

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ use serde::de::{Visitor, MapVisitor, Unexpected};
 use notify::{Watcher as WatcherApi, RecommendedWatcher as FileWatcher, op};
 
 use input::{Action, Binding, MouseBinding, KeyBinding};
+use index::{Line, Column};
 
 use ansi;
 
@@ -212,6 +213,10 @@ impl<'a> Shell<'a> {
 /// Top-level config type
 #[derive(Debug, Deserialize)]
 pub struct Config {
+    /// Initial dimensions
+    #[serde(default)]
+    dimensions: Dimensions,
+
     /// Pixels per inch
     #[serde(default)]
     dpi: Dpi,
@@ -273,6 +278,7 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             draw_bold_text_with_bright_colors: true,
+            dimensions: Default::default(),
             dpi: Default::default(),
             font: Default::default(),
             render_timer: Default::default(),
@@ -969,6 +975,12 @@ impl Config {
         &self.font
     }
 
+    /// Get window dimensions
+    #[inline]
+    pub fn dimensions(&self) -> Dimensions {
+        self.dimensions
+    }
+
     /// Get dpi config
     #[inline]
     pub fn dpi(&self) -> &Dpi {
@@ -1017,6 +1029,45 @@ impl Config {
         f.read_to_string(&mut contents)?;
 
         Ok(contents)
+    }
+}
+
+/// Window Dimensions
+///
+/// Newtype to avoid passing values incorrectly
+#[derive(Debug, Copy, Clone, Deserialize)]
+pub struct Dimensions {
+    /// Window width in character columns
+    columns: Column,
+
+    /// Window Height in character lines
+    lines: Line,
+}
+
+impl Default for Dimensions {
+    fn default() -> Dimensions {
+        Dimensions::new(Column(80), Line(24))
+    }
+}
+
+impl Dimensions {
+    pub fn new(columns: Column, lines: Line) -> Self {
+        Dimensions {
+            columns: columns,
+            lines: lines
+        }
+    }
+
+    /// Get lines
+    #[inline]
+    pub fn lines_u32(&self) -> u32 {
+        self.lines.0 as u32
+    }
+
+    /// Get columns
+    #[inline]
+    pub fn columns_u32(&self) -> u32 {
+        self.columns.0 as u32
     }
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -177,8 +177,10 @@ impl Display {
         let cell_height = (metrics.line_height + font.offset().y() as f64) as u32;
 
         // Resize window to specified dimensions
-        let width = cell_width * options.columns_u32() + 4;
-        let height = cell_height * options.lines_u32() + 4;
+        let dimensions = options.dimensions()
+            .unwrap_or_else(|| config.dimensions());
+        let width = cell_width * dimensions.columns_u32() + 4;
+        let height = cell_height * dimensions.lines_u32() + 4;
         let size = Size { width: Pixels(width), height: Pixels(height) };
         info!("set_inner_size: {}", size);
 


### PR DESCRIPTION
I saw #370 and decided to have a go at implementing this.

Will use a default of 80x24 cols x lines if neither config file or argument options are specified.
Argument options will override config options if specified.