### PR TITLE
Adding snapcraft.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@ FlameGraph
 
 # other ignores
 *.DS_Store
+=======
+
+# Snapcraft files
+stage
+prime
+parts
+*.snap
+*.pyc
+alacritty_*_source.tar.bz2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: alacritty # you probably want to 'snapcraft register <name>'
+version: '0.1.0' # just for humans, typically '1.2+git' or '1.3.2'
+summary: Modern, GPU accelerated terminal emulator # 79 char long summary
+description: |
+  Modern, GPU accelerated terminal emulator
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: classic # use 'strict' once you have the right plugs and slots
+parts:
+  alacritty:
+    plugin: rust
+    source: .
+    stage-packages: [xclip]
+    build-packages: [libfreetype6-dev, libfontconfig1-dev, cmake]
+  desktop:
+    plugin: dump
+    source: .
+    stage:
+      - Alacritty.desktop
+apps:
+  alacritty:
+    command: env XDG_RUNTIME_DIR= XDG_CONFIG_HOME=$SNAP_USER_DATA XDG_DATA_DIRS=$SNAP_DATA PATH=$SNAP/bin:$PATH alacritty
+    desktop: Alacritty.desktop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,5 +18,5 @@ parts:
       - Alacritty.desktop
 apps:
   alacritty:
-    command: env XDG_RUNTIME_DIR= XDG_CONFIG_HOME=$SNAP_USER_DATA XDG_DATA_DIRS=$SNAP_DATA PATH=$SNAP/bin:$PATH alacritty
+    command: env XDG_RUNTIME_DIR= XDG_CONFIG_HOME=$SNAP_USER_DATA XDG_DATA_DIRS=$SNAP_DATA PATH=$SNAP/bin:$PATH SNAP= alacritty
     desktop: Alacritty.desktop


### PR DESCRIPTION
[Snapcraft](https://snapcraft.io/) makes Linux packaging very simple in a cross-distro
way. This adds the snapcraft.yaml file to setup a snap of
alacritty.