### PR TITLE
Use a wildcard dependency for clippy, and start fixing warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.155 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.164 (registry+https://github.com/rust-lang/crates.io-index)",
  "copypasta 0.0.1",
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -150,19 +150,19 @@ dependencies = [
 
 [[package]]
 name = "clippy"
-version = "0.0.155"
+version = "0.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.155 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.164 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.155"
+version = "0.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -856,7 +856,7 @@ version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1338,8 +1338,8 @@ dependencies = [
 "checksum cgl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86765cb42c2a2c497e142af72517c1b4d7ae5bb2f25dfa77a5c69642f2342d89"
 "checksum cgmath 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2372c02a7cfabf871ec42ecc968406a7b5916bcfd51defc6a0498fcb19fa2e5"
 "checksum clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2267a8fdd4dce6956ba6649e130f62fb279026e5e84b92aa939ac8f85ce3f9f0"
-"checksum clippy 0.0.155 (registry+https://github.com/rust-lang/crates.io-index)" = "03ba983d61af163f1b3ccc31cf1eb4925e62264bdfdc4b6b7f2d8fa6b7cd30ec"
-"checksum clippy_lints 0.0.155 (registry+https://github.com/rust-lang/crates.io-index)" = "315166a7e8c0fa313d852dd9d156857ffdfd40aad7989df4b2035970a1a31f6a"
+"checksum clippy 0.0.164 (registry+https://github.com/rust-lang/crates.io-index)" = "e0e65e4e7970d79aaa7c729e2e5b0a98d570cb6de0cad02573bfc055231201f5"
+"checksum clippy_lints 0.0.164 (registry+https://github.com/rust-lang/crates.io-index)" = "10dd44eb151418e02e548b9401a11976c0fd68dd17644b4a58a3ab5a96c9ac0f"
 "checksum cmake 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8a6541a55bcd72d3de4faee2d101a5a66df29790282c7f797082a7228a9b3d"
 "checksum cocoa 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4047fed6536f40cc2ae5e7834fb38e382c788270191c4cd69196f89686d076ce"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
@@ -1367,14 +1367,14 @@ dependencies = [
 "checksum fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a772d36c338d07a032d5375a36f15f9a7043bf0cb8ce7cee658e037c6032874"
 "checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
 "checksum gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "65256ec4dc2592e6f05bfc1ca3b956a4e0698aa90b1dff1f5687d55a5a3fd59a"
-"checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
+"checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum gl_generator 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e7acbf2ba3d52e9e1ad96a84362129e9c1aa0af55ebfc86a91004e1b83eca61c"
 "checksum gleam 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "bf887141f0c2a83eae026cbf3fba74f0a5cb0f01d20e5cdfcd8c4ad39295be1e"
 "checksum glutin 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cee1543cf7efce742534d31c024d8dd1aa0e8944d36ebdd7dfccdb80b84700d"
 "checksum heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "556cd479866cf85c3f671209c85e8a6990211c916d1002c2fcb2e9b7cf60bc36"
 "checksum inotify 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887fcc180136e77a85e6a6128579a719027b1bab9b1c38ea4444244fe262c20c"
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
-"checksum itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22c285d60139cf413244894189ca52debcfd70b57966feed060da76802e415a0"
+"checksum itertools 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ab4d6a273c31ef276c917019239588b23bc696f277af8db10742cba3c27ec2f0"
 "checksum itoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac17257442c2ed77dbc9fd555cf83c58b0c7f7d0e8f2ae08c0ac05c72842e1f6"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d5a08e2a31d665af8f1ca437eab6d00a93c9d62a549f73f9ed8fc2e55b5a91a7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ fnv = "1"
 unicode-width = "0.1.4"
 arraydeque = "0.2.3"
 glutin = "0.9.2"
-clippy = { version = "0.0.155", optional = true }
+clippy = { version = "*", optional = true }
+
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
 x11-dl = "2"

--- a/copypasta/src/x11.rs
+++ b/copypasta/src/x11.rs
@@ -137,7 +137,7 @@ impl Clipboard {
             .stdin(Stdio::piped())
             .spawn()?;
 
-        if let Some(mut stdin) = child.stdin.as_mut() {
+        if let Some(stdin) = child.stdin.as_mut() {
             stdin.write_all(contents.as_bytes())?;
         }
 

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -30,8 +30,9 @@ extern crate core_foundation;
 extern crate core_foundation_sys;
 #[cfg(target_os = "macos")]
 extern crate core_graphics;
-
+#[cfg(target_os = "macos")]
 extern crate euclid;
+
 extern crate libc;
 
 #[cfg(not(target_os = "macos"))]

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -909,7 +909,7 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
             'm' => {
                 // Sometimes a C-style for loop is just what you need
                 let mut i = 0; // C-for initializer
-                if args.len() == 0 {
+                if args.is_empty() {
                     handler.terminal_attribute(Attr::Reset);
                     return;
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,8 +123,8 @@ impl Options {
         }
 
         if let Some(mut dimensions) = matches.values_of("dimensions") {
-            let width = dimensions.next().map(|w| w.parse().map(|w| Column(w)));
-            let height = dimensions.next().map(|h| h.parse().map(|h| Line(h)));
+            let width = dimensions.next().map(|w| w.parse().map(Column));
+            let height = dimensions.next().map(|h| h.parse().map(Line));
             if let (Some(Ok(width)), Some(Ok(height))) = (width, height) {
                 options.dimensions = Some(Dimensions::new(width, height));
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,7 +79,7 @@ impl Default for Mouse {
     }
 }
 
-/// VisulBellAnimations are modeled after a subset of CSS transitions and Robert
+/// `VisualBellAnimations` are modeled after a subset of CSS transitions and Robert
 /// Penner's Easing Functions.
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub enum VisualBellAnimation {

--- a/src/display.rs
+++ b/src/display.rs
@@ -259,7 +259,7 @@ impl Display {
             terminal.resize(w as f32, h as f32);
             let size = terminal.size_info();
 
-            for mut item in items {
+            for item in items {
                 item.on_resize(size)
             }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -359,7 +359,7 @@ impl<'a, T> IntoIterator for &'a mut Row<T> {
     type IntoIter = slice::IterMut<'a, T>;
 
     #[inline]
-    fn into_iter(mut self) -> slice::IterMut<'a, T> {
+    fn into_iter(self) -> slice::IterMut<'a, T> {
         self.iter_mut()
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -267,9 +267,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
         if line < Line(223) && column < Column(223) {
             let msg = vec![
-                '\x1b' as u8,
-                '[' as u8,
-                'M' as u8,
+                b'\x1b',
+                b'[',
+                b'M',
                 32 + button,
                 32 + 1 + column.0 as u8,
                 32 + 1 + line.0 as u8,
@@ -443,7 +443,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 *self.ctx.received_count() = 0;
                 *self.ctx.suppress_chars() = false;
 
-                if self.process_key_bindings(&mods, key) {
+                if self.process_key_bindings(mods, key) {
                     *self.ctx.suppress_chars() = true;
                 }
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 //! Alacritty - The GPU Enhanced Terminal
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(feature = "clippy", deny(clippy))]
 #![cfg_attr(feature = "clippy", deny(enum_glob_use))]
 #![cfg_attr(feature = "clippy", deny(if_not_else))]
 #![cfg_attr(feature = "clippy", deny(wrong_pub_self_convention))]
@@ -103,6 +102,7 @@ impl Mul<f32> for Rgb {
 
 #[cfg_attr(feature = "clippy", allow(too_many_arguments))]
 #[cfg_attr(feature = "clippy", allow(doc_markdown))]
+#[cfg_attr(feature = "clippy", allow(unreadable_literal))]
 pub mod gl {
     #![allow(non_upper_case_globals)]
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -43,11 +43,9 @@ impl<T: Send + io::Write> log::Log for Logger<T> {
     }
 
     fn log(&self, record: &log::LogRecord) {
-        if self.enabled(record.metadata()) {
-            if record.target().starts_with("alacritty") {
-                if let Ok(ref mut writer) = self.output.lock() {
-                    let _ = writer.write(format!("{}\n", record.args()).as_ref());
-                }
+        if self.enabled(record.metadata()) && record.target().starts_with("alacritty") {
+            if let Ok(ref mut writer) = self.output.lock() {
+                writer.write_all(format!("{}\n", record.args()).as_ref()).expect("Error while logging!");
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn run(mut config: Config, options: cli::Options) -> Result<(), Box<Error>> {
     // synchronized since the I/O loop updates the state, and the display
     // consumes it periodically.
     let event_loop = EventLoop::new(
-        terminal.clone(),
+        Arc::clone(&terminal),
         display.notifier(),
         pty.reader(),
         options.ref_test,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -588,7 +588,7 @@ impl QuadRenderer {
         while let Ok(msg) = self.rx.try_recv() {
             match msg {
                 Msg::ShaderReload => {
-                    self.reload_shaders(&config, Size {
+                    self.reload_shaders(config, Size {
                         width: Pixels(props.width as u32),
                         height: Pixels(props.height as u32)
                     });

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1566,7 +1566,7 @@ impl ansi::Handler for Term {
     #[inline]
     fn save_cursor_position(&mut self) {
         trace!("CursorSave");
-        let mut cursor = if self.alt {
+        let cursor = if self.alt {
             &mut self.cursor_save_alt
         } else {
             &mut self.cursor_save

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -183,9 +183,9 @@ pub fn new<T: ToWinsize>(config: &Config, options: &Options, size: T, window_id:
 
     let default_shell = &Shell::new(pw.shell);
     let shell = config.shell()
-        .unwrap_or(&default_shell);
+        .unwrap_or(default_shell);
 
-    let initial_command = options.command().unwrap_or(&shell);
+    let initial_command = options.command().unwrap_or(shell);
 
     let mut builder = Command::new(initial_command.program());
     for arg in initial_command.args() {

--- a/src/window.rs
+++ b/src/window.rs
@@ -192,10 +192,10 @@ impl Window {
             .with_vsync(true);
         let window = ::glutin::GlWindow::new(window, context, &event_loop)?;
 
-        /// Set OpenGL symbol loader
+        // Set OpenGL symbol loader
         gl::load_with(|symbol| window.get_proc_address(symbol) as *const _);
 
-        /// Make the context current so OpenGL operations can run
+        // Make the context current so OpenGL operations can run
         unsafe {
             window.make_current()?;
         }
@@ -294,10 +294,10 @@ impl Window {
         use libc::{setlocale, LC_CTYPE};
         let xlib = xlib::Xlib::open().expect("get xlib");
         unsafe {
-            /// Use empty c string to fallback to LC_CTYPE in environment variables
+            // Use empty c string to fallback to LC_CTYPE in environment variables
             setlocale(LC_CTYPE, b"\0".as_ptr() as *const _);
-            /// Use empty c string for implementation dependent behavior,
-            /// which might be the XMODIFIERS set in env
+            // Use empty c string for implementation dependent behavior,
+            // which might be the XMODIFIERS set in env
             (xlib.XSetLocaleModifiers)(b"\0".as_ptr() as *const _);
         }
     }


### PR DESCRIPTION
Because there are so many clippy warnings in the current codebase,
this commit removes '#![cfg_attr(feature = "clippy", deny(clippy))]',
to make it easier to fix warnings incrementally.