### PR TITLE
Do not replace $SHELL with --command option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ pub struct Options {
     pub dimensions: Option<Dimensions>,
     pub title: String,
     pub log_level: log::LogLevelFilter,
-    pub shell: Option<Shell<'static>>,
+    pub command: Option<Shell<'static>>,
 }
 
 impl Default for Options {
@@ -36,7 +36,7 @@ impl Default for Options {
             dimensions: None,
             title: DEFAULT_TITLE.to_owned(),
             log_level: log::LogLevelFilter::Warn,
-            shell: None,
+            command: None,
         }
     }
 }
@@ -123,7 +123,7 @@ impl Options {
             // Arg::min_values(1) is set.
             let command = String::from(args.next().unwrap());
             let args = args.map(String::from).collect();
-            options.shell = Some(Shell::new_with_args(command, args));
+            options.command = Some(Shell::new_with_args(command, args));
         }
 
         options
@@ -133,7 +133,7 @@ impl Options {
         self.dimensions
     }
 
-    pub fn shell(&self) -> Option<&Shell> {
-        self.shell.as_ref()
+    pub fn command(&self) -> Option<&Shell> {
+        self.command.as_ref()
     }
 }

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -188,12 +188,13 @@ pub fn new<T: ToWinsize>(config: &Config, options: &Options, size: T) -> Pty {
     let (master, slave) = openpty(win.ws_row as _, win.ws_col as _);
 
     let default_shell = &Shell::new(pw.shell);
-    let shell = options.shell()
-        .or_else(|| config.shell())
+    let shell = config.shell()
         .unwrap_or(&default_shell);
 
-    let mut builder = Command::new(shell.program());
-    for arg in shell.args() {
+    let initial_command = options.command().unwrap_or(&shell);
+
+    let mut builder = Command::new(initial_command.program());
+    for arg in initial_command.args() {
         builder.arg(arg);
     }
 


### PR DESCRIPTION
Fixes #501

Continue to allow user to override default shell in yaml config, but `--command` option is not guaranteed to be a shell command, and should not override `$SHELL`.