### PR TITLE
Add built crate and more verbose debug banner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "alacritty"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "built 0.1.0 (git+https://github.com/lukaslueg/built)",
  "cgmath 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -60,6 +61,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "built"
+version = "0.1.0"
+source = "git+https://github.com/lukaslueg/built#0d986f99b50464c91280eb9b2bcbd75f0eee8c76"
+dependencies = [
+ "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "byteorder"
@@ -355,6 +366,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "inotify"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +494,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libloading"
@@ -1026,6 +1070,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "user32-sys"
@@ -1196,6 +1265,7 @@ dependencies = [
 "checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+"checksum built 0.1.0 (git+https://github.com/lukaslueg/built)" = "<none>"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
@@ -1227,10 +1297,12 @@ dependencies = [
 "checksum fsevent-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "72e33a926306442d961595c3a325864326ca4287795e106dae8993afe484ede6"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "65256ec4dc2592e6f05bfc1ca3b956a4e0698aa90b1dff1f5687d55a5a3fd59a"
+"checksum git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "046ae03385257040b2a35e56d9669d950dd911ba2bf48202fbef73ee6aab27b2"
 "checksum gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1d8edc81c5ae84605a62f5dac661a2313003b26d59839f81d47d46cf0f16a55"
 "checksum gleam 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3023edde169b7767a71d2e5dd8e8903ac3b1436ff659225310928db87d6a8a"
 "checksum glutin 0.6.1 (git+https://github.com/jwilm/glutin?rev=af7fe340bd4a2af53ea521defcb4f377cdc588cf)" = "<none>"
 "checksum heapsize 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5a376f7402b85be6e0ba504243ecbc0709c48019ecc6286d0540c2e359050c88"
+"checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum inotify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8458c07bdbdaf309c80e2c3304d14c3db64e7465d4f07cf589ccb83fd0ff31a"
 "checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum itoa 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5537accdedeaa51526addad01e989bdaeb690e8e5fcca8dce893350912778636"
@@ -1240,6 +1312,7 @@ dependencies = [
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
+"checksum libgit2-sys 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d951fd5eccae07c74e8c2c1075b05ea1e43be7f8952245af8c2840d1480b1d95"
 "checksum libloading 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "84816a8c6ed8163dfe0dbdd2b09d35c6723270ea77a4c7afa4bedf038a36cb99"
 "checksum libz-sys 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "7616099a575493da60cddc1174b686fcfb00ece89dc6f61f31ff47c35f07bbe8"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
@@ -1306,10 +1379,13 @@ dependencies = [
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0590d72182e50e879c4da3b11c6488dae18fccb1ae0c7a3eda18e16795844796"
+"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a078ebdd62c0e71a709c3d53d2af693fe09fe93fbff8344aebe289b78f9032"
 "checksum unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5e94e9f6961090fcc75180629c4ef33e5310d6ed2c0dd173f4ca63c9043b669e"
 "checksum unicode-segmentation 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7baebdc1df1363fa66161fca2fe047e4f4209011cc7e045948298996afdf85df"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5ba8a749fb4479b043733416c244fa9d1d3af3d7c23804944651c8a448cb87e"
 "checksum user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6717129de5ac253f5642fc78a51d0c7de6f9f53d617fc94e9bae7f6e71cf5504"
 "checksum utf8parse 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a15ea87f3194a3a454c78d79082b4f5e85f6956ddb6cb86bbfbe4892aa3c0323"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "alacritty"
 version = "0.1.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "built 0.1.0 (git+https://github.com/lukaslueg/built)",
+ "built 0.1.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -64,8 +64,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "built"
-version = "0.1.0"
-source = "git+https://github.com/lukaslueg/built#0d986f99b50464c91280eb9b2bcbd75f0eee8c76"
+version = "0.1.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1265,7 +1265,7 @@ dependencies = [
 "checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-"checksum built 0.1.0 (git+https://github.com/lukaslueg/built)" = "<none>"
+"checksum built 0.1.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)" = "7339291d89d6e6cdad7690764265171d6c52eabcfa22fd7f20c10ff605bf0423"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ nightly = []
 
 [build-dependencies]
 gl_generator = "0.5"
+built = { version = "0.1", git = "https://github.com/lukaslueg/built", features = ["serialized_git", "serialized_time"] }
 
 [dependencies.glutin]
 git = "https://github.com/jwilm/glutin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ nightly = []
 
 [build-dependencies]
 gl_generator = "0.5"
-built = { version = "0.1", git = "https://github.com/lukaslueg/built", features = ["serialized_git", "serialized_time"] }
+built = { version = "0.1.0-rc1", features = ["serialized_git", "serialized_time"] }
 
 [dependencies.glutin]
 git = "https://github.com/jwilm/glutin"

--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+extern crate built;
 extern crate gl_generator;
 
 use gl_generator::{Registry, Api, Profile, Fallbacks, GlobalGenerator};
@@ -27,4 +28,10 @@ fn main() {
         ])
         .write_bindings(GlobalGenerator, &mut file)
         .unwrap();
+
+    let mut built_opts = built::Options::default();
+    built_opts.set_dependencies(true);
+    let built_src = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let built_dst = Path::new(&dest).join("built.rs");
+    built::write_built_file_with_opts(&built_opts, &built_src, &built_dst).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ extern crate log;
 #[macro_use]
 pub mod macros;
 
+pub mod built {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
 pub mod ansi;
 pub mod cli;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ extern crate log;
 use std::error::Error;
 use std::sync::Arc;
 
+use alacritty::built;
 use alacritty::cli;
 use alacritty::config::{self, Config};
 use alacritty::display::Display;
@@ -78,6 +79,18 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
     logging::initialize(&options)?;
 
     info!("Welcome to Alacritty.");
+    info!("This is version {}{}, built for {} by {}.",
+          built::PKG_VERSION,
+          built::GIT_VERSION.map_or_else(|| "".to_owned(),
+                                         |v| format!(" (git {})", v)),
+          built::TARGET,
+          built::RUSTC_VERSION);
+    trace!("Alacritty was built with profile \"{}\", features \"{}\" on {} using {}",
+           built::PROFILE,
+           built::FEATURES_STR,
+           built::BUILT_TIME_UTC,
+           built::DEPENDENCIES_STR);
+
 
     // Create a display.
     //


### PR DESCRIPTION
I've put the old `build_info` into a crate of it's own that currently lives off github. RFCing.

When running alacritty with elevated verbosity, additional debug output is given:

>  ~/dev/alacritty   built  target/debug/alacritty -v
> Welcome to Alacritty.
> This is version 0.1.0 (git 62eb1e2), built for x86_64-apple-darwin by rustc 1.16.0-nightly (bf6d7b665 2017-01-15).
> device_pixel_ratio: 2
> ...

>  ~/dev/alacritty   built  target/debug/alacritty -vvvv
> Welcome to Alacritty.
> This is version 0.1.0 (git 62eb1e2), built for x86_64-apple-darwin by rustc 1.16.0-nightly (bf6d7b665 2017-01-15).
> Alacritty was built with profile "debug", features "DEFAULT, ERR_PRINTLN" on Thu, 16 Feb 2017 19:00:08 GMT using android_glue 0.2.1, ansi_term 0.9.0, bitflags 0.3.3, bitflags 0.4.0, bitflags 0.6.0, bitflags 0.7.0, block 0.1.6, built 0.1.0, byteorder 0.5.3, bytes 0.3.0, cfg-if 0.1.0, cgl 0.1.5, cgmath 0.7.0, clap 2.20.0, clippy 0.0.104, clippy_lints 0.0.104, cmake 0.1.20, cocoa 0.3.3, copypasta 0.0.1, core-foundation 0.2.3, core-foundation-sys 0.2.3, core-graphics 0.3.2, core-text 1.1.1, crossbeam 0.2.10, dlib 0.3.1, dtoa 0.2.2, dtoa 0.3.0, dwmapi-sys 0.1.0, errno 0.1.8, euclid 0.6.8, expat-sys 2.1.4, ffi-util 0.1.0, filetime 0.1.10, fnv 1.0.5, font 0.1.0, freetype-rs 0.9.0, freetype-sys 0.4.0, fs2 0.2.5, fsevent 0.2.15, fsevent-sys 0.1.5, gcc 0.3.41, gdi32-sys 0.1.1, git2 0.6.4,gl_generator 0.5.2, gleam 0.2.31, glutin 0.6.1, heapsize 0.3.8, idna 0.1.0, inotify 0.2.3, itoa 0.1.1, itoa 0.2.1, kernel32-sys 0.2.2, khronos_api 1.0.0, lazy_static 0.1.16, lazy_static 0.2.2, lazycell 0.4.0, libc 0.2.18, libgit2-sys 0.6.7, libloading 0.3.1, libz-sys 1.0.12, linked-hash-map 0.3.0, log 0.3.6, malloc_buf 0.0.6, matches 0.1.4, memmap 0.2.3, mio 0.5.1, mio 0.6.2, miow 0.1.5, net2 0.2.26, nix 0.5.1, nix 0.7.0, nom 1.2.4, notify 2.6.3, num 0.1.36, num-bigint0.1.35, num-complex 0.1.35, num-integer 0.1.32, num-iter 0.1.32, num-rational 0.1.35, num-traits 0.1.36, objc 0.2.2, objc-foundation 0.1.1, objc_id 0.1.0, osmesa-sys 0.1.2, owning_ref 0.2.4, parking_lot 0.3.6, parking_lot_core 0.2.0, phf 0.7.21, phf_codegen 0.7.21, phf_generator 0.7.21, phf_shared 0.7.21, pkg-config 0.3.8, quine-mc_cluskey 0.2.4, quote 0.3.12, rand 0.3.15, redox_syscall 0.1.16, regex-syntax 0.3.9, rustc-serialize 0.3.22, rustc_version 0.1.7, semver 0.1.20, semver 0.2.3, serde 0.7.15, serde 0.8.23, serde 0.9.3, serde_codegen_internals 0.12.0, serde_derive 0.9.2, serde_json 0.8.6, serde_json 0.9.2, serde_yaml0.6.1, servo-fontconfig 0.2.0, servo-fontconfig-sys 2.11.3, shared_library 0.1.5, shell32-sys 0.1.1, siphasher 0.2.0, slab 0.1.3, slab 0.3.0, smallvec 0.1.8,strsim 0.6.0, syn 0.11.4, target_build_utils 0.1.2, tempfile 2.1.5, term_size 0.2.1, time 0.1.36, toml 0.1.30, toml 0.2.1, unicode-bidi 0.2.5, unicode-normalization 0.1.3, unicode-segmentation 1.0.1, unicode-width 0.1.4, unicode-xid 0.0.4, url 1.4.0, user32-sys 0.1.2, utf8parse 0.1.0, vec_map 0.6.0, void 1.0.2, vte 0.2.2, walkdir 0.1.8, wayland-client 0.5.12, wayland-kbd 0.3.6, wayland-scanner 0.5.11, wayland-sys 0.5.11, wayland-window 0.2.3, winapi 0.2.8, winapi-build0.1.1, ws2_32-sys 0.2.1, x11-dl 2.12.0, xdg 2.0.0, xml-rs 0.3.5, yaml-rust 0.3.5
> device_pixel_ratio: 2
> width: 2048, height: 1536
> ...