### PR TITLE
Address VisualBell Feedback

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -94,16 +94,17 @@ colors:
 # Visual Bell
 #
 # Any time the BEL code is received, Alacritty "rings" the visual bell. Once
-# rung, the terminal reacts according to the visual bell's `effect`. You can
-# control the rate of this transition by setting the `duration` (represented
-# in milliseconds) and `animation` properties.
+# rung, the terminal reacts according to the visual bell's "effect".
 #
-# Possible values for `effect`
+# Possible effects
 # `None`
 # `FlashText`
 # `FlashBackground`
 #
-# Possible values for `animation`
+# The `FlashText` and `FlashBackground` effects accept a `duration` property,
+# specified in milliseconds, and an `easing` property.
+#
+# Possible values for `easing`
 # `Ease`
 # `EaseOut`
 # `EaseOutSine`
@@ -115,13 +116,22 @@ colors:
 # `EaseOutCirc`
 # `Linear`
 #
-# To completely disable the visual bell, set its `duration` to 0 or its `effect`
+# To completely disable the visual bell, set its `duration` to 0 or its effect
 # to `None`.
 #
-visual_bell:
-  animation: EaseOutExpo
-  duration: 0
-  effect: None
+#visual_bell:
+#  FlashText:
+#    color: '0xffffff'
+#    duration: 100
+#    easing: EaseOutQuint
+#
+#visual_bell:
+#  FlashBackground:
+#    color: '0xffffff'
+#    duration: 100
+#    easing: EaseOutQuint
+#
+visual_bell: None
 
 # Key bindings
 #

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -94,10 +94,14 @@ colors:
 # Visual Bell
 #
 # Any time the BEL code is received, Alacritty "rings" the visual bell. Once
-# rung, the terminal background will be set to white and transition back to the
-# default background color. You can control the rate of this transition by
-# setting the `duration` property (represented in milliseconds). You can also
-# configure the transition function by setting the `animation` property.
+# rung, the terminal reacts according to the visual bell's `effect`. You can
+# control the rate of this transition by setting the `duration` (represented
+# in milliseconds) and `animation` properties.
+#
+# Possible values for `effect`
+# `None`
+# `FlashText`
+# `FlashBackground`
 #
 # Possible values for `animation`
 # `Ease`
@@ -111,11 +115,13 @@ colors:
 # `EaseOutCirc`
 # `Linear`
 #
-# To completely disable the visual bell, set its duration to 0.
+# To completely disable the visual bell, set its `duration` to 0 or its `effect`
+# to `None`.
 #
 visual_bell:
   animation: EaseOutExpo
   duration: 0
+  effect: None
 
 # Key bindings
 #

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -94,16 +94,17 @@ colors:
 # Visual Bell
 #
 # Any time the BEL code is received, Alacritty "rings" the visual bell. Once
-# rung, the terminal reacts according to the visual bell's `effect`. You can
-# control the rate of this transition by setting the `duration` (represented
-# in milliseconds) and `animation` properties.
+# rung, the terminal reacts according to the visual bell's "effect".
 #
-# Possible values for `effect`
+# Possible effects
 # `None`
 # `FlashText`
 # `FlashBackground`
 #
-# Possible values for `animation`
+# The `FlashText` and `FlashBackground` effects accept a `duration` property,
+# specified in milliseconds, and an `easing` property.
+#
+# Possible values for `easing`
 # `Ease`
 # `EaseOut`
 # `EaseOutSine`
@@ -115,13 +116,22 @@ colors:
 # `EaseOutCirc`
 # `Linear`
 #
-# To completely disable the visual bell, set its `duration` to 0 or its `effect`
+# To completely disable the visual bell, set its `duration` to 0 or its effect
 # to `None`.
 #
-visual_bell:
-  animation: EaseOutExpo
-  duration: 0
-  effect: None
+#visual_bell:
+#  FlashText:
+#    color: '0xffffff'
+#    duration: 100
+#    easing: EaseOutQuint
+#
+#visual_bell:
+#  FlashBackground:
+#    color: '0xffffff'
+#    duration: 100
+#    easing: EaseOutQuint
+#
+visual_bell: None
 
 # Key bindings
 #

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -94,10 +94,14 @@ colors:
 # Visual Bell
 #
 # Any time the BEL code is received, Alacritty "rings" the visual bell. Once
-# rung, the terminal background will be set to white and transition back to the
-# default background color. You can control the rate of this transition by
-# setting the `duration` property (represented in milliseconds). You can also
-# configure the transition function by setting the `animation` property.
+# rung, the terminal reacts according to the visual bell's `effect`. You can
+# control the rate of this transition by setting the `duration` (represented
+# in milliseconds) and `animation` properties.
+#
+# Possible values for `effect`
+# `None`
+# `FlashText`
+# `FlashBackground`
 #
 # Possible values for `animation`
 # `Ease`
@@ -111,11 +115,13 @@ colors:
 # `EaseOutCirc`
 # `Linear`
 #
