### PR TITLE
Use cursor cell template when handling 'CSI X' escape sequence

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1495,7 +1495,7 @@ impl ansi::Handler for Term {
         let end = min(start + count, self.grid.num_cols() - 1);
 
         let row = &mut self.grid[self.cursor.point.line];
-        let template = self.empty_cell;
+        let template = self.cursor.template; // Cleared cells have current background color set
         for c in &mut row[start..end] {
             c.reset(&template);
         }


### PR DESCRIPTION
This ensures that the cleared cells are set to the proper background
color, which is the main usage of this escape sequence.

Fixes #612