### PR TITLE
Update Solus deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Alacritty. Here's a `eopkg` command that should install all of them. If
 something is still found to be missing, please open an issue.
 
 ```sh
-sudo eopkg install freetype2-devel fontconfig-devel
+sudo eopkg install fontconfig-devel
 ```
 
 ### NixOS/Nixpkgs


### PR DESCRIPTION
Removed freetype2-devel, it isn't necessary given fontconfig-devel depends on freetype2-devel, just as it depends on expat-devel.