### PR TITLE
Don't enforce window dimensions if configured with 0 columns or lines

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -15,6 +15,7 @@ env:
   TERM: xterm-256color
 
 # Window dimensions in character columns and lines
+# Falls back to size specified by window manager if set to 0x0.
 # (changes require restart)
 dimensions:
   columns: 80

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,8 @@ impl Options {
                 .long("dimensions")
                 .short("d")
                 .value_names(&["columns", "lines"])
-                 .help("Defines the window dimensions. Falls back to size specified by window manager if set to 0x0 [default: 80x24]"))
+                .help("Defines the window dimensions. Falls back to size specified by \
+                       window manager if set to 0x0 [default: 80x24]"))
             .arg(Arg::with_name("title")
                 .long("title")
                 .short("t")
@@ -97,7 +98,8 @@ impl Options {
             .arg(Arg::with_name("config-file")
                  .long("config-file")
                  .takes_value(true)
-                 .help("Specify alternative configuration file [default: $XDG_CONFIG_HOME/alacritty/alacritty.yml]"))
+                 .help("Specify alternative configuration file \
+                       [default: $XDG_CONFIG_HOME/alacritty/alacritty.yml]"))
             .arg(Arg::with_name("command")
                 .long("command")
                 .short("e")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,7 @@ impl Options {
                 .long("dimensions")
                 .short("d")
                 .value_names(&["columns", "lines"])
-                .help("Defines the window dimensions [default: 80x24]"))
+                 .help("Defines the window dimensions. Falls back to size specified by window manager if set to 0x0 [default: 80x24]"))
             .arg(Arg::with_name("title")
                 .long("title")
                 .short("t")

--- a/src/display.rs
+++ b/src/display.rs
@@ -139,7 +139,7 @@ impl Display {
         // Create the window where Alacritty will be displayed
         let mut window = Window::new(&options.title)?;
 
-        // get window properties for initializing the other subsytems
+        // get window properties for initializing the other subsystems
         let mut viewport_size = window.inner_size_pixels()
             .expect("glutin returns window size");
         let dpr = window.hidpi_factor();
@@ -155,17 +155,17 @@ impl Display {
 
         let dimensions = options.dimensions()
             .unwrap_or_else(|| config.dimensions());
-        
+
         // Resize window to specified dimensions unless one or both dimensions are 0
         if dimensions.columns_u32() > 0 && dimensions.lines_u32() > 0 {
             let width = cell_width as u32 * dimensions.columns_u32();
             let height = cell_height as u32 * dimensions.lines_u32();
-            
+
             let new_viewport_size = Size {
                 width: Pixels(width + 2 * config.padding().x as u32),
                 height: Pixels(height + 2 * config.padding().y as u32),
             };
-            
+
             window.set_inner_size(&new_viewport_size);
             renderer.resize(new_viewport_size.width.0 as _, new_viewport_size.height.0 as _);
             viewport_size = new_viewport_size


### PR DESCRIPTION
Currently alacritty always enforces the starting window size based on the dimensions specified as an option or in the configuration file. This presents a problem for me, because I use XMonad to create the window with a certain size and in a certain position based on the size of the screen.

However, since alacritty forces itself into a certain size instead of allowing the window manager to dictate the size of the window, it makes alacritty difficult to integrate into my workflow as the window always resizes itself to something else. This pull request essentially falls back to using the existing size of the window when either the `width` or the `height` dimension properties are less than or equal to zero.

This will allow me to specify `-d 0 0` in order to tell alacritty not to resize itself at all.

Thanks!