### PR TITLE
Support bitmap fonts

### DIFF
--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -149,7 +149,7 @@ impl ::Rasterize for Rasterizer {
         Ok(font.metrics())
     }
 
-    fn load_font(&mut self, desc: &FontDesc, size: Size) -> Result<FontKey, Error> {
+    fn load_font(&mut self, desc: &FontDesc, size: Size) -> Result<(FontKey, Size), Error> {
         self.keys
             .get(&(desc.to_owned(), size))
             .map(|k| Ok(*k))
@@ -176,7 +176,7 @@ impl ::Rasterize for Rasterizer {
                 self.fonts.insert(key, font);
                 self.keys.insert((desc.clone(), size), key);
 
-                Ok(key)
+                Ok((key, size))
             })
     }
 

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -235,7 +235,7 @@ pub trait Rasterize {
     fn metrics(&self, FontKey) -> Result<Metrics, Self::Err>;
 
     /// Load the font described by `FontDesc` and `Size`
-    fn load_font(&mut self, &FontDesc, Size) -> Result<FontKey, Self::Err>;
+    fn load_font(&mut self, &FontDesc, Size) -> Result<(FontKey, Size), Self::Err>;
 
     /// Rasterize the glyph described by `GlyphKey`.
     fn get_glyph(&mut self, &GlyphKey) -> Result<RasterizedGlyph, Self::Err>;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -195,38 +195,38 @@ impl GlyphCache {
         // Load regular font
         let regular_desc = make_desc(&font.normal, font::Slant::Normal, font::Weight::Normal);
 
-        let regular = rasterizer
+        let (regular, font_size) = rasterizer
             .load_font(&regular_desc, size)?;
 
         // helper to load a description if it is not the regular_desc
         let load_or_regular = |desc:FontDesc, rasterizer: &mut Rasterizer| {
             if desc == regular_desc {
-                regular
+                (regular, font_size)
             } else {
-                rasterizer.load_font(&desc, size).unwrap_or_else(|_| regular)
+                rasterizer.load_font(&desc, size).unwrap_or_else(|_| (regular, font_size))
             }
         };
 
         // Load bold font
         let bold_desc = make_desc(&font.bold, font::Slant::Normal, font::Weight::Bold);
 
-        let bold = load_or_regular(bold_desc, &mut rasterizer);
+        let (bold, _) = load_or_regular(bold_desc, &mut rasterizer);
 
         // Load italic font
         let italic_desc = make_desc(&font.italic, font::Slant::Italic, font::Weight::Normal);
 
-        let italic = load_or_regular(italic_desc, &mut rasterizer);
+        let (italic, _) = load_or_regular(italic_desc, &mut rasterizer);
 
         // Need to load at least one glyph for the face before calling metrics.
         // The glyph requested here ('m' at the time of writing) has no special
         // meaning.
-        rasterizer.get_glyph(&GlyphKey { font_key: regular, c: 'm', size: font.size() })?;
+        rasterizer.get_glyph(&GlyphKey { font_key: regular, c: 'm', size: font_size })?;
         let metrics = rasterizer.metrics(regular)?;
 
         let mut cache = GlyphCache {
             cache: HashMap::default(),
             rasterizer: rasterizer,
-            font_size: font.size(),
+            font_size: font_size,
             font_key: regular,
             bold_key: bold,
             italic_key: italic,
@@ -240,7 +240,7 @@ impl GlyphCache {
                     cache.get(&GlyphKey {
                         font_key: $font,
                         c: i as char,
-                        size: font.size()
+                        size: font_size,
                     }, loader);
                 }
             }


### PR DESCRIPTION
To allow FontConfig to work with Bitmap font, we shall pass the size
we are interested in, and account for the size returned in the font
matching process. This is, because we cannot scale those fonts.

FontConfig will return the closest match, and we take its returned
pixel size back when we are rendering the glyphs.

There's an oddity when call set_char_size in `freetype2` - we need to
behave as if the DPI is 72. It is due to the following macro:

    #define FT_REQUEST_HEIGHT( req )                                        \
          ( (req)->vertResolution                                           \
              ? ( (req)->height * (FT_Pos)(req)->vertResolution + 36 ) / 72 \
              : (req)->height )

Further work can allow for integer scaling of the largest bitmap
font varient.

Tested with Terminus PCF-type font under Linux.

This addresses issue #582 .