### PR TITLE
Don't panic when setting cursor visibility fails

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -274,11 +274,14 @@ impl Window {
     pub fn set_cursor_visible(&mut self, visible: bool) {
         if visible != self.cursor_visible {
             self.cursor_visible = visible;
-            self.window.set_cursor_state(if visible {
+            match self.window.set_cursor_state(if visible {
                 CursorState::Normal
             } else {
                 CursorState::Hide
-            }).unwrap();
+            }) {
+                Ok(()) => {},
+                Err(msg) => println!("Failed to set cursor visibility: {}", msg),
+            }
         }
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -274,13 +274,12 @@ impl Window {
     pub fn set_cursor_visible(&mut self, visible: bool) {
         if visible != self.cursor_visible {
             self.cursor_visible = visible;
-            match self.window.set_cursor_state(if visible {
+            if let Err(err) = self.window.set_cursor_state(if visible {
                 CursorState::Normal
             } else {
                 CursorState::Hide
             }) {
-                Ok(()) => {},
-                Err(msg) => println!("Failed to set cursor visibility: {}", msg),
+                warn!("Failed to set cursor visibility: {}", err);
             }
         }
     }


### PR DESCRIPTION
Currently setting cursor visibility always fails on Wayland. It shouldn't be a critical error on any platform.