### PR TITLE
changes osx fallback symbol font style

### DIFF
--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -164,7 +164,8 @@ impl ::Rasterize for Rasterizer {
                 // fallbacks somehow.
                 {
                     let symbols = {
-                        let d = FontDesc::new("Apple Symbols".to_owned(), desc.style.clone());
+                        let fallback_style = Style::Description { slant:Slant::Normal, weight:Weight::Normal  } ;
+                        let d = FontDesc::new("Apple Symbols".to_owned(), fallback_style);
                         self.get_font(&d, size)?
                     };
                     font.fallbacks.push(symbols);


### PR DESCRIPTION
Previously, the fallback symbol font copied the style of the font from
the config. However, the only available style for the fallback symbol
font is Normal slant, Normal weight.