### PR TITLE
Wait to display window until initialization is complete

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -197,6 +197,9 @@ impl Display {
             api.clear(background_color);
         });
 
+        // Show the window now that it's been initialized
+        window.show();
+
         Ok(Display {
             window: window,
             renderer: renderer,

--- a/src/window.rs
+++ b/src/window.rs
@@ -190,7 +190,8 @@ impl Window {
         Window::platform_window_init();
         let window = WindowBuilder::new()
             .with_title(title)
-            .with_transparency(true);
+            .with_transparency(true)
+            .with_visibility(false);
         let context = ContextBuilder::new()
             .with_vsync(true);
         let window = ::glutin::GlWindow::new(window, context, &event_loop)?;
@@ -264,6 +265,10 @@ impl Window {
     #[inline]
     pub fn resize(&self, width: u32, height: u32) {
         self.window.resize(width, height);
+    }
+
+    pub fn show(&self) {
+        self.window.show();
     }
 
     /// Block waiting for events


### PR DESCRIPTION
Helps to address #297.

Patch waits to display window until initial configuration is complete. This prevents the window from visually resizing.

Gif demonstration:

![test2](https://user-images.githubusercontent.com/1291012/32991608-8c62b2fa-cd0c-11e7-9a68-4d156f9386d1.gif)

In the current release, the window will snap and resize as it configures. In the second case, it hides while configuring.

Unfortunately, this doesn't seem to fix the initial blink of black for the screen, but it does help to address some of the "flickering" during startup.

