### PR TITLE
Implement and use ansi attribute CancelBold

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -536,6 +536,8 @@ pub enum Attr {
     Hidden,
     /// Strikethrough text
     Strike,
+    /// Cancel bold
+    CancelBold,
     /// Cancel bold and dim
     CancelBoldDim,
     /// Cancel italic
@@ -872,6 +874,7 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
                         7 => Attr::Reverse,
                         8 => Attr::Hidden,
                         9 => Attr::Strike,
+                        21 => Attr::CancelBold,
                         22 => Attr::CancelBoldDim,
                         23 => Attr::CancelItalic,
                         24 => Attr::CancelUnderline,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1703,6 +1703,7 @@ impl ansi::Handler for Term {
             Attr::Reverse => self.cursor.template.flags.insert(cell::INVERSE),
             Attr::CancelReverse => self.cursor.template.flags.remove(cell::INVERSE),
             Attr::Bold => self.cursor.template.flags.insert(cell::BOLD),
+            Attr::CancelBold => self.cursor.template.flags.remove(cell::BOLD),
             Attr::Dim => self.cursor.template.flags.insert(cell::DIM),
             Attr::CancelBoldDim => self.cursor.template.flags.remove(cell::BOLD | cell::DIM),
             Attr::Italic => self.cursor.template.flags.insert(cell::ITALIC),


### PR DESCRIPTION
While playing around with ansi.rs I noticed that CancelBold was not implemented, so I would like to fix that upstream as well.