### PR TITLE
Enable Shift + Insert to paste

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -167,6 +167,7 @@ key_bindings:
   - { key: C,        mods: Command, action: Copy                         }
   - { key: Q,        mods: Command, action: Quit                         }
   - { key: W,        mods: Command, action: Quit                         }
+  - { key: Insert,   mods: Shift,   action: PasteSelection               }
   - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }
   - { key: Home,                    chars: "\x1b[1~",  mode: ~AppCursor  }
   - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }


### PR DESCRIPTION
Shift + Insert is a default bind to paste selection.

I don't know if this is used on Mac, so I didn't change it.