### PR TITLE
Fix hang on exit after child process failed

### DIFF
--- a/src/tty.rs
+++ b/src/tty.rs
@@ -21,7 +21,7 @@ use std::os::unix::process::CommandExt;
 use std::ptr;
 use std::process::{Command, Stdio};
 
-use libc::{self, winsize, c_int, pid_t, WNOHANG, WIFEXITED, WEXITSTATUS, SIGCHLD, TIOCSCTTY};
+use libc::{self, winsize, c_int, pid_t, WNOHANG, SIGCHLD, TIOCSCTTY};
 
 use term::SizeInfo;
 use display::OnResize;
@@ -48,15 +48,9 @@ extern "C" fn sigchld(_a: c_int) {
             die!("Waiting for pid {} failed: {}\n", PID, errno());
         }
 
-        if PID != p {
-            return;
+        if PID == p {
+            SHOULD_EXIT = true;
         }
-
-        if !WIFEXITED(status) || WEXITSTATUS(status) != 0 {
-            die!("child finished with error '{}'\n", status);
-        }
-
-        SHOULD_EXIT = true;
     }
 }
 


### PR DESCRIPTION
Quick test (works ~50%) is to press Ctrl+C followed by Ctrl+D.

Reproducible on Arch Linux with OpenGL from NVidia.

Fixes #228 

**NOTE:** I'm not sure what the original code tried to solve but AFAIK terminal emulators exit with code 0 even if last child process exit code is non-zero (or is terminated).

Call stack when the app hangs:

```
__GI___sched_yield (__GI___sched_yield @7f4ac603a700:5)
___lldb_unnamed_symbol1397$$libGLX_nvidia.so.0 (___lldb_unnamed_symbol1397$$libGLX_nvidia.so.0 @7f4ac1c10950:8)
___lldb_unnamed_symbol36172$$libnvidia-glcore.so.378.13 (___lldb_unnamed_symbol36172$$libnvidia-glcore.so.378.13 @7f4ac092c710:80)
___lldb_unnamed_symbol899$$libGLX_nvidia.so.0 (___lldb_unnamed_symbol899$$libGLX_nvidia.so.0 @7f4ac1be7bd0:45)
___lldb_unnamed_symbol929$$libGLX_nvidia.so.0 (___lldb_unnamed_symbol929$$libGLX_nvidia.so.0 @7f4ac1beb6e0:244)
___lldb_unnamed_symbol1662$$libGLX_nvidia.so.0 (___lldb_unnamed_symbol1662$$libGLX_nvidia.so.0 @7f4ac1c5c000:112)
_dl_fini (_dl_fini @7f4ac705a750:128)
__run_exit_handlers (__run_exit_handlers @7f4ac5f9c5d0:70)
__GI_exit (@7f4ac5f9c71a:3)
std::sys::imp::os::exit (/build/rust/src/rustc-1.15.1-src/src/libstd/sys/unix/os.rs:526)
std::process::exit (/build/rust/src/rustc-1.15.1-src/src/libstd/process.rs:858)
alacritty::tty::sigchld (/home/lukas/apps/alacritty/src/tty.rs:56)
___lldb_unnamed_symbol1$$libc.so.6 (__restore_rt @7f4ac5f99a90:3)
__GI___poll (__GI___poll @7f4ac6048650:15)
___lldb_unnamed_symbol4$$libxcb.so.1 (___lldb_unnamed_symbol4$$libxcb.so.1 @7f4ac388c840:39)
xcb_wait_for_event (xcb_wait_for_event @7f4ac388e630:28)
_XReadEvents (_XReadEvents @7f4ac3aeb070:88)
XPeekEvent (XPeekEvent @7f4ac3adc9c0:57)
glutin::api::x11::window::{{impl}}::next (/home/lukas/.cargo/git/checkouts/glutin-2b5ecc80feb2e4c5/cc64178/src/api/x11/window.rs:297)
glutin::platform::platform::api_dispatch::{{impl}}::next (/home/lukas/.cargo/git/checkouts/glutin-2b5ecc80feb2e4c5/cc64178/src/platform/linux/api_dispatch.rs:169)
```
