### PR TITLE
fix warning on mac caused by set_urgent

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -348,7 +348,7 @@ impl Window {
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd")))]
-    pub fn set_urgent(&self, is_urgent: bool) {
+    pub fn set_urgent(&self, _: bool) {
     }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]


### PR DESCRIPTION
On mac, compiling throws a warning due to `is_urgent` not being used within `set_urgent`. This can be changed just by using an underscore instead.
I'm aware of how much of a non-issue this is, but still it's nice to not see any warnings when compiling.