### PR TITLE
Touchpad scroll fix (do not merge!)

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -145,7 +145,8 @@ pub struct Mouse {
     pub scroll_px: i32,
     pub line: Line,
     pub column: Column,
-    pub cell_side: Side
+    pub cell_side: Side,
+    pub lines_scrolled: f32,
 }
 
 impl Default for Mouse {
@@ -160,6 +161,7 @@ impl Default for Mouse {
             line: Line(0),
             column: Column(0),
             cell_side: Side::Left,
+            lines_scrolled: 0.0,
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -352,15 +352,18 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
         match delta {
             MouseScrollDelta::LineDelta(_columns, lines) => {
-                let code = if lines > 0.0 {
+                let to_scroll = self.ctx.mouse_mut().lines_scrolled + lines;
+
+                let code = if to_scroll > 0.0 {
                     64
                 } else {
                     65
                 };
 
-                for _ in 0..(lines.abs() as usize) {
+                for _ in 0..(to_scroll.abs() as usize) {
                     self.normal_mouse_report(code);
                 }
+                self.ctx.mouse_mut().lines_scrolled = to_scroll % 1.0;
             },
             MouseScrollDelta::PixelDelta(_x, y) => {
                 match phase {


### PR DESCRIPTION
This is an RFC PR to fix #721, my first attempt at modifying a Rust application that people use and my first foray into Alacritty's code. As such there are a few issues with how it's implemented — I'm not happy with how the scrolling state is duplicated across `event::Processor` and `input::ActionContext` (although this might be appropriate?), the names I've used are terrible and I've added a dumb implementation of the state function to what is as far as I can tell a stub implementation of `ActionContext` for testing purposes. I'd love to get some feedback on where this stuff should go and what it should look like!