### PR TITLE
Add dim color support

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -103,6 +103,17 @@ colors:
     magenta: '0xb77ee0'
     cyan:    '0x54ced6'
     white:   '0x2a2a2a'
+  
+  # Dim colors
+  dim:
+    black:   '0x333333'
+    red:     '0xf2777a'
+    green:   '0x99cc99'
+    yellow:  '0xffcc66'
+    blue:    '0x6699cc'
+    magenta: '0xcc99cc'
+    cyan:    '0x66cccc'
+    white:   '0xdddddd'
 
 # Visual Bell
 #

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -102,6 +102,17 @@ colors:
     magenta: '0xb77ee0'
     cyan:    '0x54ced6'
     white:   '0x2a2a2a'
+  
+  # Dim colors
+  dim:
+    black:   '0x333333'
+    red:     '0xf2777a'
+    green:   '0x99cc99'
+    yellow:  '0xffcc66'
+    blue:    '0x6699cc'
+    magenta: '0xcc99cc'
+    cyan:    '0x66cccc'
+    white:   '0xdddddd'
 
 # Visual Bell
 #

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -389,6 +389,22 @@ pub enum NamedColor {
     CursorText,
     /// Color for the cursor itself
     Cursor,
+    /// Dim black
+    DimBlack,
+    /// Dim red
+    DimRed,
+    /// Dim green
+    DimGreen,
+    /// Dim yellow
+    DimYellow,
+    /// Dim blue
+    DimBlue,
+    /// Dim magenta
+    DimMagenta,
+    /// Dim cyan
+    DimCyan,
+    /// Dim white
+    DimWhite,
 }
 
 impl NamedColor {
@@ -402,6 +418,35 @@ impl NamedColor {
             NamedColor::Magenta => NamedColor::BrightMagenta,
             NamedColor::Cyan => NamedColor::BrightCyan,
             NamedColor::White => NamedColor::BrightWhite,
+            NamedColor::DimBlack => NamedColor::Black,
+            NamedColor::DimRed => NamedColor::Red,
+            NamedColor::DimGreen => NamedColor::Green,
+            NamedColor::DimYellow => NamedColor::Yellow,
+            NamedColor::DimBlue => NamedColor::Blue,
+            NamedColor::DimMagenta => NamedColor::Magenta,
+            NamedColor::DimCyan => NamedColor::Cyan,
+            NamedColor::DimWhite => NamedColor::White,
+            val => val
+        }
+    }
+    pub fn to_dim(&self) -> Self {
+        match *self {
+            NamedColor::Black => NamedColor::DimBlack,
+            NamedColor::Red => NamedColor::DimRed,
+            NamedColor::Green => NamedColor::DimGreen,
+            NamedColor::Yellow => NamedColor::DimYellow,
+            NamedColor::Blue => NamedColor::DimBlue,
+            NamedColor::Magenta => NamedColor::DimMagenta,
+            NamedColor::Cyan => NamedColor::DimCyan,
+            NamedColor::White => NamedColor::DimWhite,
+            NamedColor::BrightBlack => NamedColor::Black,
+            NamedColor::BrightRed => NamedColor::Red,
+            NamedColor::BrightGreen => NamedColor::Green,
+            NamedColor::BrightYellow => NamedColor::Yellow,
+            NamedColor::BrightBlue => NamedColor::Blue,
+            NamedColor::BrightMagenta => NamedColor::Magenta,
+            NamedColor::BrightCyan => NamedColor::Cyan,
+            NamedColor::BrightWhite => NamedColor::White,
             val => val
         }
     }
