### PR TITLE
Set urgent WM flag on bell on X11 systems

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -282,6 +282,14 @@ impl Display {
             self.window.set_title(&title);
         }
 
+        if let Some(is_urgent) = terminal.next_is_urgent.take() {
+            // We don't need to set the urgent flag if we already have the
+            // user's attention.
+            if !is_urgent || !self.window.is_focused {
+                self.window.set_urgent(is_urgent);
+            }
+        }
+
         let size_info = *terminal.size_info();
         let visual_bell_intensity = terminal.visual_bell.intensity();
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -319,6 +319,7 @@ impl<N: Notify> Processor<N> {
 
                         if is_focused {
                             processor.ctx.terminal.dirty = true;
+                            processor.ctx.terminal.next_is_urgent = Some(false);
                         } else {
                             *hide_cursor = false;
                         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -243,6 +243,7 @@ impl<N: Notify> Processor<N> {
         ref_test: bool,
         resize_tx: &mpsc::Sender<(u32, u32)>,
         hide_cursor: &mut bool,
+        window_is_focused: &mut bool,
     ) {
         match event {
             // Pass on device events
@@ -314,6 +315,8 @@ impl<N: Notify> Processor<N> {
                         processor.ctx.terminal.dirty = true;
                     },
                     Focused(is_focused) => {
+                        *window_is_focused = is_focused;
+
                         if is_focused {
                             processor.ctx.terminal.dirty = true;
                         } else {
@@ -387,6 +390,8 @@ impl<N: Notify> Processor<N> {
                 mouse_bindings: &self.mouse_bindings[..],
             };
 
+            let mut window_is_focused = window.is_focused;
+
             // Scope needed to that hide_cursor isn't borrowed after the scope
             // ends.
             {
@@ -401,6 +406,7 @@ impl<N: Notify> Processor<N> {
                         ref_test,
                         resize_tx,
                         hide_cursor,
+                        &mut window_is_focused,
                     );
                 };
 
@@ -414,6 +420,8 @@ impl<N: Notify> Processor<N> {
             if self.hide_cursor_when_typing {
                 window.set_cursor_visible(!self.hide_cursor);
             }
+
+            window.is_focused = window_is_focused;
 
             if processor.ctx.selection_modified {
                 processor.ctx.terminal.dirty = true;

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -661,6 +661,7 @@ pub struct Term {
     pub dirty: bool,
 
     pub visual_bell: VisualBell,
+    pub next_is_urgent: Option<bool>,
 
     /// Saved cursor from main grid
     cursor_save: Cursor,
@@ -763,6 +764,7 @@ impl Term {
             next_title: None,
             dirty: false,
             visual_bell: VisualBell::new(config),
+            next_is_urgent: None,
             input_needs_wrap: false,
             grid: grid,
             alt_grid: alt,
@@ -1426,6 +1428,7 @@ impl ansi::Handler for Term {
     fn bell(&mut self) {
         trace!("bell");
         self.visual_bell.ring();
+        self.next_is_urgent = Some(true);
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -39,6 +39,9 @@ pub struct Window {
     event_loop: EventsLoop,
     window: glutin::GlWindow,
     cursor_visible: bool,
+
+    /// Whether or not the window is the focused window.
+    pub is_focused: bool,
 }
 
 /// Threadsafe APIs for the window
@@ -204,6 +207,7 @@ impl Window {
             event_loop: event_loop,
             window: window,
             cursor_visible: true,
+            is_focused: true,
         };
 
         window.run_os_extensions();


### PR DESCRIPTION
This patch adds support for setting the urgent flag on systems using X11
when a terminal bell occurs.

When the window becomes focused, we will clear the urgent flag since not
all WMs will clear it automatically.

Fixes #181