### PR TITLE
Ensure that the event loop thread cleanly exits on shutdown

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -22,7 +22,7 @@ pub enum Msg {
     /// Data that should be written to the pty
     Input(Cow<'static, [u8]>),
 
-    /// Indicates that the `EvemtLoop` should shut down, as Alacritty is shutting down
+    /// Indicates that the `EventLoop` should shut down, as Alacritty is shutting down
     Shutdown
 }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -58,7 +58,6 @@ enum DrainResult {
 }
 
 impl DrainResult {
-
     pub fn is_shutdown(&self) -> bool {
         match *self {
             DrainResult::Shutdown => true,
@@ -66,22 +65,12 @@ impl DrainResult {
         }
     }
 
-    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         match *self {
             DrainResult::Empty => true,
             _ => false
         }
     }
-
-    #[allow(dead_code)]
-    pub fn is_item(&self) -> bool {
-        match *self {
-            DrainResult::ReceivedItem => true,
-            _ => false
-        }
-    }
-
 }
 
 /// All of the mutable state needed to run the event loop
@@ -222,7 +211,11 @@ impl<Io> EventLoop<Io>
             }
         }
 
-        return if received_item { DrainResult::ReceivedItem } else { DrainResult::Empty };
+        if received_item {
+            DrainResult::ReceivedItem
+        } else {
+            DrainResult::Empty
+        }
     }
 
     // Returns a `bool` indicating whether or not the event loop should continue running
@@ -246,6 +239,7 @@ impl<Io> EventLoop<Io>
                 PollOpt::edge() | PollOpt::oneshot()
             ).expect("reregister fd after channel recv");
         }
+
         true
     }
 
@@ -287,14 +281,11 @@ impl<Io> EventLoop<Io>
                         // Doing this check in !terminal.dirty will prevent the
                         // condition from being checked overzealously.
                         //
-                        // We want to break if `drain_recv_channel` returns either `Ok(true)`
-                        // (new items came in for writing) or `Err` (we need to shut down)
+                        // Break if `drain_recv_channel` signals there is work to do or
+                        // shutting down.
                         if state.writing.is_some()
                             || !state.write_list.is_empty()
-                            || match self.drain_recv_channel(state) {
-                                DrainResult::Shutdown | DrainResult::ReceivedItem => true,
-                                _ => false
-                            }
+                            || !self.drain_recv_channel(state).is_empty()
                         {
                             break;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use alacritty::cli;
 use alacritty::config::{self, Config};
 use alacritty::display::Display;
 use alacritty::event;
-use alacritty::event_loop::{self, EventLoop};
+use alacritty::event_loop::{self, EventLoop, Msg};
 use alacritty::logging;
 use alacritty::sync::FairMutex;
 use alacritty::term::{Term};
@@ -126,7 +126,7 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
     //
     // Need the Rc<RefCell<_>> here since a ref is shared in the resize callback
     let mut processor = event::Processor::new(
-        event_loop::Notifier(loop_tx),
+        event_loop::Notifier(event_loop.channel()),
         display.resize_channel(),
         &options,
         &config,
@@ -177,6 +177,8 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
             break;
         }
     }
+
+    loop_tx.send(Msg::Shutdown).expect("Error sending shutdown to event loop");
 
     // FIXME patch notify library to have a shutdown method
     // config_reloader.join().ok();


### PR DESCRIPTION
Background:

If a shell process exits with children still alive (typically due to the
`disown` shell builtin), POLLHUP will not be sent to the master PTY file
descriptor. This is due to the fact that the disowned process still has
the slave PTY open as its STDIN, STDOUT, and STDERR.

If a disowned process never reads or writes from its file descriptors
(which is often the case for graphical applications), the event loop
will end up blocking on poll()/select() when not handling user input
received over the mio channel. When Alacritty shuts down and joins on the
event loop thread, there can never be any more input on the mio channel -
the main thread is no longer handling user keystrokes from the window. Unless
a disowned process happens to access its slave PTY file descriptors, the
event loop will never get the chance to deetect that it should exit.

This commit extends the `Msg` enum to include an explicit `Shutdown`
message, which ensures a clean shutdown (e.g. closing the 'recording'
file). This allows the select()/poll() call to remain blocking, instead
of needing to periodically check the shutdown state in between
timed-out calls.

Fixes #339