@@ -411,7 +456,7 @@ impl NamedColor {
 pub enum Color {
     Named(NamedColor),
     Spec(Rgb),
-    Indexed(u8),
+    Indexed(usize),
 }
 
 /// Terminal character attributes
@@ -953,7 +998,7 @@ fn parse_color(attrs: &[i64], i: &mut usize) -> Option<Color> {
                 let idx = attrs[*i];
                 match idx {
                     0 ... 255 => {
-                        Some(Color::Indexed(idx as u8))
+                        Some(Color::Indexed(idx as usize))
                     },
                     _ => {
                         warn!("Invalid color index: {}", idx);

--- a/src/term/cell.rs
+++ b/src/term/cell.rs
@@ -25,6 +25,7 @@ bitflags! {
         const WRAPLINE          = 0b00010000,
         const WIDE_CHAR         = 0b00100000,
         const WIDE_CHAR_SPACER  = 0b01000000,
+        const DIM               = 0b10000000,
     }
 }
 
@@ -75,6 +76,10 @@ impl LineLength for grid::Row<Cell> {
 impl Cell {
     pub fn bold(&self) -> bool {
         self.flags.contains(BOLD)
+    }
+
+    pub fn dim(&self) -> bool {
+        self.flags.contains(DIM)
     }
 
     pub fn new(c: char, fg: Color, bg: Color) -> Cell {

--- a/src/term/color.rs
+++ b/src/term/color.rs
@@ -7,11 +7,11 @@ use config::Colors;
 /// List of indexed colors
 ///
 /// The first 16 entries are the standard ansi named colors. Items 16..232 are
-/// the color cube.  Items 233..256 are the grayscale ramp. Finally, item 256 is
+/// the color cube.  Items 233..256 are the grayscale ramp. Item 256 is
 /// the configured foreground color, item 257 is the configured background
 /// color, item 258 is the cursor foreground color, item 259 is the cursor
-/// background color.
-pub struct List([Rgb; 260]);
+/// background color. 260-267 are dim versons of the ansi colors (2/3 or custom).
+pub struct List([Rgb; 268]);
 
 impl<'a> From<&'a Colors> for List {
     fn from(colors: &Colors) -> List {
@@ -47,6 +47,30 @@ impl List {
         self[ansi::NamedColor::BrightMagenta] = colors.bright.magenta;
         self[ansi::NamedColor::BrightCyan]    = colors.bright.cyan;
         self[ansi::NamedColor::BrightWhite]   = colors.bright.white;
+
+        // Dims
+        match colors.dim {
+            Some(ref dim_colors) => {
+                self[ansi::NamedColor::DimBlack]   = dim_colors.black;
+                self[ansi::NamedColor::DimRed]     = dim_colors.red;
+                self[ansi::NamedColor::DimGreen]   = dim_colors.green;
+                self[ansi::NamedColor::DimYellow]  = dim_colors.yellow;
+                self[ansi::NamedColor::DimBlue]    = dim_colors.blue;
+                self[ansi::NamedColor::DimMagenta] = dim_colors.magenta;
+                self[ansi::NamedColor::DimCyan]    = dim_colors.cyan;
+                self[ansi::NamedColor::DimWhite]   = dim_colors.white;
+            }
+            None => {
+                self[ansi::NamedColor::DimBlack]   = colors.normal.black   * 0.66;
+                self[ansi::NamedColor::DimRed]     = colors.normal.red     * 0.66;
+                self[ansi::NamedColor::DimGreen]   = colors.normal.green   * 0.66;
+                self[ansi::NamedColor::DimYellow]  = colors.normal.yellow  * 0.66;
+                self[ansi::NamedColor::DimBlue]    = colors.normal.blue    * 0.66;
+                self[ansi::NamedColor::DimMagenta] = colors.normal.magenta * 0.66;
+                self[ansi::NamedColor::DimCyan]    = colors.normal.cyan    * 0.66;
+                self[ansi::NamedColor::DimWhite]   = colors.normal.white   * 0.66;
+            }
+        }
 
         // Foreground and background
         self[ansi::NamedColor::Foreground] = colors.primary.foreground;

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -204,18 +204,27 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                 let fg = match *fg {
                     Color::Spec(rgb) => rgb,
                     Color::Named(ansi) => {
+                        let mut ansi_mod = ansi;
                         if self.config.draw_bold_text_with_bright_colors() && cell.bold() {
-                            self.colors[ansi.to_bright()]
-                        } else {
-                            self.colors[ansi]
+                            ansi_mod = ansi_mod.to_bright();
                         }
+
+                        if cell.dim() {
+                            ansi_mod = ansi_mod.to_dim();
+                        }
+                        self.colors[ansi_mod]
                     },
                     Color::Indexed(idx) => {
                         let idx = if self.config.draw_bold_text_with_bright_colors()
                             && cell.bold()
                             && idx < 8
+                            && !cell.dim()
                         {
                             idx + 8
+                        } else if cell.dim() && idx >= 8 && idx < 16 {
+                            idx - 8
+                        } else if cell.dim() && idx < 8 {
+                            idx + 260
                         } else {
                             idx
                         };
@@ -1485,7 +1494,8 @@ impl ansi::Handler for Term {
             Attr::Reverse => self.cursor.template.flags.insert(cell::INVERSE),
             Attr::CancelReverse => self.cursor.template.flags.remove(cell::INVERSE),
             Attr::Bold => self.cursor.template.flags.insert(cell::BOLD),
-            Attr::CancelBoldDim => self.cursor.template.flags.remove(cell::BOLD),
+            Attr::Dim => self.cursor.template.flags.insert(cell::DIM),
+            Attr::CancelBoldDim => self.cursor.template.flags.remove(cell::BOLD | cell::DIM),
             Attr::Italic => self.cursor.template.flags.insert(cell::ITALIC),
             Attr::CancelItalic => self.cursor.template.flags.remove(cell::ITALIC),
             Attr::Underscore => self.cursor.template.flags.insert(cell::UNDERLINE),


### PR DESCRIPTION
Add support for the VTE 'dim' flag, with additional support for
custom-themed dim colors. If no color is specified in the config,
it will default to 2/3 the previous (not a spec, but the value
other terminals seem to use). 

The actual dimming behavior brings bright colors to normal and
regular colors to the new dim ones. Custom RGB values are not
changed, nor are non-named indexed colors.

Old behavior:
![Old Behavior](https://i.imgur.com/CYwY4Nr.png)

New behavior:
![New Defaults](https://i.imgur.com/JKwdnao.png)

New behavior with (odd-looking) custom colors:
![New w/ Custom Colors](https://i.imgur.com/ngKLRH9.png)

The colors from the config file are roughly Tomorrow Night Eighties.