### PR TITLE
Support more color escape codes

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -82,17 +82,17 @@ fn parse_number(input: &[u8]) -> Option<u8> {
     if input.is_empty() {
         return None;
     }
-    let mut index: u8 = 0;
+    let mut num: u8 = 0;
     for c in input {
         let c = *c as char;
         if let Some(digit) = c.to_digit(10) {
-            index *= 10;
-            index += digit as u8;
+            num *= 10;
+            num += digit as u8;
         } else {
             return None;
         }
     }
-    Some(index)
+    Some(num)
 }
 
 /// The processor wraps a `vte::Parser` to ultimately call methods on a Handler

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -787,6 +787,19 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
                 }
             }
 
+            // Set text cursor color
+            b"12" => {
+                if params.len() < 2 {
+                    return unhandled!();
+                }
+
+                if let Some(color) = parse_rgb_color(params[1]) {
+                    self.handler.set_color(NamedColor::Cursor as usize, color);
+                } else {
+                    unhandled!()
+                }
+            }
+
             // Reset foreground color
             b"110" => {
                 self.handler.reset_color(NamedColor::Foreground as usize);
@@ -795,6 +808,11 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
             // Reset background color
             b"111" => {
                 self.handler.reset_color(NamedColor::Background as usize);
+            }
+
+            // Reset text cursor color
+            b"112" => {
+                self.handler.reset_color(NamedColor::Cursor as usize);
             }
 
             _ => {

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -744,18 +744,20 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
 
             // Set color index
             b"4" => {
-                if params.len() < 3 {
+                if params.len() == 1 || params.len() % 2 == 0 {
                     return unhandled!();
                 }
 
-                if let Some(index) = parse_number(params[1]) {
-                    if let Some(color) = parse_rgb_color(params[2]) {
-                        self.handler.set_color(index as usize, color);
+                for chunk in params[1..].chunks(2) {
+                    if let Some(index) = parse_number(chunk[0]) {
+                        if let Some(color) = parse_rgb_color(chunk[1]) {
+                            self.handler.set_color(index as usize, color);
+                        } else {
+                            unhandled!();
+                        }
                     } else {
                         unhandled!();
                     }
-                } else {
-                    unhandled!();
                 }
             }
 


### PR DESCRIPTION
This should fix #743. However some codes like those related to highlight color
are not implemented because they are not (yet) supported by the application.
Also intrestingly, there doesn't seem to be an escape code for changing cursor
foreground color, only the background color.