### PR TITLE
Make Travis test alacritty on nightly Rust, but allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ os:
 rust:
   - 1.15.0
   - stable
+  - nightly
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rust: nightly
 
 script:
   - cargo test --no-default-features


### PR DESCRIPTION
This allows us to notice and report any regressions that have occured on
nightly, without requiring tests to pass on nightly for the entire build
to succeed.

The `fast_finish` flag will cause Travis to mark the build as successful
if the only builds still running are allowed to fail (e.g. `nightly`).
This allows us to manually inspect builds (or implement some form of
notifications) to see if any nightly regressions have occured, without
slowing down the overall build time.