### PR TITLE
Implement OSC command '1' (Set Icon Name)

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -560,6 +560,10 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
                 }
             },
 
+            // Set icon name
+            // This is ignored, since alacritty has no concept of tabs
+            b'1' => return,
+
             // Set color index
             b'4' => {
                 if params.len() < 3 {


### PR DESCRIPTION
Per the [Xterm control sequences](http://www.xfree86.org/4.7.0/ctlseqs.html) documentation, the OSC command '1' is used to set the ['Icon name'](https://unix.stackexchange.com/questions/234136/in-xterm-what-is-icon-name). While it may change the tab name in some terminal emulators, I haven't been able to find a working example yet.

Since alacritty doesn't support tabs anyway, I've made the '1' command set the window title, just as command '2' (Set window title and icon name) does.

For an example of a program which actually uses this command, install [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh), and launch a new `zsh` shell - no further modifications are needed. The command is issued [here](https://github.com/robbyrussell/oh-my-zsh/blob/b908feebcfb0ca8a9a80360d177e716c24c317d6/lib/termsupport.zsh#L22), which is run on every command given to zsh.