### PR TITLE
Add cursor style option

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -201,6 +201,14 @@ selection:
 
 hide_cursor_when_typing: false
 
+# Style of the cursor (changes require restart)
+#
+# Values for 'cursor_style':
+# - Block
+# - Underline
+# - Beam
+cursor_style: Block
+
 # Live config reload (changes require restart)
 live_config_reload: true
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -201,7 +201,7 @@ selection:
 
 hide_cursor_when_typing: false
 
-# Style of the cursor (changes require restart)
+# Style of the cursor
 #
 # Values for 'cursor_style':
 # - Block

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -182,7 +182,7 @@ selection:
 
 hide_cursor_when_typing: false
 
-# Style of the cursor (changes require restart)
+# Style of the cursor
 #
 # Values for 'cursor_style':
 # - Block

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -182,6 +182,14 @@ selection:
 
 hide_cursor_when_typing: false
 
+# Style of the cursor (changes require restart)
+#
+# Values for 'cursor_style':
+# - Block
+# - Underline
+# - Beam
+cursor_style: Block
+
 # Live config reload (changes require restart)
 live_config_reload: true
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -179,7 +179,7 @@ pub trait Handler {
     fn set_title(&mut self, &str) {}
 
     /// Set the cursor style
-    fn set_cursor_style(&mut self, _: CursorStyle) {}
+    fn set_cursor_style(&mut self, _: Option<CursorStyle>) {}
 
     /// A character to be displayed
     fn input(&mut self, _c: char) {}
@@ -1076,9 +1076,10 @@ impl<'a, H, W> vte::Perform for Performer<'a, H, W>
             'u' => handler.restore_cursor_position(),
             'q' => {
                 let style = match arg_or_default!(idx: 0, default: 0) {
-                    0 ... 2 => CursorStyle::Block,
-                    3 | 4 => CursorStyle::Underline,
-                    5 | 6 => CursorStyle::Beam,
+                    0 => None,
+                    1 | 2 => Some(CursorStyle::Block),
+                    3 | 4 => Some(CursorStyle::Underline),
+                    5 | 6 => Some(CursorStyle::Beam),
                     _ => unhandled!()
                 };
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -344,7 +344,7 @@ pub trait Handler {
 }
 
 /// Describes shape of cursor
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize)]
 pub enum CursorStyle {
     /// Cursor is a block like `▒`
     Block,
@@ -354,6 +354,12 @@ pub enum CursorStyle {
 
     /// Cursor is a vertical bar `⎸`
     Beam,
+}
+
+impl Default for CursorStyle {
+    fn default() -> CursorStyle {
+        CursorStyle::Block
+    }
 }
 
 /// Terminal modes

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ use glutin::ModifiersState;
 
 use input::{Action, Binding, MouseBinding, KeyBinding};
 use index::{Line, Column};
+use ansi::CursorStyle;
 
 use util::fmt::Yellow;
 
@@ -275,6 +276,10 @@ pub struct Config {
     #[serde(default)]
     hide_cursor_when_typing: bool,
 
+    /// Style of the cursor
+    #[serde(default)]
+    cursor_style: CursorStyle,
+
     /// Live config reload
     #[serde(default="true_bool")]
     live_config_reload: bool,
@@ -329,6 +334,7 @@ impl Default for Config {
             visual_bell: Default::default(),
             env: Default::default(),
             hide_cursor_when_typing: Default::default(),
+            cursor_style: Default::default(),
             live_config_reload: true,
             padding: default_padding(),
         }
@@ -1177,6 +1183,12 @@ impl Config {
     #[inline]
     pub fn hide_cursor_when_typing(&self) -> bool {
         self.hide_cursor_when_typing
+    }
+
+    /// Style of the cursor
+    #[inline]
+    pub fn cursor_style(&self) -> CursorStyle {
+        self.cursor_style
     }
 
     /// Live config reload

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -708,7 +708,11 @@ pub struct Term {
     /// Original colors from config
     original_colors: color::List,
 
+    /// Current style of the cursor
     cursor_style: CursorStyle,
+
+    /// Default style for resetting the cursor
+    default_cursor_style: CursorStyle,
 }
 
 /// Terminal size info
@@ -811,6 +815,7 @@ impl Term {
             original_colors: color::List::from(config.colors()),
             semantic_escape_chars: config.selection().semantic_escape_chars.clone(),
             cursor_style: config.cursor_style(),
+            default_cursor_style: config.cursor_style(),
         }
     }
 
@@ -1869,9 +1874,13 @@ impl ansi::Handler for Term {
     }
 
     #[inline]
-    fn set_cursor_style(&mut self, style: CursorStyle) {
+    fn set_cursor_style(&mut self, style: Option<CursorStyle>) {
         trace!("set_cursor_style {:?}", style);
-        self.cursor_style = style;
+        self.cursor_style = if let Some(cursor_style) = style {
+            cursor_style
+        } else {
+            self.default_cursor_style
+        };
     }
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -709,7 +709,7 @@ pub struct Term {
     original_colors: color::List,
 
     /// Current style of the cursor
-    cursor_style: CursorStyle,
+    cursor_style: Option<CursorStyle>,
 
     /// Default style for resetting the cursor
     default_cursor_style: CursorStyle,
@@ -814,7 +814,7 @@ impl Term {
             color_modified: [false; color::COUNT],
             original_colors: color::List::from(config.colors()),
             semantic_escape_chars: config.selection().semantic_escape_chars.clone(),
-            cursor_style: config.cursor_style(),
+            cursor_style: None,
             default_cursor_style: config.cursor_style(),
         }
     }
@@ -840,6 +840,7 @@ impl Term {
             }
         }
         self.visual_bell.update_config(config);
+        self.default_cursor_style = config.cursor_style();
     }
 
     #[inline]
@@ -1008,7 +1009,7 @@ impl Term {
             self.mode,
             config,
             selection,
-            self.cursor_style,
+            self.cursor_style.unwrap_or(self.default_cursor_style),
         )
     }
 
@@ -1876,11 +1877,7 @@ impl ansi::Handler for Term {
     #[inline]
     fn set_cursor_style(&mut self, style: Option<CursorStyle>) {
         trace!("set_cursor_style {:?}", style);
-        self.cursor_style = if let Some(cursor_style) = style {
-            cursor_style
-        } else {
-            self.default_cursor_style
-        };
+        self.cursor_style = style;
     }
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -773,7 +773,7 @@ impl Term {
         self.next_title.take()
     }
 
-    pub fn new(config : &Config, size: SizeInfo) -> Term {
+    pub fn new(config: &Config, size: SizeInfo) -> Term {
         let template = Cell::default();
 
         let num_cols = size.cols();
@@ -810,7 +810,7 @@ impl Term {
             color_modified: [false; color::COUNT],
             original_colors: color::List::from(config.colors()),
             semantic_escape_chars: config.selection().semantic_escape_chars.clone(),
-            cursor_style: CursorStyle::Block,
+            cursor_style: config.cursor_style(),
         }
     }
 


### PR DESCRIPTION
This makes it possible to change the default cursor style of the
terminal. It requires a restart to apply the changes.

When vim or a different terminal application changes the cursor, it is
not reset. But I wouldn't say that's an issue with alacritty, but rather
with the terminal application.