### PR TITLE
Add a config option to send or not send ESC when ALT-key is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `alt_send_esc` option for controlling if alt key should send escape sequences
+
 ### Changed
 
 - All options in the configuration file are now optional

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -352,6 +352,9 @@ live_config_reload: true
 # backend cannot be initialized.
 enable_experimental_conpty_backend: false
 
+# Send ESC (\x1b) before characters when alt is pressed.
+alt_send_esc: true
+
 # Key bindings
 #
 # Key bindings are specified as a list of objects. Each binding will specify a

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -538,6 +538,10 @@ pub struct Config {
     #[serde(default, deserialize_with = "failure_default")]
     enable_experimental_conpty_backend: bool,
 
+    /// Send escape sequences using the alt key.
+    #[serde(default = "default_true_bool", deserialize_with = "deserialize_true_bool")]
+    alt_send_esc: bool,
+
     // TODO: DEPRECATED
     custom_cursor_colors: Option<bool>,
 
@@ -1817,6 +1821,12 @@ impl Config {
     #[inline]
     pub fn enable_experimental_conpty_backend(&self) -> bool {
         self.enable_experimental_conpty_backend
+    }
+
+    /// Send escape sequences using the alt key
+    #[inline]
+    pub fn alt_send_esc(&self) -> bool {
+        self.alt_send_esc
     }
 
     // Update the history size, used in ref tests

--- a/src/event.rs
+++ b/src/event.rs
@@ -293,6 +293,7 @@ pub struct Processor<N> {
     pending_events: Vec<Event>,
     window_changes: WindowChanges,
     save_to_clipboard: bool,
+    alt_send_esc: bool,
 }
 
 /// Notify that the terminal was resized
@@ -337,6 +338,7 @@ impl<N: Notify> Processor<N> {
             pending_events: Vec::with_capacity(4),
             window_changes: Default::default(),
             save_to_clipboard: config.selection().save_to_clipboard,
+            alt_send_esc: config.alt_send_esc(),
         }
     }
 
@@ -518,6 +520,7 @@ impl<N: Notify> Processor<N> {
                 key_bindings: &self.key_bindings[..],
                 mouse_bindings: &self.mouse_bindings[..],
                 save_to_clipboard: self.save_to_clipboard,
+                alt_send_esc: self.alt_send_esc,
             };
 
             let mut window_is_focused = window.is_focused;
@@ -573,5 +576,6 @@ impl<N: Notify> Processor<N> {
         self.mouse_bindings = config.mouse_bindings().to_vec();
         self.mouse_config = config.mouse().to_owned();
         self.save_to_clipboard = config.selection().save_to_clipboard;
+        self.alt_send_esc = config.alt_send_esc();
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -49,6 +49,7 @@ pub struct Processor<'a, A: 'a> {
     pub scrolling_config: &'a config::Scrolling,
     pub ctx: A,
     pub save_to_clipboard: bool,
+    pub alt_send_esc: bool,
 }
 
 pub trait ActionContext {
@@ -742,7 +743,11 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 c.encode_utf8(&mut bytes[..]);
             }
 
-            if *self.ctx.received_count() == 0 && self.ctx.last_modifiers().alt && utf8_len == 1 {
+            if self.alt_send_esc
+                && *self.ctx.received_count() == 0
+                && self.ctx.last_modifiers().alt
+                && utf8_len == 1
+            {
                 bytes.insert(0, b'\x1b');
             }
 
@@ -977,6 +982,7 @@ mod tests {
                     key_bindings: &config.key_bindings()[..],
                     mouse_bindings: &config.mouse_bindings()[..],
                     save_to_clipboard: config.selection().save_to_clipboard,
+                    alt_send_esc: config.alt_send_esc(),
                 };
 
                 if let Event::WindowEvent { event: WindowEvent::MouseInput { state, button, modifiers, .. }, .. } = $input {


### PR DESCRIPTION
In some keyboard layouts, some characters like @, {}, [], etc.. requires the ALT-key. Sending the escape character when the ALT-key i pressed, makes it hard to enter those characters.

Therefore I think it's a good idea to choose wether to send the escape character or not. This PR should fix that.