### PR TITLE
Add "Quit" action to allow exit on a Cmd-W or Cmd-Q

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -144,6 +144,8 @@ colors:
 key_bindings:
   - { key: V,        mods: Command, action: Paste                        }
   - { key: C,        mods: Command, action: Copy                         }
+  - { key: Q,        mods: Command, action: Quit                         }
+  - { key: W,        mods: Command, action: Quit                         }
   - { key: Home,                    chars: "\x1b[H",   mode: ~AppCursor  }
   - { key: Home,                    chars: "\x1b[1~",  mode: AppCursor   }
   - { key: End,                     chars: "\x1b[F",   mode: ~AppCursor  }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -144,6 +144,8 @@ colors:
 key_bindings:
   - { key: V,        mods: Command, action: Paste                        }
   - { key: C,        mods: Command, action: Copy                         }
+  - { key: Q,        mods: Command, action: Quit                         }
+  - { key: W,        mods: Command, action: Quit                         }
   - { key: Home,                    chars: "\x1b[H",   mode: ~AppCursor  }
   - { key: Home,                    chars: "\x1b[1~",  mode: AppCursor   }
   - { key: End,                     chars: "\x1b[F",   mode: ~AppCursor  }

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,7 +352,7 @@ impl de::Deserialize for ActionWrapper {
             type Value = ActionWrapper;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("Paste, Copy, or PasteSelection")
+                f.write_str("Paste, Copy, PasteSelection, or Quit")
             }
 
             fn visit_str<E>(self, value: &str) -> ::std::result::Result<ActionWrapper, E>
@@ -362,6 +362,7 @@ impl de::Deserialize for ActionWrapper {
                     "Paste" => Action::Paste,
                     "Copy" => Action::Copy,
                     "PasteSelection" => Action::PasteSelection,
+                    "Quit" => Action::Quit,
                     _ => return Err(E::invalid_value(Unexpected::Str(value), &self)),
                 }))
             }

--- a/src/input.rs
+++ b/src/input.rs
@@ -137,6 +137,9 @@ pub enum Action {
 
     /// Paste contents of selection buffer
     PasteSelection,
+
+    /// Quits Alacritty.
+    Quit,
 }
 
 impl Action {
@@ -164,6 +167,10 @@ impl Action {
                     .unwrap_or_else(|err| {
                         warn!("Error loading data from clipboard. {}", Red(err));
                     });
+            },
+            Action::Quit => {
+                // FIXME should do a more graceful shutdown
+                ::std::process::exit(0);
             },
         }
     }


### PR DESCRIPTION
Adds a new "Quit" action and binds it to Cmd-W and Cmd-Q on Mac OS in an
attempt to make Alacritty feel more like a "normal" citizen of the
operating system. Alternatives like Ctrl-D are okay, but I usually want
to leave my shells nested within Tmux open even if I exit my terminal.
It's also largely selfish: I've built up muscle memory over the years
that takes my fingers to Cmd-Q first (and I suspect I'm not the only
one).

The implementation for an exit is copied from `event.rs` which notably
is already tagged with a FIXME. It seems that `tty.rs` contains a
`process_should_exit` system to help handle a `SIGCHLD`, and it's
possible that these two exit implementations should be merged together.
I could probably tackle that as my next project.

As mentioned in #218, Alacritty can't really spawn other windows right
now, so I've tied in Cmd-W as simply another synonym for quitting until
that's implemented.

One other thought: I'm not super convinced on the approach of having all
key bindings configured directly from a Yaml file and without any
defaults. You can see that even here it will be a bit of a problem
because there may be hundreds of Mac users out there who won't get this
key binding until they port it in manually for bootstrap from a fresh
version of the repository's default configuration file.

Fixes #218.