### PR TITLE
rebased mystal:transparency with master

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -158,6 +158,9 @@ visual_bell:
   animation: EaseOutExpo
   duration: 0
 
+# Background opacity
+background_opacity: 1.0
+
 # Key bindings
 #
 # Each binding is defined as an object with some properties. Most of the

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -158,6 +158,9 @@ visual_bell:
   animation: EaseOutExpo
   duration: 0
 
+# Background opacity
+background_opacity: 1.0
+
 # Key bindings
 #
 # Each binding is defined as an object with some properties. Most of the

--- a/font/src/darwin/byte_order.rs
+++ b/font/src/darwin/byte_order.rs
@@ -24,25 +24,33 @@ pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Little;
 pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Big;
 
 #[cfg(target_endian = "little")]
-pub fn extract_rgb(bytes: Vec<u8>) -> Vec<u8> {
+pub fn extract_rgba(bytes: Vec<u8>) -> Vec<u8> {
     let pixels = bytes.len() / 4;
-    let mut rgb = Vec::with_capacity(pixels * 3);
+    let mut rgba = Vec::with_capacity(pixels * 4);
 
     for i in 0..pixels {
         let offset = i * 4;
-        rgb.push(bytes[offset + 2]);
-        rgb.push(bytes[offset + 1]);
-        rgb.push(bytes[offset + 0]);
+        rgba.push(bytes[offset + 2]);
+        rgba.push(bytes[offset + 1]);
+        rgba.push(bytes[offset + 0]);
+        rgba.push(bytes[offset + 3]);
     }
 
-    rgb
+    rgba
 }
 
 #[cfg(target_endian = "big")]
-pub fn extract_rgb(bytes: Vec<u8>) -> Vec<u8> {
-    bytes.into_iter()
-         .enumerate()
-         .filter(|&(index, _)| ((index) % 4) != 0)
-         .map(|(_, val)| val)
-         .collect::<Vec<_>>()
+pub fn extract_rgba(bytes: Vec<u8>) -> Vec<u8> {
+    let pixels = bytes.len() / 4;
+    let mut rgba = Vec::with_capacity(pixels * 4);
+
+    for i in 0..pixels {
+        let offset = i * 4;
+        rgba.push(bytes[offset + 1]);
+        rgba.push(bytes[offset + 2]);
+        rgba.push(bytes[offset + 3]);
+        rgba.push(bytes[offset + 0]);
+    }
+
+    rgba
 }

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -46,7 +46,7 @@ use super::{FontDesc, RasterizedGlyph, Metrics, FontKey, GlyphKey};
 
 pub mod byte_order;
 use self::byte_order::kCGBitmapByteOrder32Host;
-use self::byte_order::extract_rgb;
+use self::byte_order::extract_rgba;
 
 use super::Size;
 
@@ -487,7 +487,7 @@ impl Font {
             kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host
         );
 
-        // Give the context an opaque, black background
+        // Give the context a clear, black background
         cg_context.set_rgb_fill_color(0.0, 0.0, 0.0, 1.0);
         let context_rect = CGRect::new(
             &CGPoint::new(0.0, 0.0),
@@ -525,7 +525,7 @@ impl Font {
 
         let rasterized_pixels = cg_context.data().to_vec();
 
-        let buf = extract_rgb(rasterized_pixels);
+        let buf = extract_rgba(rasterized_pixels);
 
         Ok(RasterizedGlyph {
             c: character,

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -230,12 +230,14 @@ impl FreeTypeRasterizer {
         let pitch = bitmap.pitch().abs() as usize;
         match bitmap.pixel_mode()? {
             PixelMode::Lcd => {
-                for i in 0..bitmap.rows() {
-                    let start = (i as usize) * pitch;
-                    let stop = start + bitmap.width() as usize;
-                    packed.extend_from_slice(&buf[start..stop]);
+                for x in 0..(bitmap.width() / 3) {
+                    let start = (y as usize * pitch) + (x as usize * 3);
+                    packed.extend_from_slice(&buf[start..start + 3]);
+                    // Append an alpha channel for this pixel.
+                    packed.push(255);
                 }
                 Ok((bitmap.width() / 3, packed))
+
             },
             // Mono data is stored in a packed format using 1 bit per pixel.
             PixelMode::Mono => {

--- a/res/text.f.glsl
+++ b/res/text.f.glsl
@@ -21,15 +21,17 @@ flat in int background;
 layout(location = 0, index = 0) out vec4 color;
 layout(location = 0, index = 1) out vec4 alphaMask;
 
+uniform float bgOpacity;
 uniform sampler2D mask;
 
 void main()
 {
     if (background != 0) {
         alphaMask = vec4(1.0, 1.0, 1.0, 1.0);
-        color = vec4(bg + vb, 1.0);
+        color = vec4(bg + vb, bgOpacity);
     } else {
-        alphaMask = vec4(texture(mask, TexCoords).rgb, 1.0);
+        vec3 textColor = texture(mask, TexCoords).rgb;
+        alphaMask = vec4(textColor, textColor.r);
         color = vec4(fg, 1.0);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,6 +173,40 @@ impl<'a> Shell<'a> {
     }
 }
 
+/// Wrapper around f32 that represents an alpha value between 0.0 and 1.0
+#[derive(Clone, Copy, Debug)]
+pub struct Alpha(f32);
+
+impl Alpha {
+    pub fn new(value: f32) -> Self {
+        Alpha(Self::clamp_to_valid_range(value))
+    }
+
+    pub fn set(&mut self, value: f32) {
+        self.0 = Self::clamp_to_valid_range(value);
+    }
+
+    pub fn get(&self) -> f32 {
+        self.0
+    }
+
+    fn clamp_to_valid_range(value: f32) -> f32 {
+        if value < 0.0 {
+            0.0
+        } else if value > 1.0 {
+            1.0
+        } else {
+            value
+        }
+    }
+}
+
+impl Default for Alpha {
+    fn default() -> Self {
+        Alpha(1.0)
+    }
+}
+
 /// Top-level config type
 #[derive(Debug, Deserialize)]
 pub struct Config {
@@ -210,6 +244,10 @@ pub struct Config {
 
     #[serde(default)]
     colors: Colors,
+
+    // Background opacity from 0.0 to 1.0
+    #[serde(default)]
+    background_opacity: Alpha,
 
     /// Keybindings
     #[serde(default="default_key_bindings")]
@@ -281,6 +319,7 @@ impl Default for Config {
             render_timer: Default::default(),
             custom_cursor_colors: false,
             colors: Default::default(),
+            background_opacity: Default::default(),
             key_bindings: Vec::new(),
             mouse_bindings: Vec::new(),
             selection: Default::default(),
@@ -696,6 +735,15 @@ impl de::Deserialize for RawBinding {
     }
 }
 
+impl de::Deserialize for Alpha {
+    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where D: de::Deserializer
+    {
+        let value = f32::deserialize(deserializer)?;
+        Ok(Alpha::new(value))
+    }
+}
+
 impl de::Deserialize for MouseBinding {
     fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
         where D: de::Deserializer
@@ -1036,6 +1084,10 @@ impl Config {
     /// array for performance.
     pub fn colors(&self) -> &Colors {
         &self.colors
+    }
+
+    pub fn background_opacity(&self) -> Alpha {
+        self.background_opacity
     }
 
     pub fn key_bindings(&self) -> &[KeyBinding] {

--- a/src/window.rs
+++ b/src/window.rs
@@ -186,7 +186,8 @@ impl Window {
 
         Window::platform_window_init();
         let window = WindowBuilder::new()
-            .with_title(title);
+            .with_title(title)
+            .with_transparency(true);
         let context = ContextBuilder::new()
             .with_vsync(true);
         let window = ::glutin::GlWindow::new(window, context, &event_loop)?;


### PR DESCRIPTION
This is a rebase of mystal transparency work here:
https://github.com/jwilm/alacritty/pull/331

Mystal seems to be busy with other work so I decided to go ahead and rebase this with the current code accordingly.

This code has been tested accordingly on a fresh master on osx 10.12.6 and seems to be working as expected.