### PR TITLE
Optimize OSX glyph_offset for Menlo

### DIFF
--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -63,9 +63,10 @@ font:
   # Glyph offset determines the locations of the glyphs within their cells with
   # the default being at the bottom. Increase the x offset to move the glyph to
   # the right, increase the y offset to move the glyph upward.
+  # NOTE: This is optimized for Menlo
   glyph_offset:
-    x: 0.0
-    y: 0.0
+    x: -0.5
+    y: 2.0
 
   # OS X only: use thin stroke font rendering. Thin strokes are suitable
   # for retina displays, but for non-retina you probably want this set to


### PR DESCRIPTION
I've optimized the glyph offset on Mac OSX for Menlo.
![Glyph Offset](https://cldup.com/4wEZUsPLcW.png)