### PR TITLE
Support web notation for hex colors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -970,8 +970,11 @@ impl FromStr for Rgb {
             }
         }
 
-        if chars.next().unwrap() != '0' { return Err(()); }
-        if chars.next().unwrap() != 'x' { return Err(()); }
+        match chars.next().unwrap() {
+            '0' => if chars.next().unwrap() != 'x' { return Err(()); },
+            '#' => (),
+            _ => return Err(()),
+        }
 
         component!(r, g, b);
 


### PR DESCRIPTION
Just checking if you would be interested in this.
Not being able to just use the more common format of specifying hex colors has bugged me for a while now.

This is my first contribution to a Rust project in any form, so please be gentle 🙂 