### PR TITLE
Treat white and bright black as grays

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -101,18 +101,18 @@ colors:
     blue:    '0x7aa6da'
     magenta: '0xc397d8'
     cyan:    '0x70c0ba'
-    white:   '0x424242'
+    white:   '0xc7c7c7'
 
   # Bright colors
   bright:
-    black:   '0x666666'
+    black:   '0x686868'
     red:     '0xff3334'
     green:   '0x9ec400'
     yellow:  '0xe7c547'
     blue:    '0x7aa6da'
     magenta: '0xb77ee0'
     cyan:    '0x54ced6'
-    white:   '0x2a2a2a'
+    white:   '0xffffff'
 
 # Visual Bell
 #

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -100,18 +100,18 @@ colors:
     blue:    '0x7aa6da'
     magenta: '0xc397d8'
     cyan:    '0x70c0ba'
-    white:   '0x424242'
+    white:   '0xc7c7c7'
 
   # Bright colors
   bright:
-    black:   '0x666666'
+    black:   '0x686868'
     red:     '0xff3334'
     green:   '0x9ec400'
     yellow:  '0xe7c547'
     blue:    '0x7aa6da'
     magenta: '0xb77ee0'
     cyan:    '0x54ced6'
-    white:   '0x2a2a2a'
+    white:   '0xffffff'
 
 # Visual Bell
 #

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -395,8 +395,14 @@ pub enum NamedColor {
     /// Cyan
     Cyan,
     /// White
+    ///
+    /// Note that in terminal color schemes White is often used to represent a
+    /// light gray color while BrightWhite is used for true white.
     White,
     /// Bright black
+    ///
+    /// Note that in terminal color schemes BrightBlack is often used to
+    /// represent a dark gray color while Black is used for true black.
     BrightBlack,
     /// Bright red
     BrightRed,


### PR DESCRIPTION
See #503 for background, but this starts treating white as a light gray
and bright black as a light gray. This is a commonly found idiom and
makes programs that use gray more readable.

I took the new prooposed colors from the default iTerm2 color scheme.

Fixes #503.