### PR TITLE
Implement an option to not start the config_monitor thread

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -278,6 +278,9 @@ selection:
 
 hide_cursor_when_typing: false
 
+# Live config reload (changes require restart)
+live_config_reload: true
+
 # Shell
 #
 # You can set shell.program to the path of your favorite shell, e.g. /bin/fish.

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -273,6 +273,9 @@ selection:
 
 hide_cursor_when_typing: false
 
+# Live config reload (changes require restart)
+live_config_reload: true
+
 # Shell
 #
 # You can set shell.program to the path of your favorite shell, e.g. /bin/fish.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,7 @@ const DEFAULT_TITLE: &'static str = "Alacritty";
 
 /// Options specified on the command line
 pub struct Options {
+    pub live_config_reload: Option<bool>,
     pub print_events: bool,
     pub ref_test: bool,
     pub dimensions: Option<Dimensions>,
@@ -35,6 +36,7 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Options {
         Options {
+            live_config_reload: None,
             print_events: false,
             ref_test: false,
             dimensions: None,
@@ -59,6 +61,11 @@ impl Options {
             .arg(Arg::with_name("ref-test")
                 .long("ref-test")
                 .help("Generates ref test"))
+            .arg(Arg::with_name("live-config-reload")
+                .long("live-config-reload")
+                .help("Live configuration reload")
+                .takes_value(true)
+                .use_delimiter(false))
             .arg(Arg::with_name("print-events")
                 .long("print-events"))
             .arg(Arg::with_name("dimensions")
@@ -105,6 +112,14 @@ impl Options {
 
         if matches.is_present("print-events") {
             options.print_events = true;
+        }
+
+        if let Some(val) = matches.value_of("live-config-reload") {
+            match val {
+                "y" | "yes" => options.live_config_reload = Some(true),
+                "n" | "no"  => options.live_config_reload = Some(false),
+                _           => options.live_config_reload = None,
+            }
         }
 
         if let Some(mut dimensions) = matches.values_of("dimensions") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -277,6 +277,10 @@ pub struct Config {
     /// Hide cursor when typing
     #[serde(default)]
     hide_cursor_when_typing: bool,
+
+    /// Live config reload
+    #[serde(default)]
+    live_config_reload: bool,
 }
 
 fn default_padding() -> Delta {
@@ -329,6 +333,7 @@ impl Default for Config {
             visual_bell: Default::default(),
             env: Default::default(),
             hide_cursor_when_typing: Default::default(),
+            live_config_reload: Default::default(),
             padding: default_padding(),
         }
     }
@@ -1175,6 +1180,12 @@ impl Config {
     #[inline]
     pub fn hide_cursor_when_typing(&self) -> bool {
         self.hide_cursor_when_typing
+    }
+
+    /// Live config reload
+    #[inline]
+    pub fn live_config_reload(&self) -> bool {
+        self.live_config_reload
     }
 
     pub fn load_from<P: Into<PathBuf>>(path: P) -> Result<Config> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,8 +148,15 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
     //
     // The monitor watches the config file for changes and reloads it. Pending
     // config changes are processed in the main loop.
-    let config_monitor = config.path()
-        .map(|path| config::Monitor::new(path, display.notifier()));
+    let config_monitor = match (options.live_config_reload, config.live_config_reload()) {
+        // Start monitor if CLI flag says yes
+        (Some(true), _) |
+        // Or if no CLI flag was passed and the config says yes
+        (None, true) => config.path()
+                .map(|path| config::Monitor::new(path, display.notifier())),
+        // Otherwise, don't start the monitor
+        _ => None,
+    };
 
     // Kick off the I/O thread
     let io_thread = event_loop.spawn(None);


### PR DESCRIPTION
I normally have a lot of terminals open and don't really care if they can reload the latest configuration or not.

It seems that I'm not alone on this, hence this PR.

CC: #670 