### PR TITLE
Keep selection mode when holding button and moving mouse

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -65,11 +65,11 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     }
 
     fn clear_selection(&mut self) {
-        self.selection.clear();
+        self.terminal.clear_selection(&mut self.selection);
     }
 
     fn update_selection(&mut self, point: Point, side: Side) {
-        self.selection.update(point, side);
+        self.terminal.update_selection(&mut self.selection, point, side);
     }
 
     fn semantic_selection(&mut self, point: Point) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -232,7 +232,6 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             } else {
                 Side::Left
             };
-            self.ctx.mouse_mut().cell_side = cell_side;
 
             if self.ctx.mouse_mut().left_button_state == ElementState::Pressed {
                 let report_mode = mode::MOUSE_REPORT_CLICK | mode::MOUSE_MOTION;

--- a/src/input.rs
+++ b/src/input.rs
@@ -493,7 +493,7 @@ mod tests {
     use term::{SizeInfo, Term, TermMode, mode};
     use event::{Mouse, ClickState};
     use config::{self, Config, ClickHandler};
-    use selection::Selection;
+    use selection::{Selection, SelectionMode, Span};
     use index::{Point, Side};
 
     use super::{Action, Binding, Processor};
@@ -535,7 +535,7 @@ mod tests {
         fn clear_selection(&mut self) { }
 
         fn update_selection(&mut self, point: Point, side: Side) {
-            self.selection.update(point, side);
+            self.selection.update(Span::new(point, point), side, SelectionMode::Cell);
         }
 
         fn semantic_selection(&mut self, _point: Point) {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -427,4 +427,142 @@ mod test {
             ty: SpanType::ExcludeFront
         });
     }
+
+    /// Test non-cell selection
+    ///
+    /// 1. [  ][  ][  ][  ][  ]
+    ///    [  ][  ][  ][  ][  ]
+    /// 2. [  ][BX][XX][XE][  ]
+    ///    [  ][  ][  ][  ][  ]
+    #[test]
+    fn selection_semantic_mode() {
+        let mut selection = Selection::Empty;
+        let location = Span { front: Point::new(Line(0), Column(1)), tail: Point::new(Line(0), Column(3)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Semantic);
+
+        assert_eq!(selection.span().unwrap(), Span {
+            front: Point::new(Line(0), Column(1)),
+            tail: Point::new(Line(0), Column(3)),
+            ty: SpanType::Inclusive,
+        });
+    }
+
+    /// Test non-cell selection
+    ///
+    /// 1. [  ][  ][  ][  ][  ]
+    ///    [  ][  ][  ][  ][  ]
+    /// 2. [  ][BX][XX][XE][  ]
+    ///    [  ][  ][  ][  ][  ]
+    /// 3. [  ][BX][XX][XE][  ]
+    ///    [BX][XE][  ][  ][  ]
+    /// 4. [  ][BX][XX][XX][XX]
+    ///    [XX][XE][  ][  ][  ]
+    #[test]
+    fn selection_semantic_mode_extend() {
+        let mut selection = Selection::Empty;
+        let location = Span { front: Point::new(Line(0), Column(1)), tail: Point::new(Line(0), Column(3)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Semantic);
+        let location = Span { front: Point::new(Line(1), Column(0)), tail: Point::new(Line(1), Column(1)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Semantic);
+
+        assert_eq!(selection.span().unwrap(), Span {
+            front: Point::new(Line(0), Column(1)),
+            tail: Point::new(Line(1), Column(1)),
+            ty: SpanType::Inclusive,
+        });
+    }
+
+    /// Test non-cell selection
+    ///
+    /// 1. [  ][  ][  ][  ][  ]
+    ///    [  ][  ][  ][  ][  ]
+    /// 2. [  ][  ][  ][  ][  ]
+    ///    [BX][XE][  ][  ][  ]
+    /// 3. [  ][BX][XX][XE][  ]
+    ///    [BX][XE][  ][  ][  ]
+    /// 4. [  ][BX][XX][XX][XX]
+    ///    [XX][XE][  ][  ][  ]
+    #[test]
+    fn selection_semantic_mode_extend_reverse() {
+        let mut selection = Selection::Empty;
+        let location = Span { front: Point::new(Line(1), Column(0)), tail: Point::new(Line(1), Column(1)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Semantic);
+        let location = Span { front: Point::new(Line(0), Column(1)), tail: Point::new(Line(0), Column(3)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Semantic);
+
+        assert_eq!(selection.span().unwrap(), Span {
+            front: Point::new(Line(0), Column(1)),
+            tail: Point::new(Line(1), Column(1)),
+            ty: SpanType::Inclusive,
+        });
+    }
+
+    /// Test non-cell selection
+    ///
+    /// 1. [  ][  ][  ][  ][  ]
+    ///    [  ][  ][  ][  ][  ]
+    /// 2. [BX][XX][XX][XX][XE]
+    ///    [  ][  ][  ][  ][  ]
+    #[test]
+    fn selection_line_mode() {
+        let mut selection = Selection::Empty;
+        let location = Span { front: Point::new(Line(0), Column(0)), tail: Point::new(Line(0), Column(4)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Line);
+
+        assert_eq!(selection.span().unwrap(), Span {
+            front: Point::new(Line(0), Column(0)),
+            tail: Point::new(Line(0), Column(4)),
+            ty: SpanType::Inclusive,
+        });
+    }
+
+    /// Test non-cell selection
+    ///
+    /// 1. [  ][  ][  ][  ][  ]
+    ///    [  ][  ][  ][  ][  ]
+    /// 2. [BX][XX][XX][XX][XE]
+    ///    [  ][  ][  ][  ][  ]
+    /// 3. [BX][XX][XX][XX][XE]
+    ///    [BX][XX][XX][XX][XE]
+    /// 4. [BX][XX][XX][XX][XX]
+    ///    [XX][XX][XX][XX][XE]
+    #[test]
+    fn selection_line_mode_extend() {
+        let mut selection = Selection::Empty;
+        let location = Span { front: Point::new(Line(0), Column(0)), tail: Point::new(Line(0), Column(4)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Line);
+        let location = Span { front: Point::new(Line(1), Column(0)), tail: Point::new(Line(1), Column(4)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Line);
+
+        assert_eq!(selection.span().unwrap(), Span {
+            front: Point::new(Line(0), Column(0)),
+            tail: Point::new(Line(1), Column(4)),
+            ty: SpanType::Inclusive,
+        });
+    }
+
+    /// Test non-cell selection
+    ///
+    /// 1. [  ][  ][  ][  ][  ]
+    ///    [  ][  ][  ][  ][  ]
+    /// 2. [  ][  ][  ][  ][  ]
+    ///    [BX][XX][XX][XX][XE]
+    /// 3. [BX][XX][XX][XX][XE]
+    ///    [BX][XX][XX][XX][XE]
+    /// 4. [BX][XX][XX][XX][XX]
+    ///    [XX][XX][XX][XX][XE]
+    #[test]
+    fn selection_line_mode_extend_reverse() {
+        let mut selection = Selection::Empty;
+        let location = Span { front: Point::new(Line(1), Column(0)), tail: Point::new(Line(1), Column(4)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Line);
+        let location = Span { front: Point::new(Line(0), Column(0)), tail: Point::new(Line(0), Column(4)), ty: SpanType::Inclusive };
+        selection.update(location, Side::Left, SelectionMode::Line);
+
+        assert_eq!(selection.span().unwrap(), Span {
+            front: Point::new(Line(0), Column(0)),
+            tail: Point::new(Line(1), Column(4)),
+            ty: SpanType::Inclusive,
+        });
+    }
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -25,7 +25,7 @@ use unicode_width::UnicodeWidthChar;
 use ansi::{self, Color, NamedColor, Attr, Handler, CharsetIndex, StandardCharset, CursorStyle};
 use grid::{BidirectionalIterator, Grid, ClearRegion, ToRange, Indexed};
 use index::{self, Point, Column, Line, Linear, IndexRange, Contains, RangeInclusive, Side};
-use selection::{Span, Selection};
+use selection::{Span, Selection, SelectionMode};
 use config::{Config, VisualBellAnimation};
 use Rgb;
 
@@ -620,6 +620,8 @@ pub struct Term {
 
     semantic_escape_chars: String,
 
+    selection_mode: SelectionMode,
+
     /// Colors used for rendering
     colors: color::List,
 
@@ -725,6 +727,7 @@ impl Term {
             colors: color::List::from(config.colors()),
             semantic_escape_chars: config.selection().semantic_escape_chars.clone(),
             cursor_style: CursorStyle::Block,
+            selection_mode: SelectionMode::Cell,
         }
     }
 
@@ -739,19 +742,31 @@ impl Term {
         self.dirty
     }
 
-    pub fn line_selection(&self, selection: &mut Selection, point: Point) {
-        selection.clear();
-        selection.update(Point {
-            line: point.line,
-            col: Column(0),
-        }, Side::Left);
-        selection.update(Point {
-            line: point.line,
-            col: self.grid.num_cols() - Column(1),
-        }, Side::Right);
+    pub fn update_selection(&self, selection: &mut Selection, point: Point, side: Side) {
+        match self.selection_mode {
+            SelectionMode::Cell => selection.update(Span::new(point, point), side, SelectionMode::Cell),
+            SelectionMode::Line => selection.update(self.line_span(point), side, SelectionMode::Line),
+            SelectionMode::Semantic => selection.update(self.semantic_span(point), side, SelectionMode::Semantic),
+        };
     }
 
-    pub fn semantic_selection(&self, selection: &mut Selection, point: Point) {
+    fn line_span(&self, point: Point) -> Span {
+        Span::new(Point {
+            line: point.line,
+            col: Column(0)
+        }, Point {
+            line: point.line,
+            col: self.grid.num_cols() - Column(1)
+        })
+    }
+
+    pub fn line_selection(&mut self, selection: &mut Selection, point: Point) {
+        selection.clear();
+        self.selection_mode = SelectionMode::Line;
+        selection.update(self.line_span(point), Side::Left, SelectionMode::Line);
+    }
+
+    fn semantic_span(&self, point: Point) -> Span {
         let mut side_left = Point {
             line: point.line,
             col: point.col
@@ -792,9 +807,18 @@ impl Term {
             }
         }
 
+        Span::new(side_left, side_right)
+    }
+
+    pub fn semantic_selection(&mut self, selection: &mut Selection, point: Point) {
         selection.clear();
-        selection.update(side_left, Side::Left);
-        selection.update(side_right, Side::Right);
+        self.selection_mode = SelectionMode::Semantic;
+        selection.update(self.semantic_span(point), Side::Left, SelectionMode::Semantic);
+    }
+
+    pub fn clear_selection(&mut self, selection: &mut Selection) {
+        self.selection_mode = SelectionMode::Cell;
+        selection.clear();
     }
 
     pub fn string_from_selection(&self, span: &Span) -> String {


### PR DESCRIPTION
There was a bit of talk in #30 about keeping the selection mode when double or triple clicking the mouse button and dragging the selection around, so I had a bit of a try at implementing this.

This is just a rough implementation to get the ball rolling and some more input.

There's one or two more modes, that I'm thinking of implementing, which would require a major rewrite; Column mode and Multiple selections.