### PR TITLE
Lazily reset `start_time` in VisualBell's `completed` method

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -372,9 +372,14 @@ impl VisualBell {
     }
 
     /// Check whether or not the visual bell has completed "ringing".
-    pub fn completed(&self) -> bool {
+    pub fn completed(&mut self) -> bool {
         match self.start_time {
-            Some(earlier) => Instant::now().duration_since(earlier) > self.duration,
+            Some(earlier) => {
+                if Instant::now().duration_since(earlier) >= self.duration {
+                    self.start_time = None;
+                }
+                false
+            },
             None => true
         }
     }


### PR DESCRIPTION
Fixes #416. Here's what I think is happening: at short `duration`s, the VisualBell's [`completed` check](https://github.com/jwilm/alacritty/blob/3ce6e1e4b2924b0d432cbb3e62b4bbef88dd38ff/src/term/mod.rs#L377) is returning `true` before we've actually had a chance to draw the "normal" background color. I thought about driving this condition off of whether or not `intensity` returns 0.0, but we may still miss a draw, I think. Perhaps the best way to tackle this is to let `completed` lazily reset the VisualBell's `start_time` (something @jwilm asked about when this feature originally landed), and to only return `true` when the VisualBell's `start_time` is `None`. This should effectively delay the final draw until after the VisualBell completes.

***

@lord-re would you mind testing with these changes?

@jwilm at very short `duration`s, there now appears to be a small discrepancy between the clear color and the background color of the glyphs. Perhaps the technique you described, drawing a quad, would fix this; however, I am not entirely sure how this should work. If you can share some pointers, perhaps I could take a stab at it.