### PR TITLE
use xxhash for faster glyph caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,6 @@ dependencies = [
  "clippy 0.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "copypasta 0.0.1",
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "font 0.1.0",
  "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.6.1 (git+https://github.com/jwilm/glutin?rev=cc64178d39a1fa06b2c5403117e5e0ef24deeac4)",
@@ -22,6 +21,7 @@ dependencies = [
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twox-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vte 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -272,11 +272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "font"
@@ -1027,6 +1022,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,7 +1223,6 @@ dependencies = [
 "checksum euclid 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7b555729225fcc2aabc1ac951f9346967b35c901f4f03a480c31b6a45824109"
 "checksum expat-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cef36cd1a8a02d28b91d97347c63247b9e4cb8a8e36df36f8201dc87a1c0859c"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
-"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum freetype-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8c93a141b156862ab58d0206fa44a9b20d899c86c3e6260017ab748029aa42"
 "checksum freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccfb6d96cac99921f0c2142a91765f6c219868a2c45bdfe7d65a08775f18127"
 "checksum fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcd414e5a1a979b931bb92f41b7a54106d3f6d2e6c253e9ce943b7cd468251ef"
@@ -1307,6 +1309,7 @@ dependencies = [
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0590d72182e50e879c4da3b11c6488dae18fccb1ae0c7a3eda18e16795844796"
+"checksum twox-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6270b5a975962209c151051229cdc11a77cea5a431fa65e3e21d24a74e5bef14"
 "checksum unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5e94e9f6961090fcc75180629c4ef33e5310d6ed2c0dd173f4ca63c9043b669e"
 "checksum unicode-segmentation 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7baebdc1df1363fa66161fca2fe047e4f4209011cc7e045948298996afdf85df"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ copypasta = { path = "./copypasta" }
 xdg = "2.0.0"
 log = "0.3"
 clap = "2.20"
-fnv = "1.0.5"
+twox-hash = "1.0.1"
 unicode-width = "0.1.4"
 
 clippy = { version = "0.0.104", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 extern crate cgmath;
 extern crate copypasta;
 extern crate errno;
-extern crate fnv;
+extern crate twox_hash;
 extern crate font;
 extern crate glutin;
 extern crate libc;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -21,7 +21,7 @@ use std::ptr;
 use std::sync::mpsc;
 
 use cgmath;
-use fnv::FnvHasher;
+use twox_hash::XxHash;
 use font::{self, Rasterizer, Rasterize, RasterizedGlyph, FontDesc, GlyphKey, FontKey};
 use gl::types::*;
 use gl;
@@ -138,7 +138,7 @@ pub struct Glyph {
 /// representations of the same code point.
 pub struct GlyphCache {
     /// Cache of buffered glyphs
-    cache: HashMap<GlyphKey, Glyph, BuildHasherDefault<FnvHasher>>,
+    cache: HashMap<GlyphKey, Glyph, BuildHasherDefault<XxHash>>,
 
     /// Rasterizer for loading new glyphs
     rasterizer: Rasterizer,


### PR DESCRIPTION
[twox-hash](https://libraries.io/cargo/twox-hash) is a rust implementation of the [xxhash](https://github.com/Cyan4973/xxHash) algorithm.
>xxHash is an Extremely fast Hash algorithm, running at RAM speed limits. It successfully completes the SMHasher test suite which evaluates collision, dispersion and randomness qualities of hash functions. Code is highly portable, and hashes are identical on all platforms (little / big endian).

When doing my `base64 /dev/urandom` test tonight I found a good chunk of time was spent in the fnv hasher inside GlyphCache. I researched hashing algorithms available in rust and thought xxhash would be be a good fit. 
# Before FNV
<img width="874" alt="screen shot 2017-04-14 at 10 35 32 pm" src="https://cloud.githubusercontent.com/assets/177491/25060139/1f921372-2164-11e7-8c47-79c902bdf2b7.png">

# After XXHASH
<img width="863" alt="screen shot 2017-04-14 at 10 37 23 pm" src="https://cloud.githubusercontent.com/assets/177491/25060141/29b583d4-2164-11e7-9f94-c727a4e8ef6c.png">

# Summary
Both benchmarks ran for about two seconds of base64 output. Fnv hashing was about 25% of the weight in the first run. XXhash was about 5.9% of the second run. Seems like an easy win.
