### PR TITLE
Find and set $WINDOWID to X11 window ID

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -335,4 +335,8 @@ impl Display {
             api.clear();
         });
     }
+
+    pub fn get_window_id(&self) -> Option<usize> {
+        self.window.get_window_id()
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,12 +98,15 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
     let terminal = Term::new(&config, display.size().to_owned());
     let terminal = Arc::new(FairMutex::new(terminal));
 
+    // Find the window ID for setting $WINDOWID
+    let window_id = display.get_window_id();
+
     // Create the pty
     //
     // The pty forks a process to run the shell on the slave side of the
     // pseudoterminal. A file descriptor for the master side is retained for
     // reading/writing to the shell.
-    let mut pty = tty::new(&config, &options, display.size());
+    let mut pty = tty::new(&config, &options, display.size(), window_id);
 
     // Create the pseudoterminal I/O loop
     //

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -174,7 +174,7 @@ fn get_pw_entry(buf: &mut [i8; 1024]) -> Passwd {
 }
 
 /// Create a new tty and return a handle to interact with it.
-pub fn new<T: ToWinsize>(config: &Config, options: &Options, size: T) -> Pty {
+pub fn new<T: ToWinsize>(config: &Config, options: &Options, size: T, window_id: Option<usize>) -> Pty {
     let win = size.to_winsize();
     let mut buf = [0; 1024];
     let pw = get_pw_entry(&mut buf);
@@ -203,6 +203,9 @@ pub fn new<T: ToWinsize>(config: &Config, options: &Options, size: T) -> Pty {
     builder.env("SHELL", shell.program());
     builder.env("HOME", pw.dir);
     builder.env("TERM", "xterm-256color"); // default term until we can supply our own
+    if let Some(window_id) = window_id {
+        builder.env("WINDOWID", format!("{}", window_id));
+    }
     for (key, value) in config.env().iter() {
         builder.env(key, value);
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -304,6 +304,7 @@ impl Window {
         }
     }
 
+    #[cfg(not(target_os = "macos"))]
     pub fn get_window_id(&self) -> Option<usize> {
         use glutin::os::unix::WindowExt;
 
@@ -311,6 +312,11 @@ impl Window {
             Some(xlib_window) => Some(xlib_window as usize),
             None => None
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn get_window_id(&self) -> Option<usize> {
+        None
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -303,6 +303,15 @@ impl Window {
                                                 else { glutin::CursorState::Hide }).unwrap();
         }
     }
+
+    pub fn get_window_id(&self) -> Option<usize> {
+        use glutin::os::unix::WindowExt;
+
+        match self.glutin_window.get_xlib_window() {
+            Some(xlib_window) => Some(xlib_window as usize),
+            None => None
+        }
+    }
 }
 
 pub trait OsExtensions {


### PR DESCRIPTION
Closes issue #471.

The window ID is retrieved from Display (from Window) in `run` and passed to `tty::new`, which uses `builder.env` to set it.

```
ns ~> echo $WINDOWID
62914562
ns ~> xdotool getactivewindow
62914562
```