### PR TITLE
use an empty cell as template when resizing grids

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -863,7 +863,7 @@ impl Term {
         println!("num_cols, num_lines = {}, {}", num_cols, num_lines);
 
         // Resize grids to new size
-        let template = self.cursor.template;
+        let template = self.empty_cell;
         self.grid.resize(num_lines, num_cols, &template);
         self.alt_grid.resize(num_lines, num_cols, &template);
 


### PR DESCRIPTION
This resolves #415.

Seems to be an oversight that the cell template was the cursor block. I changed it to the empty cell and this seems to have fixed the issue.