### PR TITLE
Fix render issues on macOS

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -247,8 +247,8 @@ impl Display {
         });
 
         let metrics = cache.font_metrics();
-        self.size_info.cell_width = (metrics.average_advance + config.font().offset().x as f64) as f32;
-        self.size_info.cell_height = (metrics.line_height + config.font().offset().y as f64) as f32;
+        self.size_info.cell_width = ((metrics.average_advance + config.font().offset().x as f64) as f32).floor();
+        self.size_info.cell_height = ((metrics.line_height + config.font().offset().y as f64) as f32).floor();
     }
 
     #[inline]


### PR DESCRIPTION
Parts of neighboring glyphs in the atlas were being rendered
incorrectly. The issue is resolved by aligning cells to the pixel grid.

This behavior was achieved previously by first applying integer
truncation before casting to a float.

Fixes #844.