### PR TITLE
Revert "Update cell to cursor template when adding a tab."

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1143,7 +1143,7 @@ impl ansi::Handler for Term {
 
         // Cells were just moved out towards the end of the line; fill in
         // between source and dest with blanks.
-        let template = self.cursor.template;
+        let template = self.empty_cell;
         for c in &mut line[source..destination] {
             c.reset(&template);
         }
@@ -1202,9 +1202,6 @@ impl ansi::Handler for Term {
                 if (col + 1) == self.grid.num_cols() || self.tabs[*col as usize] {
                     break;
                 }
-
-                self.insert_blank(Column(1));
-
                 col += 1;
             }
         }


### PR DESCRIPTION
Reverted commit introduced a regression that caused `htop` to have
~broken display (misplaced/missing characters).

Fixes #493.

This reverts commit 96a1503040787006a45a69dc55916d983d96421e.