### PR TITLE
User fonts, macOS font fallback and refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,11 +60,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -222,12 +217,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-text"
-version = "1.1.1"
+name = "core-graphics"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-text"
+version = "4.0.0"
+source = "git+https://github.com/servo/core-text-rs?rev=7a267bc8f6c098f5370583333a5fd00a0d12fb83#7a267bc8f6c098f5370583333a5fd00a0d12fb83"
+dependencies = [
+ "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -270,14 +275,14 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.6.8"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -310,13 +315,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "font"
 version = "0.1.0"
 dependencies = [
- "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 4.0.0 (git+https://github.com/servo/core-text-rs?rev=7a267bc8f6c098f5370583333a5fd00a0d12fb83)",
+ "euclid 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-util 0.1.0",
- "freetype-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-fontconfig 0.2.0 (git+https://github.com/jwilm/rust-fontconfig)",
@@ -324,10 +329,10 @@ dependencies = [
 
 [[package]]
 name = "freetype-rs"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1221,7 +1226,6 @@ dependencies = [
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
-"checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
@@ -1240,17 +1244,18 @@ dependencies = [
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "41115a6aa5d3e1e5ef98148373f25971d1fad53818553f216495f9e67e90a624"
 "checksum core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0c56c6022ba22aedbaa7d231be545778becbe1c7aceda4c82ba2f2084dd4c723"
-"checksum core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94d4f3fab9e0242a648728764ac50e322b61eeb28c2d26d483721fe392cb2878"
+"checksum core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ead017dcf77f503dc991f6b52de6084eeea60a94b0a652baa9bf88654a28e83f"
+"checksum core-text 4.0.0 (git+https://github.com/servo/core-text-rs?rev=7a267bc8f6c098f5370583333a5fd00a0d12fb83)" = "<none>"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07c4c7cc7b396419bc0a4d90371d0cee16cb5053b53647d287c0b728000c41fe"
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
-"checksum euclid 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7b555729225fcc2aabc1ac951f9346967b35c901f4f03a480c31b6a45824109"
+"checksum euclid 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba6ab6f0e63a602978f4b8cf8a43f87a1a475ddf32407f087d579a13cf06b114"
 "checksum expat-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cef36cd1a8a02d28b91d97347c63247b9e4cb8a8e36df36f8201dc87a1c0859c"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
-"checksum freetype-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8c93a141b156862ab58d0206fa44a9b20d899c86c3e6260017ab748029aa42"
+"checksum freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1418e2a055fec8efe18c1a90a54b2cf5e649e583830dd4c71226c4e3bc920c6"
 "checksum freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccfb6d96cac99921f0c2142a91765f6c219868a2c45bdfe7d65a08775f18127"
 "checksum fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcd414e5a1a979b931bb92f41b7a54106d3f6d2e6c253e9ce943b7cd468251ef"
 "checksum fsevent 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfe593ebcfc76884138b25426999890b10da8e6a46d01b499d7c54c604672c38"

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -43,19 +43,19 @@ draw_bold_text_with_bright_colors: true
 font:
   # The normal (roman) font face to use.
   normal:
-    family: monospace # should be "Menlo" or something on macOS.
+    - family: monospace # should be "Menlo" or something on macOS.
     # Style can be specified to pick a specific face.
     # style: Regular
 
   # The bold font face
   bold:
-    family: monospace # should be "Menlo" or something on macOS.
+    - family: monospace # should be "Menlo" or something on macOS.
     # Style can be specified to pick a specific face.
     # style: Bold
 
   # The italic font face
   italic:
-    family: monospace # should be "Menlo" or something on macOS.
+    - family: monospace # should be "Menlo" or something on macOS.
     # Style can be specified to pick a specific face.
     # style: Italic
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -42,21 +42,27 @@ draw_bold_text_with_bright_colors: true
 font:
   # The normal (roman) font face to use.
   normal:
-    family: Menlo
+    - family: Menlo
     # Style can be specified to pick a specific face.
     # style: Regular
+    # Apple Symbols is a reasonable fallback for some glyphs.
+    - family: "Apple Symbols"
 
   # The bold font face
   bold:
-    family: Menlo
+    - family: Menlo
     # Style can be specified to pick a specific face.
     # style: Bold
+    # Apple Symbols is a reasonable fallback for some glyphs.
+    - family: "Apple Symbols"
 
   # The italic font face
   italic:
-    family: Menlo
+    - family: Menlo
     # Style can be specified to pick a specific face.
     # style: Italic
+    # Apple Symbols is a reasonable fallback for some glyphs.
+    - family: "Apple Symbols"
 
   # Point size of the font
   size: 12.0

--- a/font/Cargo.lock
+++ b/font/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 4.0.0 (git+https://github.com/servo/core-text-rs?rev=7a267bc8f6c098f5370583333a5fd00a0d12fb83)",
  "euclid 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-util 0.1.0",
  "freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -49,7 +49,7 @@ dependencies = [
 [[package]]
 name = "core-text"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/servo/core-text-rs?rev=7a267bc8f6c098f5370583333a5fd00a0d12fb83#7a267bc8f6c098f5370583333a5fd00a0d12fb83"
 dependencies = [
  "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -202,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f51ce3b8ebe311c56de14231eb57572c15abebd2d32b3bcb99bcdb9c101f5ac3"
 "checksum core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "41115a6aa5d3e1e5ef98148373f25971d1fad53818553f216495f9e67e90a624"
 "checksum core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ead017dcf77f503dc991f6b52de6084eeea60a94b0a652baa9bf88654a28e83f"
-"checksum core-text 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e9719616a10f717628e074744f8c55df7b450f7a34d29c196d14f4498aad05d"
+"checksum core-text 4.0.0 (git+https://github.com/servo/core-text-rs?rev=7a267bc8f6c098f5370583333a5fd00a0d12fb83)" = "<none>"
 "checksum euclid 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba6ab6f0e63a602978f4b8cf8a43f87a1a475ddf32407f087d579a13cf06b114"
 "checksum expat-sys 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccf6f838594c1571f176f0afdbeb9cfa9f83b478f269d3f0390939b1df4323e"
 "checksum freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1418e2a055fec8efe18c1a90a54b2cf5e649e583830dd4c71226c4e3bc920c6"

--- a/font/Cargo.lock
+++ b/font/Cargo.lock
@@ -2,13 +2,13 @@
 name = "font"
 version = "0.1.0"
 dependencies = [
- "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-util 0.1.0",
- "freetype-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-fontconfig 0.2.0 (git+https://github.com/jwilm/rust-fontconfig)",
@@ -16,21 +16,21 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "core-foundation"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -38,34 +38,34 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.3.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "core-text"
-version = "1.1.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "euclid"
-version = "0.6.8"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -83,10 +83,10 @@ version = "0.1.0"
 
 [[package]]
 name = "freetype-rs"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -165,7 +165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.7.9"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -198,14 +198,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
-"checksum core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "20a6d0448d3a99d977ae4a2aa5a98d886a923e863e81ad9ff814645b6feb3bbd"
-"checksum core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "05eed248dc504a5391c63794fe4fb64f46f071280afaa1b73308f3c0ce4574c5"
-"checksum core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0c56c6022ba22aedbaa7d231be545778becbe1c7aceda4c82ba2f2084dd4c723"
-"checksum core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94d4f3fab9e0242a648728764ac50e322b61eeb28c2d26d483721fe392cb2878"
-"checksum euclid 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7b555729225fcc2aabc1ac951f9346967b35c901f4f03a480c31b6a45824109"
+"checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
+"checksum core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f51ce3b8ebe311c56de14231eb57572c15abebd2d32b3bcb99bcdb9c101f5ac3"
+"checksum core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "41115a6aa5d3e1e5ef98148373f25971d1fad53818553f216495f9e67e90a624"
+"checksum core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ead017dcf77f503dc991f6b52de6084eeea60a94b0a652baa9bf88654a28e83f"
+"checksum core-text 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e9719616a10f717628e074744f8c55df7b450f7a34d29c196d14f4498aad05d"
+"checksum euclid 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba6ab6f0e63a602978f4b8cf8a43f87a1a475ddf32407f087d579a13cf06b114"
 "checksum expat-sys 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccf6f838594c1571f176f0afdbeb9cfa9f83b478f269d3f0390939b1df4323e"
-"checksum freetype-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8c93a141b156862ab58d0206fa44a9b20d899c86c3e6260017ab748029aa42"
+"checksum freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1418e2a055fec8efe18c1a90a54b2cf5e649e583830dd4c71226c4e3bc920c6"
 "checksum freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccfb6d96cac99921f0c2142a91765f6c219868a2c45bdfe7d65a08775f18127"
 "checksum gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "3da3a2cbaeb01363c8e3704fd9fd0eb2ceb17c6f27abd4c1ef040fb57d20dc79"
 "checksum heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "abb306abb8d398e053cfb1b3e7b72c2f580be048b85745c52652954f8ad1439c"
@@ -217,7 +217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "51eab148f171aefad295f8cece636fc488b9b392ef544da31ea4b8ef6b9e9c39"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
-"checksum serde 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b76133a8a02f1c6ebd3fb9a2ecaab3d54302565a51320e80931adba571aadb1b"
+"checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum servo-fontconfig 0.2.0 (git+https://github.com/jwilm/rust-fontconfig)" = "<none>"
 "checksum servo-fontconfig-sys 2.11.3 (git+https://github.com/jwilm/libfontconfig)" = "<none>"
 "checksum winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3969e500d618a5e974917ddefd0ba152e4bcaae5eb5d9b8c1fbc008e9e28c24e"

--- a/font/Cargo.toml
+++ b/font/Cargo.toml
@@ -16,7 +16,11 @@ servo-fontconfig = { git = "https://github.com/jwilm/rust-fontconfig" }
 freetype-rs = "0.13.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-text = "4.0.0"
+#core-text = { path = "../../core-text-rs" }
 core-foundation = "0.3.0"
 core-graphics = "0.7.0"
 core-foundation-sys = "0.3.1"
+
+[target.'cfg(target_os = "macos")'.dependencies.core-text]
+git = "https://github.com/servo/core-text-rs"
+rev = "7a267bc8f6c098f5370583333a5fd00a0d12fb83"

--- a/font/Cargo.toml
+++ b/font/Cargo.toml
@@ -6,17 +6,17 @@ description = "Font rendering using the best available solution per platform"
 license = "Apache-2.0"
 
 [dependencies]
-euclid = "0.6.8"
+euclid = "0.12.0"
 libc = "0.2"
 ffi-util = { path = "../ffi-util" }
 log = "0.3"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 servo-fontconfig = { git = "https://github.com/jwilm/rust-fontconfig" }
-freetype-rs = "0.9.0"
+freetype-rs = "0.13.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-text = "1.1.1"
-core-foundation = "0.2.2"
-core-graphics = "0.3.2"
-core-foundation-sys = "0.2.2"
+core-text = "4.0.0"
+core-foundation = "0.3.0"
+core-graphics = "0.7.0"
+core-foundation-sys = "0.3.1"

--- a/font/src/darwin/byte_order.rs
+++ b/font/src/darwin/byte_order.rs
@@ -15,7 +15,7 @@
 //! Constants for bitmap byte order
 #![allow(non_upper_case_globals)]
 pub const kCGBitmapByteOrder32Little: u32 = 2 << 12;
-pub const kCGBitmapByteOrder32Big: u32 = 4 << 12;
+//pub const kCGBitmapByteOrder32Big: u32 = 4 << 12;
 
 #[cfg(target_endian = "little")]
 pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Little;

--- a/font/src/darwin/cg_color.rs
+++ b/font/src/darwin/cg_color.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID, CFTypeRef, TCFType};
-use core_graphics::color_space::{CGColorSpace, CGColorSpaceRef};
-use core_graphics::base::CGFloat;
+//use core_graphics::color_space::{CGColorSpace, CGColorSpaceRef};
+//use core_graphics::base::CGFloat;
 use std::mem;
 
 #[repr(C)]
@@ -75,18 +75,17 @@ impl TCFType<CGColorRef> for CGColor {
     }
 }
 
-impl CGColor {
-    pub fn new(color_space: CGColorSpace, values: [CGFloat; 4]) -> CGColor {
-        unsafe {
-            let result = CGColorCreate(color_space.as_concrete_TypeRef(), values.as_ptr());
-            TCFType::wrap_under_create_rule(result)
-        }
-    }
-}
+// impl CGColor {
+//     pub fn new(color_space: CGColorSpace, values: [CGFloat; 4]) -> CGColor {
+//         unsafe {
+//             let result = CGColorCreate(color_space.as_concrete_TypeRef(), values.as_ptr());
+//             TCFType::wrap_under_create_rule(result)
+//         }
+//     }
+// }
 
 #[link(name = "ApplicationServices", kind = "framework")]
 extern {
-    fn CGColorCreate(space: CGColorSpaceRef, vals: *const CGFloat) -> CGColorRef;
+//    fn CGColorCreate(space: CGColorSpaceRef, vals: *const CGFloat) -> CGColorRef;
     fn CGColorGetTypeID() -> CFTypeID;
 }
-

--- a/font/src/darwin/cg_ext.rs
+++ b/font/src/darwin/cg_ext.rs
@@ -1,0 +1,139 @@
+// Copyright 2016 Joe Wilm, The Alacritty Project Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+use core_foundation::base::TCFType;
+use core_graphics::base::CGFloat;
+use core_graphics::context::{CGContext, CGContextRef};
+use core_graphics::font::{CGFont, CGFontRef, CGGlyph};
+use core_graphics::geometry::{CGPoint, CGRect};
+
+use libc::{size_t, c_int};
+
+use darwin::cg_color::{CGColorRef, CGColor};
+
+
+
+/// Additional methods needed to render fonts for Alacritty
+///
+/// TODO upstream these into core_graphics crate
+pub trait CGContextExt {
+    fn set_allows_font_subpixel_quantization(&self, bool);
+    fn set_should_subpixel_quantize_fonts(&self, bool);
+    fn set_allows_font_subpixel_positioning(&self, bool);
+    fn set_should_subpixel_position_fonts(&self, bool);
+    fn set_allows_antialiasing(&self, bool);
+    fn set_should_antialias(&self, bool);
+    fn fill_rect(&self, rect: CGRect);
+    fn set_font_smoothing_background_color(&self, color: CGColor);
+    fn show_glyphs_at_positions(&self, &[CGGlyph], &[CGPoint]);
+    fn set_font(&self, &CGFont);
+    fn set_font_size(&self, size: f64);
+    fn set_font_smoothing_style(&self, style: i32);
+}
+
+impl CGContextExt for CGContext {
+    fn set_allows_font_subpixel_quantization(&self, allows: bool) {
+        unsafe {
+            CGContextSetAllowsFontSubpixelQuantization(self.as_concrete_TypeRef(), allows);
+        }
+    }
+
+    fn set_should_subpixel_quantize_fonts(&self, should: bool) {
+        unsafe {
+            CGContextSetShouldSubpixelQuantizeFonts(self.as_concrete_TypeRef(), should);
+        }
+    }
+
+    fn set_should_subpixel_position_fonts(&self, should: bool) {
+        unsafe {
+            CGContextSetShouldSubpixelPositionFonts(self.as_concrete_TypeRef(), should);
+        }
+    }
+
+    fn set_allows_font_subpixel_positioning(&self, allows: bool) {
+        unsafe {
+            CGContextSetAllowsFontSubpixelPositioning(self.as_concrete_TypeRef(), allows);
+        }
+    }
+
+    fn set_should_antialias(&self, should: bool) {
+        unsafe {
+            CGContextSetShouldAntialias(self.as_concrete_TypeRef(), should);
+        }
+    }
+
+    fn set_allows_antialiasing(&self, allows: bool) {
+        unsafe {
+            CGContextSetAllowsAntialiasing(self.as_concrete_TypeRef(), allows);
+        }
+    }
+
+    fn fill_rect(&self, rect: CGRect) {
+        unsafe {
+            CGContextFillRect(self.as_concrete_TypeRef(), rect);
+        }
+    }
+
+    fn set_font_smoothing_background_color(&self, color: CGColor) {
+        unsafe {
+            CGContextSetFontSmoothingBackgroundColor(self.as_concrete_TypeRef(),
+                                                     color.as_concrete_TypeRef());
+        }
+    }
+
+    fn show_glyphs_at_positions(&self, glyphs: &[CGGlyph], positions: &[CGPoint]) {
+        assert_eq!(glyphs.len(), positions.len());
+        unsafe {
+            CGContextShowGlyphsAtPositions(self.as_concrete_TypeRef(),
+                                           glyphs.as_ptr(),
+                                           positions.as_ptr(),
+                                           glyphs.len());
+        }
+    }
+
+    fn set_font(&self, font: &CGFont) {
+        unsafe {
+            CGContextSetFont(self.as_concrete_TypeRef(), font.as_concrete_TypeRef());
+        }
+    }
+
+    fn set_font_size(&self, size: f64) {
+        unsafe {
+            CGContextSetFontSize(self.as_concrete_TypeRef(), size as CGFloat);
+        }
+    }
+
+    fn set_font_smoothing_style(&self, style: i32) {
+        unsafe {
+            CGContextSetFontSmoothingStyle(self.as_concrete_TypeRef(), style as _);
+        }
+    }
+}
+
+#[link(name = "ApplicationServices", kind = "framework")]
+extern {
+    fn CGContextSetAllowsFontSubpixelQuantization(c: CGContextRef, allows: bool);
+    fn CGContextSetShouldSubpixelQuantizeFonts(c: CGContextRef, should: bool);
+    fn CGContextSetAllowsFontSubpixelPositioning(c: CGContextRef, allows: bool);
+    fn CGContextSetShouldSubpixelPositionFonts(c: CGContextRef, should: bool);
+    fn CGContextSetAllowsAntialiasing(c: CGContextRef, allows: bool);
+    fn CGContextSetShouldAntialias(c: CGContextRef, should: bool);
+    fn CGContextFillRect(c: CGContextRef, r: CGRect);
+    fn CGContextSetFontSmoothingBackgroundColor(c: CGContextRef, color: CGColorRef);
+    fn CGContextShowGlyphsAtPositions(c: CGContextRef, glyphs: *const CGGlyph,
+                                      positions: *const CGPoint, count: size_t);
+    fn CGContextSetFont(c: CGContextRef, font: CGFontRef);
+    fn CGContextSetFontSize(c: CGContextRef, size: CGFloat);
+    fn CGContextSetFontSmoothingStyle(c: CGContextRef, style: c_int);
+}

--- a/font/src/darwin/cg_ext.rs
+++ b/font/src/darwin/cg_ext.rs
@@ -13,107 +13,16 @@
 // limitations under the License.
 //
 use core_foundation::base::TCFType;
-use core_graphics::base::CGFloat;
 use core_graphics::context::{CGContext, CGContextRef};
-use core_graphics::font::{CGFont, CGFontRef, CGGlyph};
-use core_graphics::geometry::{CGPoint, CGRect};
 
-use libc::{size_t, c_int};
-
-use darwin::cg_color::{CGColorRef, CGColor};
-
-
+use libc::{c_int};
 
 /// Additional methods needed to render fonts for Alacritty
-///
-/// TODO upstream these into core_graphics crate
 pub trait CGContextExt {
-    fn set_allows_font_subpixel_quantization(&self, bool);
-    fn set_should_subpixel_quantize_fonts(&self, bool);
-    fn set_allows_font_subpixel_positioning(&self, bool);
-    fn set_should_subpixel_position_fonts(&self, bool);
-    fn set_allows_antialiasing(&self, bool);
-    fn set_should_antialias(&self, bool);
-    fn fill_rect(&self, rect: CGRect);
-    fn set_font_smoothing_background_color(&self, color: CGColor);
-    fn show_glyphs_at_positions(&self, &[CGGlyph], &[CGPoint]);
-    fn set_font(&self, &CGFont);
-    fn set_font_size(&self, size: f64);
     fn set_font_smoothing_style(&self, style: i32);
 }
 
 impl CGContextExt for CGContext {
-    fn set_allows_font_subpixel_quantization(&self, allows: bool) {
-        unsafe {
-            CGContextSetAllowsFontSubpixelQuantization(self.as_concrete_TypeRef(), allows);
-        }
-    }
-
-    fn set_should_subpixel_quantize_fonts(&self, should: bool) {
-        unsafe {
-            CGContextSetShouldSubpixelQuantizeFonts(self.as_concrete_TypeRef(), should);
-        }
-    }
-
-    fn set_should_subpixel_position_fonts(&self, should: bool) {
-        unsafe {
-            CGContextSetShouldSubpixelPositionFonts(self.as_concrete_TypeRef(), should);
-        }
-    }
-
-    fn set_allows_font_subpixel_positioning(&self, allows: bool) {
-        unsafe {
-            CGContextSetAllowsFontSubpixelPositioning(self.as_concrete_TypeRef(), allows);
-        }
-    }
-
-    fn set_should_antialias(&self, should: bool) {
-        unsafe {
-            CGContextSetShouldAntialias(self.as_concrete_TypeRef(), should);
-        }
-    }
-
-    fn set_allows_antialiasing(&self, allows: bool) {
-        unsafe {
-            CGContextSetAllowsAntialiasing(self.as_concrete_TypeRef(), allows);
-        }
-    }
-
-    fn fill_rect(&self, rect: CGRect) {
-        unsafe {
-            CGContextFillRect(self.as_concrete_TypeRef(), rect);
-        }
-    }
-
-    fn set_font_smoothing_background_color(&self, color: CGColor) {
-        unsafe {
-            CGContextSetFontSmoothingBackgroundColor(self.as_concrete_TypeRef(),
-                                                     color.as_concrete_TypeRef());
-        }
-    }
-
-    fn show_glyphs_at_positions(&self, glyphs: &[CGGlyph], positions: &[CGPoint]) {
-        assert_eq!(glyphs.len(), positions.len());
-        unsafe {
-            CGContextShowGlyphsAtPositions(self.as_concrete_TypeRef(),
-                                           glyphs.as_ptr(),
-                                           positions.as_ptr(),
-                                           glyphs.len());
-        }
-    }
-
-    fn set_font(&self, font: &CGFont) {
-        unsafe {
-            CGContextSetFont(self.as_concrete_TypeRef(), font.as_concrete_TypeRef());
-        }
-    }
-
-    fn set_font_size(&self, size: f64) {
-        unsafe {
-            CGContextSetFontSize(self.as_concrete_TypeRef(), size as CGFloat);
-        }
-    }
-
     fn set_font_smoothing_style(&self, style: i32) {
         unsafe {
             CGContextSetFontSmoothingStyle(self.as_concrete_TypeRef(), style as _);
@@ -123,17 +32,7 @@ impl CGContextExt for CGContext {
 
 #[link(name = "ApplicationServices", kind = "framework")]
 extern {
-    fn CGContextSetAllowsFontSubpixelQuantization(c: CGContextRef, allows: bool);
-    fn CGContextSetShouldSubpixelQuantizeFonts(c: CGContextRef, should: bool);
-    fn CGContextSetAllowsFontSubpixelPositioning(c: CGContextRef, allows: bool);
-    fn CGContextSetShouldSubpixelPositionFonts(c: CGContextRef, should: bool);
-    fn CGContextSetAllowsAntialiasing(c: CGContextRef, allows: bool);
-    fn CGContextSetShouldAntialias(c: CGContextRef, should: bool);
-    fn CGContextFillRect(c: CGContextRef, r: CGRect);
-    fn CGContextSetFontSmoothingBackgroundColor(c: CGContextRef, color: CGColorRef);
-    fn CGContextShowGlyphsAtPositions(c: CGContextRef, glyphs: *const CGGlyph,
-                                      positions: *const CGPoint, count: size_t);
-    fn CGContextSetFont(c: CGContextRef, font: CGFontRef);
-    fn CGContextSetFontSize(c: CGContextRef, size: CGFloat);
+    /// As of 19 May 2017, this doesn't seem to be part of Apple's
+    /// official Core Graphics API.
     fn CGContextSetFontSmoothingStyle(c: CGContextRef, style: c_int);
 }

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -41,6 +41,7 @@ extern crate ffi_util;
 #[macro_use]
 extern crate log;
 
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
@@ -49,18 +50,28 @@ use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 #[cfg(not(target_os = "macos"))]
 mod ft;
 #[cfg(not(target_os = "macos"))]
-pub use ft::{FreeTypeRasterizer as Rasterizer, Error};
+pub use ft::{Font, RasterizerImpl, Error};
 
 // If target is macos, reexport everything from darwin
 #[cfg(target_os = "macos")]
 mod darwin;
 #[cfg(target_os = "macos")]
-pub use darwin::*;
+pub use darwin::{Font, RasterizerImpl, Error};
+
+#[derive(Debug, Clone)]
+pub struct FontList {
+    fonts: Vec<Font>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FontDesc {
     name: String,
     style: Style,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FontDescList {
+    pub descs: Vec<FontDesc>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -223,20 +234,229 @@ pub struct Metrics {
     pub descent: f32,
 }
 
-pub trait Rasterize {
+//
+// We support two types of font fallbacks depending on platform.
+// 1. For macOS, we load the user provided fallback lists (from alacritty.yml)
+//    and add on what we get from get_fallback_fonts(), which are lists
+//    provided by the system.
+// 2. For freetype/fontconfig, we try the user fallbacks, and failing that
+//    fall back on fontconfig where an appropriate font is found using get_glyph_fallback()
+//    depending on glyph.
+//
+pub trait RasterizeImpl {
     /// Errors occurring in Rasterize methods
     type Err: ::std::error::Error + Send + Sync + 'static;
 
-    /// Create a new Rasterize
-    fn new(dpi_x: f32, dpi_y: f32, device_pixel_ratio: f32, use_thin_strokes: bool) -> Result<Self, Self::Err>
+    /// Create a new RasterizeImpl
+    fn new() -> Result<Self,Self::Err>
         where Self: Sized;
 
-    /// Get `Metrics` for the given `FontKey`
-    fn metrics(&self, FontKey) -> Result<Metrics, Self::Err>;
+    /// Load the fonts described by `FontDesc` and `Size`, this doesn't
+    /// necessarily mean the implementation must load the font
+    /// before calls to metrics/get_glyph.
+    fn load_font(
+        &self,
+        &Details,
+        &FontDesc,
+        Size,
+    ) -> Result<Font, Self::Err>;
 
-    /// Load the font described by `FontDesc` and `Size`
-    fn load_font(&mut self, &FontDesc, Size) -> Result<FontKey, Self::Err>;
+    /// Get the fallback list of `Font` for given `FontDesc` `Font` and `Size`.
+    /// This is used on macOS.
+    fn get_fallback_fonts(
+        &self,
+        &Details,
+        &FontDesc,
+        &Font,
+        Size,
+        &Vec<String>,
+    ) -> Result<Vec<Font>, Self::Err>;
+
+    /// Get `Metrics` for the given `Font`
+    fn metrics(
+        &self,
+        &Details,
+        &Font,
+    ) -> Result<Metrics, Self::Err>;
+
+    /// Rasterize the glyph described by `char` `Font` and `Size`.
+    fn get_glyph(
+        &self,
+        &Details,
+        char,
+        &[u16], // utf16 encoded char for macOS
+        &Font,
+        Size,
+    ) -> Result<RasterizedGlyph, Self::Err>;
+
+    /// Try to rasterize the glyph described by `char` `Font` and `Size` using
+    /// fallback mechanisms. This is relevant for fontconfig.
+    fn get_glyph_fallback(
+        &mut self,
+        &Details,
+        char,
+        &[u16], // utf16 encoded char for macOS
+        Size,
+    ) -> Result<RasterizedGlyph, Self::Err>;
+}
+
+pub struct Details {
+    pub dpi_x: f32,
+    pub dpi_y: f32,
+    pub device_pixel_ratio: f32,
+    pub use_thin_strokes: bool,
+}
+
+/// Exposed Rasterizer delegating to actual RasterizeImpl depending on platform
+pub struct Rasterizer {
+    fonts: HashMap<FontKey, FontList>,
+    keys: HashMap<(FontDescList, Size), FontKey>,
+    r_impl: RasterizerImpl,
+    details: Details,
+}
+
+impl Rasterizer {
+
+    pub fn new(
+        dpi_x: f32,
+        dpi_y: f32,
+        device_pixel_ratio: f32,
+        use_thin_strokes: bool,
+    ) -> Result<Self,Error> {
+        Ok(Rasterizer {
+            fonts: HashMap::new(),
+            keys: HashMap::new(),
+            r_impl: RasterizerImpl::new()?,
+            details: Details {dpi_x, dpi_y, device_pixel_ratio, use_thin_strokes},
+        })
+    }
+
+    /// Declare the font list described by `FontDescList` and `Size` to get
+    /// the corresponding `FontKey`
+    pub fn declare_font_list(
+        &mut self,
+        lists: &FontDescList,
+        size: Size,
+    ) -> Result<FontKey, Error> {
+
+        self.keys
+            .get(&(lists.clone(), size))
+            .map(|k| Ok(*k))
+            .unwrap_or_else(|| {
+
+                // these are the fonts configured by the user in alacritty.yml
+                let user_fonts = lists.descs.clone().into_iter()
+                    .filter_map(|x| {
+                        // delegate font loading to platform implementation
+                        match self.r_impl.load_font(&self.details, &x, size) {
+                            Ok(font) => Some(Ok((x, font))),
+
+                            // fonts that fail to load for some reason
+                            Err(e) =>
+                                if let Error::MissingFont(ref d) = e {
+                                    // missing is not an error we abort on,
+                                    // we log it and then drop the entry.
+                                    info!("Failed to load font {}", d);
+                                    None
+                                } else {
+                                    // any other error results in aborting
+                                    // the iterator.
+                                    Some(Err(e))
+                                }
+                        }
+                    })
+                    .collect::<Result<Vec<(FontDesc,Font)>, Error>>()?;
+
+                // we don't accept loading no fonts at all.
+                if user_fonts.len() == 0 {
+                    return Err(Error::NoFontsForList)
+                }
+
+                // get system fallback fonts to add on to the user configured ones.
+                let mut fallback_fonts = {
+                    // names of fonts that were already loaded by the user config.
+                    let loaded_names:Vec<String> = user_fonts.iter()
+                        .map(|x| x.0.name.to_owned()).collect();
+                    // we consider the first font to be the "primary" to
+                    // base system fallback fonts on.
+                    let ref first = user_fonts[0].clone();
+
+                    // delegate getting fallback to platform implementation.
+                    self.r_impl.get_fallback_fonts(
+                        &self.details, &first.0, &first.1, size, &loaded_names)?
+                };
+
+                // build final list of fonts adding user_fonts + fallback_fonts.
+                let mut fonts:Vec<Font> = user_fonts.into_iter().map(|x| x.1).collect();
+                fonts.append(&mut fallback_fonts);
+
+                let key = FontKey::next();
+
+                self.fonts.insert(key, FontList {fonts});
+                self.keys.insert((lists.clone(), size), key);
+
+                Ok(key)
+            })
+
+    }
+
+    /// Get `Metrics` for the given `FontKey`
+    pub fn metrics(
+        &self,
+        key: &FontKey,
+    ) -> Result<Metrics, Error> {
+
+        let list = self.fonts
+            .get(&key)
+            .ok_or(Error::FontNotLoaded)?;
+
+        // we are guaranteed to always have at least one
+        // font in the list.
+        let ref font = list.fonts[0];
+
+        self.r_impl.metrics(&self.details, font)
+
+    }
 
     /// Rasterize the glyph described by `GlyphKey`.
-    fn get_glyph(&mut self, &GlyphKey) -> Result<RasterizedGlyph, Self::Err>;
+    pub fn get_glyph(
+        &mut self,
+        glyph: &GlyphKey,
+    ) -> Result<RasterizedGlyph, Error> {
+
+        let list = self.fonts
+            .get(&glyph.font_key)
+            .ok_or(Error::FontNotLoaded)?;
+
+        // to avoid utf16 encoding the char for every fallback
+        // lookup, we encoded it once. this is required for macOS.
+        let mut buf = [0; 2];
+        let encoded:&[u16] = glyph.c.encode_utf16(&mut buf);
+
+        for font in &list.fonts {
+            match self.r_impl.get_glyph(
+                &self.details, glyph.c, encoded, font, glyph.size) {
+                // early return, first glyph that renders
+                Ok(glyph) => return Ok(glyph),
+
+                Err(error) => {
+                    match error {
+                        // ignore the missing glyph and continue to try the next
+                        // font in the font list.
+                        Error::MissingGlyph(_) => continue,
+                        // any other error aborts the attempt
+                        _ => return Err(error)
+                    }
+                }
+
+            }
+        }
+
+        // before giving up we try doing a fallback font.
+        // for macOS this isn't used, since the fallback fonts are padded
+        // onto the list.fonts already at startup and are thus handled
+        // by the above for-loop.
+        self.r_impl.get_glyph_fallback(&self.details, glyph.c, encoded, glyph.size)
+    }
+
 }

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -34,6 +34,7 @@ extern crate core_graphics;
 extern crate euclid;
 extern crate libc;
 
+#[cfg(not(target_os = "macos"))]
 #[macro_use]
 extern crate ffi_util;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1274,13 +1274,13 @@ impl DeserializeFromF32 for Size {
 #[derive(Debug, Deserialize)]
 pub struct Font {
     /// Font family
-    pub normal: FontDescription,
+    pub normal: Vec<FontDescription>,
 
     #[serde(default="default_italic_desc")]
-    pub italic: FontDescription,
+    pub italic: Vec<FontDescription>,
 
     #[serde(default="default_bold_desc")]
-    pub bold: FontDescription,
+    pub bold: Vec<FontDescription>,
 
     // Font size in points
     #[serde(deserialize_with="DeserializeFromF32::deserialize_from_f32")]
@@ -1297,11 +1297,11 @@ pub struct Font {
     use_thin_strokes: bool
 }
 
-fn default_bold_desc() -> FontDescription {
+fn default_bold_desc() -> Vec<FontDescription> {
     Font::default().bold
 }
 
-fn default_italic_desc() -> FontDescription {
+fn default_italic_desc() -> Vec<FontDescription> {
     Font::default().italic
 }
 
@@ -1345,9 +1345,9 @@ impl Font {
 impl Default for Font {
     fn default() -> Font {
         Font {
-            normal: FontDescription::new_with_family("Menlo"),
-            bold: FontDescription::new_with_family("Menlo"),
-            italic: FontDescription::new_with_family("Menlo"),
+            normal: vec![FontDescription::new_with_family("Menlo")],
+            bold: vec![FontDescription::new_with_family("Menlo")],
+            italic: vec![FontDescription::new_with_family("Menlo")],
             size: Size::new(11.0),
             use_thin_strokes: true,
             offset: Default::default(),
@@ -1360,9 +1360,9 @@ impl Default for Font {
 impl Default for Font {
     fn default() -> Font {
         Font {
-            normal: FontDescription::new_with_family("monospace"),
-            bold: FontDescription::new_with_family("monospace"),
-            italic: FontDescription::new_with_family("monospace"),
+            normal: vec![FontDescription::new_with_family("monospace")],
+            bold: vec![FontDescription::new_with_family("monospace")],
+            italic: vec![FontDescription::new_with_family("monospace")],
             size: Size::new(11.0),
             use_thin_strokes: false,
             offset: Default::default(),

--- a/src/display.rs
+++ b/src/display.rs
@@ -21,7 +21,7 @@ use parking_lot::{MutexGuard};
 use Rgb;
 use cli;
 use config::Config;
-use font::{self, Rasterize};
+use font;
 use meter::Meter;
 use renderer::{self, GlyphCache, QuadRenderer};
 use selection::Selection;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -22,7 +22,7 @@ use std::sync::mpsc;
 
 use cgmath;
 use fnv::FnvHasher;
-use font::{self, Rasterizer, Rasterize, RasterizedGlyph, FontDesc, GlyphKey, FontKey};
+use font::{self, Rasterizer, RasterizedGlyph, FontDesc, FontDescList, GlyphKey, FontKey};
 use gl::types::*;
 use gl;
 use index::{Line, Column, RangeInclusive};
@@ -176,42 +176,47 @@ impl GlyphCache {
         let size = font.size();
         let glyph_offset = *font.glyph_offset();
 
-        fn make_desc(
-            desc: &config::FontDescription,
+        fn make_descs(
+            confs: &Vec<config::FontDescription>,
             slant: font::Slant,
             weight: font::Weight,
-        ) -> FontDesc
+        ) -> FontDescList
         {
-            let style = if let Some(ref spec) = desc.style {
-                font::Style::Specific(spec.to_owned())
-            } else {
-                font::Style::Description {slant, weight}
-            };
-            FontDesc::new(&desc.family[..], style)
+            let descs = confs.into_iter()
+                .map(|desc| {
+                    let style = if let Some(ref spec) = desc.style {
+                        font::Style::Specific(spec.to_owned())
+                    } else {
+                        font::Style::Description {slant, weight}
+                    };
+                    FontDesc::new(&desc.family[..], style)
+                })
+                .collect();
+            FontDescList {descs}
         }
 
         // Load regular font
-        let regular_desc = make_desc(&font.normal, font::Slant::Normal, font::Weight::Normal);
+        let regular_desc = make_descs(&font.normal, font::Slant::Normal, font::Weight::Normal);
 
         let regular = rasterizer
-            .load_font(&regular_desc, size)?;
+            .declare_font_list(&regular_desc, size)?;
 
         // helper to load a description if it is not the regular_desc
-        let load_or_regular = |desc:FontDesc, rasterizer: &mut Rasterizer| {
+        let load_or_regular = |desc:FontDescList, rasterizer: &mut Rasterizer| {
             if desc == regular_desc {
                 regular
             } else {
-                rasterizer.load_font(&desc, size).unwrap_or_else(|_| regular)
+                rasterizer.declare_font_list(&desc, size).unwrap_or_else(|_| regular)
             }
         };
 
         // Load bold font
-        let bold_desc = make_desc(&font.bold, font::Slant::Normal, font::Weight::Bold);
+        let bold_desc = make_descs(&font.bold, font::Slant::Normal, font::Weight::Bold);
 
         let bold = load_or_regular(bold_desc, &mut rasterizer);
 
         // Load italic font
-        let italic_desc = make_desc(&font.italic, font::Slant::Italic, font::Weight::Normal);
+        let italic_desc = make_descs(&font.italic, font::Slant::Italic, font::Weight::Normal);
 
         let italic = load_or_regular(italic_desc, &mut rasterizer);
 
@@ -219,7 +224,7 @@ impl GlyphCache {
         // The glyph requested here ('m' at the time of writing) has no special
         // meaning.
         rasterizer.get_glyph(&GlyphKey { font_key: regular, c: 'm', size: font.size() })?;
-        let metrics = rasterizer.metrics(regular)?;
+        let metrics = rasterizer.metrics(&regular)?;
 
         let mut cache = GlyphCache {
             cache: HashMap::default(),
@@ -253,7 +258,7 @@ impl GlyphCache {
 
     pub fn font_metrics(&self) -> font::Metrics {
         self.rasterizer
-            .metrics(self.font_key)
+            .metrics(&self.font_key)
             .expect("metrics load since font is loaded at glyph cache creation")
     }
 


### PR DESCRIPTION
1. Config change so `alacritty.yml` have lists of fonts that works as fallbacks.
2. Moved some shared logic to `font/src/lib.rs` so that user fallbacks can work in a similar way regardless of platform.
3. Supports two different fallback strategies depending on platform:
  - macOS adds on system defined font fallbacks at the end of the user font lists.
  - freetype/fontconfig attempts to get a fontconfig fallback per rendered glyph when needed.
4. Tidy up in `darwin` to split out some core-graphics stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jwilm/alacritty/575)
<!-- Reviewable:end -->
