### PR TITLE
Fix reading output when all child processes exited

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -253,6 +253,10 @@ impl<Io> EventLoop<Io>
                     }
                 }
             }
+
+            if ::tty::process_should_exit() {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Reproducible with e.g. `alacritty -e ls` (app panics when reading
output).

Hopefully this won't break #14.