### PR TITLE
Canonicalize the config watching path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1410,9 +1410,10 @@ impl Monitor {
             _thread: ::util::thread::spawn_named("config watcher", move || {
                 let (tx, rx) = mpsc::channel();
                 let mut watcher = FileWatcher::new(tx).unwrap();
-                watcher.watch(&path).expect("watch alacritty yml");
+                let config_path = ::std::fs::canonicalize(path)
+                    .expect("canonicalize config path");
 
-                let config_path = path.as_path();
+                watcher.watch(&config_path).expect("watch alacritty yml");
 
                 loop {
                     let event = rx.recv().expect("watcher event");


### PR DESCRIPTION
This should resolve an issue where config behind a symlink was not being
properly reloaded when edited.