### PR TITLE
Possible more-efficient direction for font fallback

### DIFF
--- a/font/src/ft/list_fonts.rs
+++ b/font/src/ft/list_fonts.rs
@@ -102,13 +102,11 @@ pub mod fc {
             // return type.
             let mut result = FcResultNoMatch;
 
-            let mut charsets: *mut FcCharSet = ptr::null_mut();
-
             let ptr = FcFontSort(
                 config.as_ptr(),
                 pattern.as_ptr(),
-                0, // false
-                &mut charsets,
+                1, // true
+                ptr::null_mut(), // charsets
                 &mut result,
             );
 

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -82,6 +82,7 @@ impl ::Rasterize for FreeTypeRasterizer {
                 let face = self.get_face(desc)?;
                 let key = FontKey::next();
                 self.faces.insert(key, face);
+                self.keys.insert(desc.to_owned(), key);
                 Ok(key)
             })
     }

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -238,3 +238,23 @@ pub trait Rasterize {
     /// Rasterize the glyph described by `GlyphKey`.
     fn get_glyph(&mut self, &GlyphKey) -> Result<RasterizedGlyph, Self::Err>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_font() {
+        let mut rasterizer = Rasterizer::new(96.0, 96.0, 1.0, false).unwrap();
+        let style = Style::Description {
+            slant: Slant::Normal,
+            weight: Weight::Normal,
+        };
+        let desc = FontDesc::new("monospace", style);
+        let size = Size::new(12.0);
+
+        let key1 = rasterizer.load_font(&desc, size).unwrap();
+        let key2 = rasterizer.load_font(&desc, size).unwrap();
+        assert!(key1 == key2);
+    }
+}


### PR DESCRIPTION
I started playing around with Alacritty a few weeks ago and decided to poke
around with font-fallback as a way to learn a little Rust.
I got things working a bit and before kicking off this pull request fetched the
latest changes from upstream.  Lo and behold, there's already work going on in
master, really cool!

Comparing the two approaches, I think there will probably be some benefit in
combining them.  This branch stores `CharSet` data from the single, original
`font_sort()` and uses it to more-rapidly search for a suitable font-face
whenever an as-of-yet unhandled character is discovered.

I believe the master's current approach (creating a `CharSet` with the new
character and conducting a new `font_match()`) may be a better way to handle the
case where the original search turned up no faces with glyphs for the character.
This branch just punts and gives the "main" face to FreeType to render the
dreaded "missing-character-rectangle" glyph.
(I haven't explicitly tested combining the two, it's possible that the searches
done by master's technique are only yielding faces that this branch is already
testing and no further searches are beneficial.)

I'm certainly enjoying Rust and this is a cool project!