### PR TITLE
Handle CSI command J3 (Clear saved lines)

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -330,6 +330,8 @@ pub enum ClearMode {
     Above,
     /// Clear entire terminal
     All,
+    /// Clear 'saved' lines (scrollback)
+    Saved
 }
 
 /// Mode for clearing tab stops
@@ -709,6 +711,7 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
                     0 => ClearMode::Below,
                     1 => ClearMode::Above,
                     2 => ClearMode::All,
+                    3 => ClearMode::Saved,
                     _ => unhandled!(),
                 };
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1443,7 +1443,9 @@ impl ansi::Handler for Term {
                 for cell in &mut self.grid[self.cursor.point.line][..self.cursor.point.col] {
                     cell.reset(&template);
                 }
-            }
+            },
+            // If scrollback is implemented, this should clear it
+            ansi::ClearMode::Saved => return
         }
     }
 


### PR DESCRIPTION
Xterm supports an extension to the CSI command [Erase in Display (ED)](http://www.xfree86.org/4.7.0/ctlseqs.html), under the command number 3. This command is used to clear the scrollback buffer - e.g. anything not visible on the screen.

Since scrollback [may not be added](https://github.com/jwilm/alacritty/issues/124) to alacritty, I've made the handler for this command do nothing. If at some point scrollback is implemented, the corresponding `match` arm can be modified to properly handle this.

For an example of a program which uses this command, run the `clear` command (using ncurses 6.0). In a supported terminal such as `gnome-terminal`, this will clear anything off of the screen from the scrollback buffer. In the current alacritty `master`, this will generate an `Unhandled CSI` message.