### PR TITLE
Add config file as cli option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,8 @@ extern crate log;
 use clap::{Arg, App};
 use index::{Line, Column};
 use config::{Dimensions, Shell};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::borrow::Cow;
 
 const DEFAULT_TITLE: &'static str = "Alacritty";
 
@@ -156,5 +157,9 @@ impl Options {
 
     pub fn command(&self) -> Option<&Shell> {
         self.command.as_ref()
+    }
+
+    pub fn config_path(&self) -> Option<Cow<Path>> {
+        self.config.as_ref().map(|p| Cow::Borrowed(p.as_path()))
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,8 +135,8 @@ impl Options {
             options.working_dir = Some(PathBuf::from(dir.to_string()));
         }
 
-        if let Some(dir) = matches.value_of("config-file") {
-            options.config = Some(PathBuf::from(dir.to_string()));
+        if let Some(path) = matches.value_of("config-file") {
+            options.config = Some(PathBuf::from(path.to_string()));
         }
 
         if let Some(mut args) = matches.values_of("command") {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,7 +86,6 @@ impl Options {
                  .help("Start the shell in the specified working directory"))
             .arg(Arg::with_name("config-file")
                  .long("config-file")
-                 .short("f")
                  .takes_value(true)
                  .help("Specify alternative configuration file [default: $XDG_CONFIG_HOME/alacritty/alacritty.yml]"))
             .arg(Arg::with_name("command")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,7 @@ pub struct Options {
     pub log_level: log::LogLevelFilter,
     pub command: Option<Shell<'static>>,
     pub working_dir: Option<PathBuf>,
+    pub config: Option<PathBuf>,
 }
 
 impl Default for Options {
@@ -40,6 +41,7 @@ impl Default for Options {
             log_level: log::LogLevelFilter::Warn,
             command: None,
             working_dir: None,
+            config: None,
         }
     }
 }
@@ -82,6 +84,11 @@ impl Options {
                  .long("working-directory")
                  .takes_value(true)
                  .help("Start the shell in the specified working directory"))
+            .arg(Arg::with_name("config-file")
+                 .long("config-file")
+                 .short("f")
+                 .takes_value(true)
+                 .help("Specify alternative configuration file [default: $XDG_CONFIG_HOME/alacritty/alacritty.yml]"))
             .arg(Arg::with_name("command")
                 .short("e")
                 .multiple(true)
@@ -126,6 +133,10 @@ impl Options {
 
         if let Some(dir) = matches.value_of("working-directory") {
             options.working_dir = Some(PathBuf::from(dir.to_string()));
+        }
+
+        if let Some(dir) = matches.value_of("config-file") {
+            options.config = Some(PathBuf::from(dir.to_string()));
         }
 
         if let Some(mut args) = matches.values_of("command") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -692,6 +692,9 @@ pub enum Error {
     /// Config file not found
     NotFound,
 
+    /// Config file empty
+    Empty,
+
     /// Couldn't read $HOME environment variable
     ReadingEnvHome(env::VarError),
 
@@ -894,6 +897,7 @@ impl ::std::error::Error for Error {
     fn cause(&self) -> Option<&::std::error::Error> {
         match *self {
             Error::NotFound => None,
+            Error::Empty => None,
             Error::ReadingEnvHome(ref err) => Some(err),
             Error::Io(ref err) => Some(err),
             Error::Yaml(ref err) => Some(err),
@@ -903,6 +907,7 @@ impl ::std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::NotFound => "could not locate config file",
+            Error::Empty => "empty config file",
             Error::ReadingEnvHome(ref err) => err.description(),
             Error::Io(ref err) => err.description(),
             Error::Yaml(ref err) => err.description(),
@@ -914,6 +919,7 @@ impl ::std::fmt::Display for Error {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         match *self {
             Error::NotFound => write!(f, "{}", ::std::error::Error::description(self)),
+            Error::Empty => write!(f, "{}", ::std::error::Error::description(self)),
             Error::ReadingEnvHome(ref err) => {
                 write!(f, "could not read $HOME environment variable: {}", err)
             },
@@ -1100,6 +1106,9 @@ impl Config {
         let mut f = fs::File::open(path)?;
         let mut contents = String::new();
         f.read_to_string(&mut contents)?;
+        if contents.len() == 0 {
+            return Err(Error::Empty);
+        }
 
         Ok(contents)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -962,7 +962,7 @@ impl Config {
     /// 2. $XDG_CONFIG_HOME/alacritty.yml
     /// 3. $HOME/.config/alacritty/alacritty.yml
     /// 4. $HOME/.alacritty.yml
-    pub fn default_config() -> Option<PathBuf> {
+    pub fn installed_config() -> Option<PathBuf> {
         // Try using XDG location by default
         ::xdg::BaseDirectories::with_prefix("alacritty")
             .ok()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1087,7 +1087,7 @@ impl Config {
         self.hide_cursor_when_typing
     }
 
-    fn load_from<P: Into<PathBuf>>(path: P) -> Result<Config> {
+    pub fn load_from<P: Into<PathBuf>>(path: P) -> Result<Config> {
         let path = path.into();
         let raw = Config::read_file(path.as_path())?;
         let mut config: Config = serde_yaml::from_str(&raw)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1407,7 +1407,7 @@ impl Monitor {
                         // Reload file
                         path.map(|path| {
                             if path == config_path {
-                                match Config::load() {
+                                match Config::load_from(path) {
                                     Ok(config) => {
                                         let _ = config_tx.send(config);
                                         handler.on_config_reload();

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,12 +44,9 @@ fn main() {
     // If a configuration file is given as a command line argument we don't generate a default file.
     // If an empty configuration file is given, i.e. /dev/null, we load the compiled-in defaults.
     let config_path = options.config.clone().unwrap_or_else(|| {
-        Config::default_config().unwrap_or_else(||{
-            match Config::write_defaults() {
-                Ok(path) => err_println!("Config file not found; write defaults config to {:?}", path),
-                Err(err) => err_println!("Write defaults config failure: {}", err)
-            }
-            Config::default_config().expect("a config file should have been written")
+        Config::installed_config().unwrap_or_else(||{
+            Config::write_defaults()
+                .unwrap_or_else(|err| die!("Write defaults config failure: {}", err))
         })
     });
     let config = Config::load_from(&config_path).unwrap_or_else(|err| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,30 +37,9 @@ use alacritty::tty::{self, process_should_exit};
 use alacritty::util::fmt::Red;
 
 fn main() {
-    // Load command line options
+    // Load command line options and config
     let options = cli::Options::load();
-
-    // Load configuration
-    // If a configuration file is given as a command line argument we don't generate a default file.
-    // If an empty configuration file is given, i.e. /dev/null, we load the compiled-in defaults.
-    let config_path = options.config.clone().unwrap_or_else(|| {
-        Config::installed_config().unwrap_or_else(||{
-            Config::write_defaults()
-                .unwrap_or_else(|err| die!("Write defaults config failure: {}", err))
-        })
-    });
-    let config = Config::load_from(&config_path).unwrap_or_else(|err| {
-        match err {
-            config::Error::NotFound => {
-                die!("Config file not found at: {}", config_path.as_path().display());
-            },
-            config::Error::Empty => {
-                err_println!("Empty config; Loading defaults");
-                Config::default()
-            },
-            _ => die!("{}", err),
-        }
-    });
+    let config = load_config(&options);
 
     // Run alacritty
     if let Err(err) = run(config, options) {
@@ -70,6 +49,32 @@ fn main() {
     info!("Goodbye.");
 }
 
+/// Load configuration
+///
+/// If a configuration file is given as a command line argument we don't
+/// generate a default file. If an empty configuration file is given, i.e.
+/// /dev/null, we load the compiled-in defaults.
+fn load_config(options: &cli::Options) -> Config {
+    let config_path = options.config_path()
+        .or_else(|| Config::installed_config())
+        .unwrap_or_else(|| {
+            Config::write_defaults()
+                .unwrap_or_else(|err| die!("Write defaults config failure: {}", err))
+        });
+
+    Config::load_from(&*config_path).unwrap_or_else(|err| {
+        match err {
+            config::Error::NotFound => {
+                die!("Config file not found at: {}", config_path.display());
+            },
+            config::Error::Empty => {
+                err_println!("Empty config; Loading defaults");
+                Config::default()
+            },
+            _ => die!("{}", err),
+        }
+    })
+}
 
 /// Run Alacritty
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,29 +43,27 @@ fn main() {
     // Load configuration
     // If a configuration file is given as a command line argument we don't generate a default file.
     // If an empty configuration file is given, i.e. /dev/null, we load the compiled-in defaults.
-    let config = {
-        let config_path = options.config.clone().unwrap_or_else(|| {
-            Config::default_config().unwrap_or_else(||{
-                match Config::write_defaults() {
-                    Ok(path) => err_println!("Config file not found; write defaults config to {:?}", path),
-                    Err(err) => err_println!("Write defaults config failure: {}", err)
-                }
-                Config::default_config().expect("a config file should have been written")
-            })
-        });
-        Config::load_from(&config_path).unwrap_or_else(|err| {
-            match err {
-                config::Error::NotFound => {
-                    die!("Config file not found at: {}", config_path.as_path().display());
-                },
-                config::Error::Empty => {
-                    err_println!("Empty config; Loading defaults");
-                    Config::default()
-                },
-                _ => die!("{}", err),
+    let config_path = options.config.clone().unwrap_or_else(|| {
+        Config::default_config().unwrap_or_else(||{
+            match Config::write_defaults() {
+                Ok(path) => err_println!("Config file not found; write defaults config to {:?}", path),
+                Err(err) => err_println!("Write defaults config failure: {}", err)
             }
+            Config::default_config().expect("a config file should have been written")
         })
-    };
+    });
+    let config = Config::load_from(&config_path).unwrap_or_else(|err| {
+        match err {
+            config::Error::NotFound => {
+                die!("Config file not found at: {}", config_path.as_path().display());
+            },
+            config::Error::Empty => {
+                err_println!("Empty config; Loading defaults");
+                Config::default()
+            },
+            _ => die!("{}", err),
+        }
+    });
 
     // Run alacritty
     if let Err(err) = run(config, options) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,11 @@ fn main() {
                 config::Error::NotFound => {
                     die!("Config file not found at: {}", config.as_path().display());
                 },
-                _ => {
-                    err_println!("Error while loading config: {}", err);
-                    err_println!("Loading defaults");
+                config::Error::Empty => {
+                    err_println!("Empty config; Loading defaults");
                     Config::default()
                 },
+                _ => die!("{}", err),
             }
         })
     }).unwrap_or_else(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,41 +43,38 @@ fn main() {
     // Load configuration
     // If a configuration file is given as a command line argument we don't generate a default file.
     // If an invalid configuration file is given, i.e. /dev/null, we load the compiled in defaults.
-    let config = match options.config {
-        Some(ref config) => {
-            Config::load_from(config).unwrap_or_else(|err| {
-                match err {
-                    config::Error::NotFound => {
-                        die!("Config file not found at: {}", config.as_path().display());
-                    },
-                    _ => {
-                        err_println!("Error while loading config: {}", err);
-                        err_println!("Loading defaults");
-                        Config::default()
-                    },
-                }
-            })
-        },
-        None => {
-            Config::load().unwrap_or_else(|err| {
-                match err {
-                    // Use default config when not found
-                    config::Error::NotFound => {
-                        match Config::write_defaults() {
-                            Ok(path) => err_println!("Config file not found; write defaults config to {:?}", path),
-                            Err(err) => err_println!("Write defaults config failure: {}", err)
-                        }
+    let config = options.config.as_ref().and_then(|config| {
+        Some(Config::load_from(config).unwrap_or_else(|err| {
+            match err {
+                config::Error::NotFound => {
+                    die!("Config file not found at: {}", config.as_path().display());
+                },
+                _ => {
+                    err_println!("Error while loading config: {}", err);
+                    err_println!("Loading defaults");
+                    Config::default()
+                },
+            }
+        }))
+    }).or_else(|| {
+        Some(Config::load().unwrap_or_else(|err| {
+            match err {
+                // Use default config when not found
+                config::Error::NotFound => {
+                    match Config::write_defaults() {
+                        Ok(path) => err_println!("Config file not found; write defaults config to {:?}", path),
+                        Err(err) => err_println!("Write defaults config failure: {}", err)
+                    }
 
-                        Config::load().expect("Config file not found or broken")
-                    },
+                    Config::load().expect("Config file not found or broken")
+                },
 
-                    // If there's a problem with the config file, print an error
-                    // and exit.
-                    _ => die!("{}", err),
-                }
-            })
-        },
-    };
+                // If there's a problem with the config file, print an error
+                // and exit.
+                _ => die!("{}", err),
+            }
+        }))
+    }).unwrap(); // This unwrap is safe, if we don't return a valid config we will exit
 
     // Run alacritty
     if let Err(err) = run(config, options) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,8 @@ use alacritty::tty::{self, process_should_exit};
 use alacritty::util::fmt::Red;
 
 fn main() {
+    // Load command line options
+    let options = cli::Options::load();
 
     // Load configuration
     let config = Config::load().unwrap_or_else(|err| {
@@ -56,9 +58,6 @@ fn main() {
             _ => die!("{}", err),
         }
     });
-
-    // Load command line options
-    let options = cli::Options::load();
 
     // Run alacritty
     if let Err(err) = run(config, options) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,8 @@ fn main() {
     // Load configuration
     // If a configuration file is given as a command line argument we don't generate a default file.
     // If an invalid configuration file is given, i.e. /dev/null, we load the compiled in defaults.
-    let config = options.config.as_ref().and_then(|config| {
-        Some(Config::load_from(config).unwrap_or_else(|err| {
+    let config = options.config.as_ref().map(|config| {
+        Config::load_from(config).unwrap_or_else(|err| {
             match err {
                 config::Error::NotFound => {
                     die!("Config file not found at: {}", config.as_path().display());
@@ -55,9 +55,9 @@ fn main() {
                     Config::default()
                 },
             }
-        }))
-    }).or_else(|| {
-        Some(Config::load().unwrap_or_else(|err| {
+        })
+    }).unwrap_or_else(|| {
+        Config::load().unwrap_or_else(|err| {
             match err {
                 // Use default config when not found
                 config::Error::NotFound => {
@@ -73,8 +73,8 @@ fn main() {
                 // and exit.
                 _ => die!("{}", err),
             }
-        }))
-    }).unwrap(); // This unwrap is safe, if we don't return a valid config we will exit
+        })
+    });
 
     // Run alacritty
     if let Err(err) = run(config, options) {


### PR DESCRIPTION
I wanted to be able to test different versions of alacritty that had different configuration file syntaxes and then this was useful.

Intended use is `--config-file alacritty.yml`.

This also allows you to use the built-in defaults with `--config-file /dev/null`.

Please review =)