### PR TITLE
Add hide cursor when typing option

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -233,6 +233,8 @@ mouse:
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
 
+hide_cursor_when_typing: false
+
 # Shell
 #
 # You can set shell.program to the path of your favorite shell, e.g. /bin/fish.

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -232,6 +232,8 @@ mouse:
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
 
+hide_cursor_when_typing: false
+
 # Shell
 #
 # You can set shell.program to the path of your favorite shell, e.g. /bin/fish.

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,6 +227,10 @@ pub struct Config {
     /// Visual bell configuration
     #[serde(default)]
     visual_bell: VisualBellConfig,
+
+    /// Hide cursor when typing
+    #[serde(default)]
+    hide_cursor_when_typing: bool,
 }
 
 #[cfg(not(target_os="macos"))]
@@ -273,6 +277,7 @@ impl Default for Config {
             config_path: None,
             visual_bell: Default::default(),
             env: Default::default(),
+            hide_cursor_when_typing: Default::default(),
         }
     }
 }
@@ -1006,6 +1011,12 @@ impl Config {
 
     pub fn env(&self) -> &HashMap<String, String> {
         &self.env
+    }
+
+    /// Should hide cursor when typing
+    #[inline]
+    pub fn hide_cursor_when_typing(&self) -> bool {
+        self.hide_cursor_when_typing
     }
 
     fn load_from<P: Into<PathBuf>>(path: P) -> Result<Config> {

--- a/src/display.rs
+++ b/src/display.rs
@@ -231,8 +231,8 @@ impl Display {
         self.tx.clone()
     }
 
-    pub fn window(&self) -> &Window {
-        &self.window
+    pub fn window(&mut self) -> &mut Window {
+        &mut self.window
     }
 
     /// Process pending resize events

--- a/src/event.rs
+++ b/src/event.rs
@@ -261,7 +261,7 @@ impl<N: Notify> Processor<N> {
     pub fn process_events<'a>(
         &mut self,
         term: &'a FairMutex<Term>,
-        window: &Window
+        window: &mut Window
     ) -> MutexGuard<'a, Term> {
         // Terminal is lazily initialized the first time an event is returned
         // from the blocking WaitEventsIterator. Otherwise, the pty reader would

--- a/src/event.rs
+++ b/src/event.rs
@@ -224,6 +224,8 @@ impl<N: Notify> Processor<N> {
                 processor.ctx.terminal.dirty = true;
             },
             glutin::Event::KeyboardInput(state, _code, key, mods, string) => {
+                // Ensure that key event originates from our window. For example using a shortcut
+                // to switch windows could generate a release key event.
                 if state == ElementState::Pressed {
                     *hide_cursor = true;
                 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -224,7 +224,9 @@ impl<N: Notify> Processor<N> {
                 processor.ctx.terminal.dirty = true;
             },
             glutin::Event::KeyboardInput(state, _code, key, mods, string) => {
-                *hide_cursor = true;
+                if state == ElementState::Pressed {
+                    *hide_cursor = true;
+                }
                 processor.process_key(state, key, mods, string);
             },
             glutin::Event::MouseInput(state, button) => {
@@ -251,6 +253,9 @@ impl<N: Notify> Processor<N> {
             glutin::Event::Refresh |
             glutin::Event::Awakened => {
                 processor.ctx.terminal.dirty = true;
+            },
+            glutin::Event::Focused(false) => {
+                *hide_cursor = false;
             },
             _ => (),
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -53,6 +53,7 @@ type Result<T> = ::std::result::Result<T, Error>;
 /// Wraps the underlying windowing library to provide a stable API in Alacritty
 pub struct Window {
     glutin_window: glutin::Window,
+    cursor_visible: bool,
 }
 
 /// Threadsafe APIs for the window
@@ -218,6 +219,7 @@ impl Window {
 
         Ok(Window {
             glutin_window: window,
+            cursor_visible: true,
         })
     }
 
@@ -290,10 +292,12 @@ impl Window {
     }
 
     /// Set cursor visible
-    #[inline]
-    pub fn set_cursor_visible(&self, show: bool) {
-        self.glutin_window.set_cursor(if show { glutin::MouseCursor::Default }
-                                      else { glutin::MouseCursor::NoneCursor });
+    pub fn set_cursor_visible(&mut self, visible: bool) {
+        if visible != self.cursor_visible {
+            self.cursor_visible = visible;
+            self.glutin_window.set_cursor(if visible { glutin::MouseCursor::Default }
+                                          else { glutin::MouseCursor::NoneCursor });
+        }
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -288,6 +288,13 @@ impl Window {
     pub fn set_title(&self, title: &str) {
         self.glutin_window.set_title(title);
     }
+
+    /// Set cursor visible
+    #[inline]
+    pub fn set_cursor_visible(&self, show: bool) {
+        self.glutin_window.set_cursor(if show { glutin::MouseCursor::Default }
+                                      else { glutin::MouseCursor::NoneCursor });
+    }
 }
 
 impl Proxy {


### PR DESCRIPTION
By default the feature is disabled. Should it be? Other terminal emulators, at least on X11, hide the cursor when typing.

Fixes #246