### PR TITLE
Fix typo in Alacritty.desktop

### DIFF
--- a/Alacritty.desktop
+++ b/Alacritty.desktop
@@ -4,7 +4,7 @@ TryExec=alacritty
 Exec=alacritty
 Icon=utilities-terminal
 Terminal=false
-Catagories=System;TerminalEmulator
+Categories=System;TerminalEmulator
 
 Name=Alacritty
 GenericName=Terminal


### PR DESCRIPTION
Desktop entry wouldn't show up in menus, so I looked through a file in search of any errors. Now everything shows up correctly.