### PR TITLE
Add support for running commands on key press

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -179,13 +179,13 @@ impl Action {
                     });
             },
             Action::Command(ref program, ref args) => {
-                trace!("running command: {} {}", program, args.join(" "));
+                trace!("running command: {} {:?}", program, args);
                 match Command::new(program).args(args).spawn() {
                     Ok(child) => {
                         debug!("spawned new proc with pid: {}", child.id());
                     },
                     Err(err) => {
-                        err_println!("couldn't run command: {}", err);
+                        warn!("couldn't run command: {}", err);
                     },
                 }
             },


### PR DESCRIPTION
Based on option `command` in key binding section in config, e.g.

```
  - { key: N,        mods: Control|Shift,    command: alacritty          }
  # or
  - {
      key: N,
      mods: Control|Shift,
      command: {
        program: "alacritty",
        args: ["-e", "vttest"],
  }}
```

specified command will be run in the background on key press. Alacritty doesn't wait for its result nor block IO.

Fixes #334.