### PR TITLE
Fix #573. Ensure we don't write 0 bytes to pty

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -60,6 +60,10 @@ impl event::Notify for Notifier {
         where B: Into<Cow<'static, [u8]>>
     {
         let bytes = bytes.into();
+        // terminal hangs if we send 0 bytes through.
+        if bytes.len() == 0 {
+            return
+        }
         match self.0.send(Msg::Input(bytes)) {
             Ok(_) => (),
             Err(_) => panic!("expected send event loop msg"),


### PR DESCRIPTION
On macOS, pasting 0 bytes from the clipboard hangs the terminal.
I.e. `pbcopy </dev/null` followed by ctrl-v. This ensures
we never send 0 bytes.