-# To completely disable the visual bell, set its duration to 0.
+# To completely disable the visual bell, set its `duration` to 0 or its `effect`
+# to `None`.
 #
 visual_bell:
   animation: EaseOutExpo
   duration: 0
+  effect: None
 
 # Key bindings
 #

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -24,13 +24,16 @@ layout(location = 0, index = 1) out vec4 alphaMask;
 
 uniform sampler2D mask;
 
+#define FLASH_TEXT 1
+#define FLASH_BACKGROUND 2
+
 void main()
 {
     if (background != 0) {
         alphaMask = vec4(1.0, 1.0, 1.0, 1.0);
-        color = vec4(bg + vbi, 1.0);
+        color = vec4(bg + (vbe == FLASH_BACKGROUND ? vbi : 0), 1.0);
     } else {
         alphaMask = vec4(texture(mask, TexCoords).rgb, 1.0);
-        color = vec4(fg, 1.0);
+        color = vec4(fg + (vbe == FLASH_TEXT ? vbi : 0), 1.0);
     }
 }

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -15,6 +15,7 @@
 in vec2 TexCoords;
 in vec3 fg;
 in vec3 bg;
+flat in int vbe;
 flat in float vbi;
 flat in int background;
 

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -15,6 +15,7 @@
 in vec2 TexCoords;
 in vec3 fg;
 in vec3 bg;
+flat in vec3 vbc;
 flat in int vbe;
 flat in float vbi;
 flat in int background;
@@ -31,9 +32,9 @@ void main()
 {
     if (background != 0) {
         alphaMask = vec4(1.0, 1.0, 1.0, 1.0);
-        color = vec4(bg + (vbe == FLASH_BACKGROUND ? vbi : 0), 1.0);
+        color = vec4(mix(bg, vbc, vbe == FLASH_BACKGROUND ? vbi : 0.0), 1.0);
     } else {
         alphaMask = vec4(texture(mask, TexCoords).rgb, 1.0);
-        color = vec4(fg + (vbe == FLASH_TEXT ? vbi : 0), 1.0);
+        color = vec4(mix(fg, vbc, vbe == FLASH_TEXT ? vbi : 0.0), 1.0);
     }
 }

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -15,7 +15,7 @@
 in vec2 TexCoords;
 in vec3 fg;
 in vec3 bg;
-flat in float vb;
+flat in float vbi;
 flat in int background;
 
 layout(location = 0, index = 0) out vec4 color;
@@ -27,7 +27,7 @@ void main()
 {
     if (background != 0) {
         alphaMask = vec4(1.0, 1.0, 1.0, 1.0);
-        color = vec4(bg + vb, 1.0);
+        color = vec4(bg + vbi, 1.0);
     } else {
         alphaMask = vec4(texture(mask, TexCoords).rgb, 1.0);
         color = vec4(fg, 1.0);

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -36,12 +36,14 @@ out vec3 bg;
 uniform vec2 termDim;
 uniform vec2 cellDim;
 
+uniform vec3 visualBellColor;
 uniform int visualBellEffect;
 uniform float visualBellIntensity;
 uniform int backgroundPass;
 
 // Orthographic projection
 uniform mat4 projection;
+flat out vec3 vbc;
 flat out int vbe;
 flat out float vbi;
 flat out int background;
@@ -76,6 +78,7 @@ void main()
         TexCoords = uvOffset + vec2(position.x, 1 - position.y) * uvSize;
     }
 
+    vbc = visualBellColor;
     vbe = visualBellEffect;
     vbi = visualBellIntensity;
     background = backgroundPass;

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -36,11 +36,13 @@ out vec3 bg;
 uniform vec2 termDim;
 uniform vec2 cellDim;
 
+uniform int visualBellEffect;
 uniform float visualBellIntensity;
 uniform int backgroundPass;
 
 // Orthographic projection
 uniform mat4 projection;
+flat out int vbe;
 flat out float vbi;
 flat out int background;
 
@@ -74,6 +76,7 @@ void main()
         TexCoords = uvOffset + vec2(position.x, 1 - position.y) * uvSize;
     }
 
+    vbe = visualBellEffect;
     vbi = visualBellIntensity;
     background = backgroundPass;
     bg = backgroundColor / vec3(255.0, 255.0, 255.0);

--- a/res/text.v.glsl
+++ b/res/text.v.glsl
@@ -36,12 +36,12 @@ out vec3 bg;
 uniform vec2 termDim;
 uniform vec2 cellDim;
 
-uniform float visualBell;
+uniform float visualBellIntensity;
 uniform int backgroundPass;
 
 // Orthographic projection
 uniform mat4 projection;
-flat out float vb;
+flat out float vbi;
 flat out int background;
 
 void main()
@@ -74,7 +74,7 @@ void main()
         TexCoords = uvOffset + vec2(position.x, 1 - position.y) * uvSize;
     }
 
