### PR TITLE
Fix Device Status reports

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -129,7 +129,7 @@ pub trait Handler {
     fn identify_terminal<W: io::Write>(&mut self, &mut W) {}
 
     // Report device status
-    fn device_status<W: io::Write>(&mut self, &mut W) {}
+    fn device_status<W: io::Write>(&mut self, &mut W, usize) {}
 
     /// Move cursor forward `cols`
     fn move_forward(&mut self, Column) {}
@@ -874,7 +874,7 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
                     i += 1; // C-for expr
                 }
             }
-            'n' => handler.device_status(writer),
+            'n' => handler.device_status(writer, arg_or_default!(idx: 0, default: 0) as usize),
             'r' => {
                 if private {
                     unhandled!();

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1240,8 +1240,18 @@ impl ansi::Handler for Term {
     }
 
     #[inline]
-    fn device_status<W: io::Write>(&mut self, writer: &mut W) {
-        let _ = writer.write_all(b"\x1b0n");
+    fn device_status<W: io::Write>(&mut self, writer: &mut W, arg: usize) {
+        trace!("device status: {}", arg);
+        match arg {
+            5 => {
+                let _ = writer.write_all(b"\x1b[0n");
+            },
+            6 => {
+                let pos = self.cursor.point;
+                let _ = write!(writer, "\x1b[{};{}R", pos.line + 1, pos.col + 1);
+            },
+            _ => debug!("unknown device status query: {}", arg),
+        };
     }
 
     #[inline]


### PR DESCRIPTION
Followup to #549. Status report was lacking `[` (it wasn't CSI). Additionally, when asked for cursor position (both queries end with `n`), we were responding with device status. Now it's implemented properly - it passes vttest's DSR test and behaves like other terminal emulators I use.