### PR TITLE
Find config file in /etc/alacritty/alacritty.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ file as the following paths:
 2. `$XDG_CONFIG_HOME/alacritty.yml`
 3. `$HOME/.config/alacritty/alacritty.yml`
 4. `$HOME/.alacritty.yml`
+5. `/etc/alacritty/alacritty.yml`
 
 If neither of these paths are found then `$XDG_CONFIG_HOME/alacritty/alacritty.yml`
 is created once alacritty is first run. On most systems this often defaults

--- a/src/config.rs
+++ b/src/config.rs
@@ -888,6 +888,7 @@ impl Config {
     /// 2. $XDG_CONFIG_HOME/alacritty.yml
     /// 3. $HOME/.config/alacritty/alacritty.yml
     /// 4. $HOME/.alacritty.yml
+    /// 5. /etc/alacritty/alacritty.yml
     pub fn load() -> Result<Config> {
         let home = env::var("HOME")?;
 
@@ -908,9 +909,17 @@ impl Config {
                     false => None
                 }
             })
-            .unwrap_or_else(|| {
+            .or_else(|| {
                 // Fallback path: $HOME/.alacritty.yml
-                PathBuf::from(&home).join(".alacritty.yml")
+                let fallback = PathBuf::from(&home).join(".alacritty.yml");
+                match fallback.exists() {
+                    true => Some(fallback),
+                    false => None
+                }
+            })
+            .unwrap_or_else(|| {
+                // Fallback path: /etc/alacritty/alacritty.yml
+                PathBuf::from("/etc/alacritty/alacritty.yml")
             });
 
         Config::load_from(path)


### PR DESCRIPTION
Adds an additional config path outside of $HOME.

This is helpful me because I use Qubes OS.  Qubes systems run many VMs each with different home folders but with most of the rest of the filesystem shared (through a template vm). Previously I had to install a config file into each VM; now I can configure it once in the template vm and have the changes picked up everywhere else.  I imagine it might be useful for systems with multiple users too.

Config path is setup as final fallback option, so it shouldn't break anyones setup (hopefully)!