### PR TITLE
Add a terminfo file declaring TrueColor support

### DIFF
--- a/alacritty.info
+++ b/alacritty.info
@@ -1,0 +1,3 @@
+alacritty| alacritty,
+	use=xterm-256color,
+	Tc,

--- a/alacritty.info
+++ b/alacritty.info
@@ -1,3 +1,5 @@
 alacritty| alacritty,
 	use=xterm-256color,
+	ritm=\E[23m,
+	sitm=\E[3m,
 	Tc,

--- a/alacritty.info
+++ b/alacritty.info
@@ -3,3 +3,6 @@ alacritty| alacritty,
 	ritm=\E[23m,
 	sitm=\E[3m,
 	Tc,
+
+alacritty-256color| alacritty with 256 colors,
+	use=alacritty,


### PR DESCRIPTION
Alacritty supports true color (24bit) escape codes. There isn't an official terminfo entry for this (yet?) but tmux has an unofficial one: _Tc_

This is used by others, e.g. [st](http://git.suckless.org/st/commit/?id=06f8cf8ca87a81db15816658c40b2afcd1ad5332)
