### PR TITLE
Add support for Beam, Underline cursors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "alacritty"
 version = "0.1.0"
 dependencies = [
+ "arraydeque 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -37,6 +38,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arraydeque"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "atty"
@@ -625,6 +635,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nom"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +757,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "odds"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "osmesa-sys"
@@ -1223,6 +1246,7 @@ dependencies = [
 [metadata]
 "checksum android_glue 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8289e9637439939cc92b1995b0972117905be88bc28116c86b64d6e589bcd38"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
+"checksum arraydeque 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "96e774cadb24c2245225280c6799793f9802b918a58a79615e9490607489a717"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
@@ -1287,6 +1311,7 @@ dependencies = [
 "checksum net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "bc01404e7568680f1259aa5729539f221cb1e6d047a0d9053cab4be8a73b5d67"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
+"checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum notify 2.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e0e7eec936337952c4228b023007528a33b2fa039d96c2e8f32d764221a9c07"
 "checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
@@ -1299,6 +1324,7 @@ dependencies = [
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
 "checksum objc-foundation 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
 "checksum objc_id 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4730aa1c64d722db45f7ccc4113a3e2c465d018de6db4d3e7dfe031e8c8a297"
+"checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d52571ddcb42e9c900c901a18d8d67e393df723fcd51dd59c5b1a85d0acb6cc"
 "checksum parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa12d706797d42551663426a45e2db2e0364bd1dbf6aeada87e89c5f981f43e9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.3"
 clap = "2.20"
 fnv = "1.0.5"
 unicode-width = "0.1.4"
-
+arraydeque = "0.2"
 clippy = { version = "0.0.104", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
@@ -44,6 +44,7 @@ default = ["err-println"]
 live-shader-reload = []
 err-println = []
 nightly = []
+bench = []
 
 [build-dependencies]
 gl_generator = "0.5"

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -102,6 +102,9 @@ pub trait Handler {
     /// OSC to set window title
     fn set_title(&mut self, &str) {}
 
+    /// Set the cursor style
+    fn set_cursor_style(&mut self, _: CursorStyle) {}
+
     /// A character to be displayed
     fn input(&mut self, _c: char) {}
 
@@ -259,6 +262,19 @@ pub trait Handler {
 
     /// Run the dectest routine
     fn dectest(&mut self) {}
+}
+
+/// Describes shape of cursor
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum CursorStyle {
+    /// Cursor is a block like `▒`
+    Block,
+
+    /// Cursor is an underscore like `_`
+    Underline,
+
+    /// Cursor is a vertical bar `⎸`
+    Beam,
 }
 
 /// Terminal modes
@@ -895,6 +911,16 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
             },
             's' => handler.save_cursor_position(),
             'u' => handler.restore_cursor_position(),
+            'q' => {
+                let style = match arg_or_default!(idx: 0, default: 0) {
+                    0 ... 2 => CursorStyle::Block,
+                    3 | 4 => CursorStyle::Underline,
+                    5 | 6 => CursorStyle::Beam,
+                    _ => unhandled!()
+                };
+
+                handler.set_cursor_style(style);
+            }
             _ => unhandled!(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 #![cfg_attr(feature = "clippy", deny(if_not_else))]
 #![cfg_attr(feature = "clippy", deny(wrong_pub_self_convention))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
+#![cfg_attr(all(test, feature = "bench"), feature(test))]
 
 #[macro_use] extern crate bitflags;
 #[macro_use] extern crate clap;
@@ -30,6 +31,7 @@
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))]
 extern crate x11_dl;
 
+extern crate arraydeque;
 extern crate cgmath;
 extern crate copypasta;
 extern crate errno;

--- a/src/term/cell.rs
+++ b/src/term/cell.rs
@@ -86,6 +86,17 @@ impl Cell {
         }
     }
 
+    /// Get foreground and background colors adjusted for INVERSE flag
+    ///
+    /// First color is the foreground, second color is the background.
+    pub fn colors(&self, force_invert: bool) -> (&Color, &Color) {
+        if self.flags.contains(INVERSE) || force_invert {
+            (&self.bg, &self.fg)
+        } else {
+            (&self.fg, &self.bg)
+        }
+    }
+
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.c == ' ' &&


### PR DESCRIPTION
Notable about this implementation is it takes a different approach for
managing cursor cells that previously. The terminal Grid is now
borrowed *immutably*. Instead of mutating Cells in the Grid, a list is
managed within the RenderableCellsIter. The cell at the cursor location
is skipped over, and instead cells are popped off a list of cursor
cells.

It would be good in the future to share some more code between the
different cursor style implementations for populating the cursor cells
list.

Supercedes #349.
Resolves #171.