### PR TITLE
Anti-alias controlled by `use_anti_alias` boolean flag

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -80,6 +80,8 @@ font:
   # false.
   use_thin_strokes: true
 
+  use_anti_alias: true
+
 # Should display the render timer
 render_timer: false
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -79,6 +79,8 @@ font:
   # false.
   use_thin_strokes: true
 
+  use_anti_alias: true
+
 # Should display the render timer
 render_timer: false
 

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -228,7 +228,7 @@ pub trait Rasterize {
     type Err: ::std::error::Error + Send + Sync + 'static;
 
     /// Create a new Rasterize
-    fn new(dpi_x: f32, dpi_y: f32, device_pixel_ratio: f32, use_thin_strokes: bool) -> Result<Self, Self::Err>
+    fn new(dpi_x: f32, dpi_y: f32, device_pixel_ratio: f32, use_thin_strokes: bool, use_anti_alias: bool) -> Result<Self, Self::Err>
         where Self: Sized;
 
     /// Get `Metrics` for the given `FontKey`

--- a/src/config.rs
+++ b/src/config.rs
@@ -1097,6 +1097,11 @@ impl Config {
         self.font.use_thin_strokes
     }
 
+    #[inline]
+    pub fn use_anti_alias(&self) -> bool {
+        self.font.use_anti_alias
+    }
+
     /// show cursor as inverted
     #[inline]
     pub fn custom_cursor_colors(&self) -> bool {
@@ -1296,7 +1301,10 @@ pub struct Font {
     glyph_offset: Delta,
 
     #[serde(default="true_bool")]
-    use_thin_strokes: bool
+    use_thin_strokes: bool,
+
+    #[serde(default="true_bool")]
+    use_anti_alias: bool,
 }
 
 fn default_bold_desc() -> FontDescription {
@@ -1352,6 +1360,7 @@ impl Default for Font {
             italic: FontDescription::new_with_family("Menlo"),
             size: Size::new(11.0),
             use_thin_strokes: true,
+            use_anti_alias: true,
             offset: Default::default(),
             glyph_offset: Default::default()
         }
@@ -1367,6 +1376,7 @@ impl Default for Font {
             italic: FontDescription::new_with_family("monospace"),
             size: Size::new(11.0),
             use_thin_strokes: false,
+            use_anti_alias: true,
             offset: Default::default(),
             glyph_offset: Default::default()
         }

--- a/src/display.rs
+++ b/src/display.rs
@@ -146,7 +146,7 @@ impl Display {
 
         info!("device_pixel_ratio: {}", dpr);
 
-        let rasterizer = font::Rasterizer::new(dpi.x(), dpi.y(), dpr, config.use_thin_strokes())?;
+        let rasterizer = font::Rasterizer::new(dpi.x(), dpi.y(), dpr, config.use_thin_strokes(), config.use_anti_alias())?;
 
         // Create renderer
         let mut renderer = QuadRenderer::new(&config, size)?;


### PR DESCRIPTION
The font I use on my current development machine ([Envy Code R](https://damieng.com/blog/2008/05/26/envy-code-r-preview-7-coding-font-released)) looks way better without any anti-alias. I needed to deactivate anti-alias, and it's better to do it without having to recompile Alacritty again.