-    vb = visualBell;
+    vbi = visualBellIntensity;
     background = backgroundPass;
     bg = backgroundColor / vec3(255.0, 255.0, 255.0);
     fg = textColor / vec3(255.0, 255.0, 255.0);

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,7 @@ pub enum VisualBellAnimation {
     Linear,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub enum VisualBellEffect {
     None,
     FlashText,

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,13 @@ pub enum VisualBellAnimation {
     Linear,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub enum VisualBellEffect {
+    None,
+    FlashText,
+    FlashBackground,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct VisualBellConfig {
     /// Visual bell animation function
@@ -99,6 +106,10 @@ pub struct VisualBellConfig {
     /// Visual bell duration in milliseconds
     #[serde(default="default_visual_bell_duration")]
     duration: u16,
+
+    /// Visual bell effect
+    #[serde(default="default_visual_bell_effect")]
+    effect: VisualBellEffect,
 }
 
 fn default_visual_bell_animation() -> VisualBellAnimation {
@@ -107,6 +118,10 @@ fn default_visual_bell_animation() -> VisualBellAnimation {
 
 fn default_visual_bell_duration() -> u16 {
     150
+}
+
+fn default_visual_bell_effect() -> VisualBellEffect {
+    VisualBellEffect::None
 }
 
 impl VisualBellConfig {
@@ -121,6 +136,12 @@ impl VisualBellConfig {
     pub fn duration(&self) -> Duration {
         Duration::from_millis(self.duration as u64)
     }
+
+    /// Visual bell effect
+    #[inline]
+    pub fn effect(&self) -> VisualBellEffect {
+        self.effect
+    }
 }
 
 impl Default for VisualBellConfig {
@@ -128,6 +149,7 @@ impl Default for VisualBellConfig {
         VisualBellConfig {
             animation: default_visual_bell_animation(),
             duration: default_visual_bell_duration(),
+            effect: default_visual_bell_effect(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,8 +93,14 @@ pub enum VisualBellAnimation {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub enum VisualBellEffect {
     None,
-    FlashText,
-    FlashBackground,
+    FlashText {
+        #[serde(deserialize_with="rgb_from_hex")]
+        color: Rgb
+    },
+    FlashBackground {
+        #[serde(deserialize_with="rgb_from_hex")]
+        color: Rgb
+    },
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -109,8 +109,8 @@ pub struct ShaderProgram {
     /// Cell dimensions (pixels)
     u_cell_dim: GLint,
 
-    /// Visual bell
-    u_visual_bell: GLint,
+    /// Visual bell intensity
+    u_visual_bell_intensity: GLint,
 
     /// Background pass flag
     ///
@@ -906,12 +906,12 @@ impl ShaderProgram {
         }
 
         // get uniform locations
-        let (projection, term_dim, cell_dim, visual_bell, background) = unsafe {
+        let (projection, term_dim, cell_dim, visual_bell_intensity, background) = unsafe {
             (
                 gl::GetUniformLocation(program, cptr!(b"projection\0")),
                 gl::GetUniformLocation(program, cptr!(b"termDim\0")),
                 gl::GetUniformLocation(program, cptr!(b"cellDim\0")),
-                gl::GetUniformLocation(program, cptr!(b"visualBell\0")),
+                gl::GetUniformLocation(program, cptr!(b"visualBellIntensity\0")),
                 gl::GetUniformLocation(program, cptr!(b"backgroundPass\0")),
             )
         };
@@ -923,7 +923,7 @@ impl ShaderProgram {
             u_projection: projection,
             u_term_dim: term_dim,
             u_cell_dim: cell_dim,
-            u_visual_bell: visual_bell,
+            u_visual_bell_intensity: visual_bell_intensity,
             u_background: background,
         };
 
@@ -955,9 +955,9 @@ impl ShaderProgram {
         }
     }
 
-    fn set_visual_bell(&self, visual_bell: f32) {
+    fn set_visual_bell(&self, visual_bell_intensity: f32) {
         unsafe {
-            gl::Uniform1f(self.u_visual_bell, visual_bell);
+            gl::Uniform1f(self.u_visual_bell_intensity, visual_bell_intensity);
         }
     }
 


### PR DESCRIPTION
@jonhoo raised some useful feedback in https://github.com/jwilm/alacritty/issues/406, namely

1. Behaviors like "brighten text", "dim text", etc., would be useful.
2. Colors should be customizable to accommodate different color schemes.
3. Non-flashing behaviors like "pixelate" would be useful.

This PR addresses 1 and 2 by converting VisualBellConfig into an enum representing one of three effects:

  * None: does nothing
  * FlashText: flashes the text a configurable color
  * FlashBackground: flashes the background a configurable color

Example video (warning: flashing lights): https://gfycat.com/IdealLazyDairycow


Other changes:

* Renamed VisualBellAnimation to "VisualBellEasing" and `animation` to `easing`.
* Moved the `cubic_bezier` code to src/config.rs and added an `ease` function to the VisualBellEasing implementation.

The VisualBellConfig enum could be expanded in the future to support a Pixelate option, e.g. something like

```yaml
visual_bell:
  Pixelate:
    size: 24 # px
    duration: 150
```

Or perhaps even a Blur could be supported; however, I think these would require adding a rendering pass, so I haven't implemented these yet.