### PR TITLE
Add TERM config entry

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -1,4 +1,17 @@
 # Configuration for Alacritty, the GPU enhanced terminal emulator
+
+
+# Any items in the `env` entry below will be added as
+# environment variables. Some entries may override variables
+# set by alacritty it self.
+env:
+  # TERM env customization. Default is xterm-256color
+  # Note: the default TERM value `xterm-256color` does not
+  # specify all features alacritty supports. This does pose
+  # a few issues with programs relying on terminfo and the
+  # `tput` command
+  TERM: xterm-256color
+
 # Window dimensions in character columns and lines
 # (changes require restart)
 dimensions:

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -1,4 +1,16 @@
 # Configuration for Alacritty, the GPU enhanced terminal emulator
+
+# Any items in the `env` entry below will be added as
+# environment variables. Some entries may override variables
+# set by alacritty it self.
+env:
+  # TERM env customization. Default is xterm-256color
+  # Note: the default TERM value `xterm-256color` does not
+  # specify all features alacritty supports. This does pose
+  # a few issues with programs relying on terminfo and the
+  # `tput` command
+  TERM: xterm-256color
+
 # Window dimensions in character columns and lines
 # (changes require restart)
 dimensions:

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::mpsc;
 use std::time::Duration;
+use std::collections::HashMap;
 
 use ::Rgb;
 use font::Size;
@@ -171,6 +172,10 @@ impl<'a> Shell<'a> {
 /// Top-level config type
 #[derive(Debug, Deserialize)]
 pub struct Config {
+    /// TERM env variable
+    #[serde(default)]
+    env: HashMap<String, String>,
+
     /// Initial dimensions
     #[serde(default)]
     dimensions: Dimensions,
@@ -267,6 +272,7 @@ impl Default for Config {
             shell: None,
             config_path: None,
             visual_bell: Default::default(),
+            env: Default::default(),
         }
     }
 }
@@ -996,6 +1002,10 @@ impl Config {
 
     pub fn shell(&self) -> Option<&Shell> {
         self.shell.as_ref()
+    }
+
+    pub fn env(&self) -> &HashMap<String, String> {
+        &self.env
     }
 
     fn load_from<P: Into<PathBuf>>(path: P) -> Result<Config> {

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -207,7 +207,10 @@ pub fn new<T: ToWinsize>(config: &Config, options: &Options, size: T) -> Pty {
     builder.env("USER", pw.name);
     builder.env("SHELL", shell.program());
     builder.env("HOME", pw.dir);
-    builder.env("TERM", "xterm-256color"); // sigh
+    builder.env("TERM", "xterm-256color"); // default term until we can supply our own
+    for (key, value) in config.env().iter() {
+        builder.env(key, value);
+    }
 
     builder.before_exec(move || {
         // Create a new process group


### PR DESCRIPTION
This PR solves an issue I had with vim not displaying comments in italics due to the TERM env variable being set to a terminfo which did not support setting and resetting italics.

Vim uses the codes defined in terminfo and invokes them with `tput` ([italics in iterm2 vim tmux ](https://alexpearce.me/2014/05/italics-in-iterm2-vim-tmux/) explains a bit and has a handy bit of code to test if the TERM is set correctly)

I kept the default as xterm-256color because as far as I can tell no terminfo db has a correct entry for italics.

There seem to be a few issues here that might be fixed if the TERM variable is set correctly (#85)