### PR TITLE
Fix the ability to pin the app to the dock

### DIFF
--- a/assets/osx/Alacritty.app/Contents/Info.plist
+++ b/assets/osx/Alacritty.app/Contents/Info.plist
@@ -6,8 +6,8 @@
     <string>Alacritty</string>
     <key>CFBundleExecutable</key>
     <string>launcher</string>
-    <!-- <key>CFBundleIdentifier</key> -->
-    <!-- <string>alacritty</string> -->
+    <key>CFBundleIdentifier</key>
+    <string>io.github.jwilm.alacritty</string>
     <key>CFBundleName</key>
     <string>Alacritty</string>
     <key>CFBundleIconFile</key>


### PR DESCRIPTION
After installing Alacritty, I found I couldn't pin the application to the dock (in mac os) for easy launching. This change fixes that.

According to the Apple documentation, this property is an identifier in reverse domain form, similar to Java package namespaces.

https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102070