### PR TITLE
Add Ctrl+PageUp and Ctrl+PageDown to default key bindings

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -189,7 +189,9 @@ key_bindings:
   - { key: Home,                    chars: "\x1b[1~",  mode: ~AppCursor  }
   - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }
   - { key: End,                     chars: "\x1b[4~",  mode: ~AppCursor  }
+  - { key: PageUp,   mods: Control, chars: "\x1b[5;5~"                   }
   - { key: PageUp,                  chars: "\x1b[5~"                     }
+  - { key: PageDown, mods: Control, chars: "\x1b[6;5~"                   }
   - { key: PageDown,                chars: "\x1b[6~"                     }
   - { key: Left,     mods: Shift,   chars: "\x1b[1;2D"                   }
   - { key: Left,     mods: Control, chars: "\x1b[1;5D"                   }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -183,7 +183,9 @@ key_bindings:
   - { key: Home,                    chars: "\x1b[1~",  mode: ~AppCursor  }
   - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }
   - { key: End,                     chars: "\x1b[4~",  mode: ~AppCursor  }
+  - { key: PageUp,   mods: Control, chars: "\x1b[5;5~"                   }
   - { key: PageUp,                  chars: "\x1b[5~"                     }
+  - { key: PageDown, mods: Control, chars: "\x1b[6;5~"                   }
   - { key: PageDown,                chars: "\x1b[6~"                     }
   - { key: Left,     mods: Shift,   chars: "\x1b[1;2D"                   }
   - { key: Left,     mods: Control, chars: "\x1b[1;5D"                   }


### PR DESCRIPTION
I was comparing the output of `showkey -a` with the sakura terminal and I noticed that Alacritty does not react on <kbd>Ctrl+PageUp</kbd> and <kbd>Ctrl+PageDown</kbd>. I personally use these keys in vim, I'm adding them to the default config because think I'm not the only one 🙂 

I also added them to macos config, although I didn't test on Mac.