### PR TITLE
Add custom underline, beam and box cursors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,4 @@
-[[package]]
-name = "aho-corasick"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
+[root]
 name = "alacritty"
 version = "0.1.0"
 dependencies = [
@@ -29,14 +21,22 @@ dependencies = [
  "notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vte 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -113,8 +113,8 @@ name = "cargo_metadata"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -184,8 +184,8 @@ dependencies = [
  "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -370,7 +370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1021,22 +1021,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1062,7 +1062,7 @@ dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1072,7 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1231,7 +1231,7 @@ name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1633,9 +1633,9 @@ dependencies = [
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
-"checksum serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "1c57ab4ec5fa85d08aaf8ed9245899d9bbdd66768945b21113b84d5f595cb6a1"
-"checksum serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "02c92ea07b6e49b959c1481804ebc9bfd92d3c459f1274c9a9546829e42a66ce"
-"checksum serde_derive_internals 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75c6aac7b99801a16db5b40b7bf0d7e4ba16e76fbf231e32a4677f271cac0603"
+"checksum serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "386122ba68c214599c44587e0c0b411e8d90894503a95425b4f9508e4317901f"
+"checksum serde_derive 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "ec0bfa6c5784e7d110514448da0e1dbad41ea5514c3e68be755b23858b83a399"
+"checksum serde_derive_internals 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "730fe9f29fe8db69a601837f416e46cba07792031ed6b27557a43e49d62d89ae"
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
 "checksum serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7cf5b0b5b4bd22eeecb7e01ac2e1225c7ef5e4272b79ee28a8392a8c8489c839"
 "checksum serde_yaml 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f868d400d9d13d00988da49f7f02aeac6ef00f11901a8c535bd59d777b9e19"

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -470,8 +470,8 @@ impl Font {
                 let width = self.glyph_advance('0') as i32;
                 // Return the new custom glyph
                 return super::get_underline_cursor_glyph(descent, width);
-            },
-            super::BEAM_CURSOR_CHAR => {
+            }
+            super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
                 // Get the top of the bounding box
                 let metrics = self.metrics();
                 let height = metrics.line_height;
@@ -483,9 +483,13 @@ impl Font {
                 // Get the width of the cell
                 let width = self.glyph_advance('0') as i32;
                 // Return the new custom glyph
-                return super::get_beam_cursor_glyph(ascent as i32, height as i32, width);
-            },
-            _ => (),
+                if character == super::BEAM_CURSOR_CHAR {
+                    return super::get_beam_cursor_glyph(ascent as i32, height as i32, width);
+                } else {
+                    return super::get_box_cursor_glyph(ascent as i32, height as i32, width);
+                }
+            }
+            _ => ()
         }
 
         let glyph_index = self.glyph_index(character)

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -475,13 +475,11 @@ impl Font {
                 // Get the top of the bounding box
                 let metrics = self.metrics();
                 let height = metrics.line_height;
-                let mut ascent = height - self.ct_font.descent() + 1.;
-                if ascent.floor() == ascent {
-                    // Fix off-by-one with an exact X.0 ascent
-                    ascent -= 1.;
-                }
+                let ascent = (height - self.ct_font.descent()).ceil();
+
                 // Get the width of the cell
                 let width = self.glyph_advance('0') as i32;
+
                 // Return the new custom glyph
                 if character == super::BEAM_CURSOR_CHAR {
                     return super::get_beam_cursor_glyph(ascent as i32, height as i32, width);

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -461,6 +461,19 @@ impl Font {
     }
 
     pub fn get_glyph(&self, character: char, _size: f64, use_thin_strokes: bool) -> Result<RasterizedGlyph, Error> {
+        // Render custom symbols for underline and beam cursor
+        if character == super::UNDERLINE_CURSOR_CHAR {
+            let descent = -(self.ct_font.descent() as i32);
+            let width = self.glyph_advance('0') as i32;
+            return super::get_underline_cursor_glyph(descent, width);
+        } else if character == super::BEAM_CURSOR_CHAR {
+            let metrics = self.metrics();
+            let height = metrics.line_height;
+            let ascent = height - self.ct_font.descent() + 1.;
+            let width = self.glyph_advance('0') as i32;
+            return super::get_beam_cursor_glyph(ascent as i32, height as i32, width);
+        };
+
         let glyph_index = self.glyph_index(character)
             .ok_or(Error::MissingGlyph(character))?;
 

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -24,7 +24,7 @@ use libc::c_uint;
 
 pub mod fc;
 
-use super::{FontDesc, RasterizedGlyph, Metrics, Size, FontKey, GlyphKey, Weight, Slant, Style};
+use super::{FontDesc, RasterizedGlyph, Metrics, Size, FontKey, GlyphKey, Weight, Slant, Style, UNDERLINE_CURSOR_CHAR};
 
 struct FixedSize {
     pixelsize: f64,
@@ -295,7 +295,7 @@ impl FreeTypeRasterizer {
         let (pixel_width, buf) = Self::normalize_buffer(&glyph.bitmap())?;
 
         // Render a custom symbol for the underline cursor
-        if glyph_key.c == '􊏢' {
+        if glyph_key.c == UNDERLINE_CURSOR_CHAR {
             // Get the bottom of the bounding box
             let size_metrics = face.ft_face.size_metrics()
                 .ok_or(Error::MissingSizeMetrics)?;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -310,7 +310,7 @@ impl FreeTypeRasterizer {
                 // Return the new custom glyph
                 super::get_underline_cursor_glyph(descent, width)
             }
-            super::BEAM_CURSOR_CHAR => {
+            super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
                 // Get the top of the bounding box
                 let size_metrics = face.ft_face
                     .size_metrics()
@@ -326,7 +326,11 @@ impl FreeTypeRasterizer {
                 let width = (metrics.vertAdvance as f32 / 128.).round() as i32;
 
                 // Return the new custom glyph
-                super::get_beam_cursor_glyph(ascent, height, width)
+                if glyph_key.c == super::BEAM_CURSOR_CHAR {
+                    super::get_beam_cursor_glyph(ascent, height, width)
+                } else {
+                    super::get_box_cursor_glyph(ascent, height, width)
+                }
             }
             _ => {
                 // If it's not a special char, return the normal glyph

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -297,33 +297,37 @@ impl FreeTypeRasterizer {
         // Render a custom symbol for the underline and beam cursor
         match glyph_key.c {
             super::UNDERLINE_CURSOR_CHAR => {
-                // Get the bottom of the bounding box
+                // Get the primary face metrics
+                let face = self.faces.get(&FontKey { token: 0 }).unwrap();
                 let size_metrics = face.ft_face
                     .size_metrics()
                     .ok_or(Error::MissingSizeMetrics)?;
+
+                // Get the bottom of the bounding box
                 let descent = (size_metrics.descender / 64) as i32;
 
                 // Get the width of the cell
-                let metrics = glyph.metrics();
-                let width = (metrics.vertAdvance as f32 / 128.).round() as i32;
+                let width = (size_metrics.max_advance / 64) as i32;
 
                 // Return the new custom glyph
                 super::get_underline_cursor_glyph(descent, width)
             }
             super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
-                // Get the top of the bounding box
+                // Get the primary face metrics
+                let face = self.faces.get(&FontKey { token: 0 }).unwrap();
                 let size_metrics = face.ft_face
                     .size_metrics()
                     .ok_or(Error::MissingSizeMetrics)?;
-                let ascent = (size_metrics.ascender / 64) as i32 - 1;
 
                 // Get the height of the cell
+                let height = (size_metrics.height / 64) as i32;
+
+                // Get the top of the bounding box
                 let descent = (size_metrics.descender / 64) as i32;
-                let height = ascent - descent;
+                let ascent = height + descent;
 
                 // Get the width of the cell
-                let metrics = glyph.metrics();
-                let width = (metrics.vertAdvance as f32 / 128.).round() as i32;
+                let width = (size_metrics.max_advance / 64) as i32;
 
                 // Return the new custom glyph
                 if glyph_key.c == super::BEAM_CURSOR_CHAR {

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -298,7 +298,8 @@ impl FreeTypeRasterizer {
         match glyph_key.c {
             super::UNDERLINE_CURSOR_CHAR => {
                 // Get the bottom of the bounding box
-                let size_metrics = face.ft_face.size_metrics()
+                let size_metrics = face.ft_face
+                    .size_metrics()
                     .ok_or(Error::MissingSizeMetrics)?;
                 let descent = (size_metrics.descender / 64) as i32;
 
@@ -308,10 +309,11 @@ impl FreeTypeRasterizer {
 
                 // Return the new custom glyph
                 super::get_underline_cursor_glyph(descent, width)
-            },
+            }
             super::BEAM_CURSOR_CHAR => {
                 // Get the top of the bounding box
-                let size_metrics = face.ft_face.size_metrics()
+                let size_metrics = face.ft_face
+                    .size_metrics()
                     .ok_or(Error::MissingSizeMetrics)?;
                 let ascent = (size_metrics.ascender / 64) as i32 - 1;
 
@@ -325,7 +327,7 @@ impl FreeTypeRasterizer {
 
                 // Return the new custom glyph
                 super::get_beam_cursor_glyph(ascent, height, width)
-            },
+            }
             _ => {
                 // If it's not a special char, return the normal glyph
                 Ok(RasterizedGlyph {

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -298,7 +298,8 @@ impl FreeTypeRasterizer {
         match glyph_key.c {
             super::UNDERLINE_CURSOR_CHAR => {
                 // Get the primary face metrics
-                let face = self.faces.get(&FontKey { token: 0 }).unwrap();
+                // This always loads the default face
+                let face = self.faces.get(glyph_key.font_key)?;
                 let size_metrics = face.ft_face
                     .size_metrics()
                     .ok_or(Error::MissingSizeMetrics)?;
@@ -314,7 +315,8 @@ impl FreeTypeRasterizer {
             }
             super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
                 // Get the primary face metrics
-                let face = self.faces.get(&FontKey { token: 0 }).unwrap();
+                // This always loads the default face
+                let face = self.faces.get(glyph_key.font_key)?;
                 let size_metrics = face.ft_face
                     .size_metrics()
                     .ok_or(Error::MissingSizeMetrics)?;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -273,6 +273,54 @@ impl FreeTypeRasterizer {
 
     fn get_rendered_glyph(&mut self, glyph_key: &GlyphKey)
                           -> Result<RasterizedGlyph, Error> {
+        // Render a custom symbol for the underline and beam cursor
+        match glyph_key.c {
+            super::UNDERLINE_CURSOR_CHAR => {
+                // Get the primary face metrics
+                // This always loads the default face
+                let face = self.faces.get(&glyph_key.font_key).unwrap();
+                let size_metrics = face.ft_face
+                    .size_metrics()
+                    .ok_or(Error::MissingSizeMetrics)?;
+
+                // Get the bottom of the bounding box
+                let descent = (size_metrics.descender / 64) as i32;
+
+                // Get the width of the cell
+                let width = (size_metrics.max_advance / 64) as i32;
+
+                // Return the new custom glyph
+                return super::get_underline_cursor_glyph(descent, width);
+            },
+            super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
+                // Get the primary face metrics
+                // This always loads the default face
+                let face = self.faces.get(&glyph_key.font_key).unwrap();
+                let size_metrics = face.ft_face
+                    .size_metrics()
+                    .ok_or(Error::MissingSizeMetrics)?;
+
+                // Get the height of the cell
+                let height = (size_metrics.height / 64) as i32;
+
+                // Get the top of the bounding box
+                let descent = (size_metrics.descender / 64) as i32;
+                let ascent = height + descent;
+
+                // Get the width of the cell
+                let width = (size_metrics.max_advance / 64) as i32;
+
+                // Return the new custom glyph
+                return if glyph_key.c == super::BEAM_CURSOR_CHAR {
+                    super::get_beam_cursor_glyph(ascent, height, width)
+                } else {
+                    super::get_box_cursor_glyph(ascent, height, width)
+                };
+            },
+            _ => (),
+        }
+
+        // Render a normal character if it's not a cursor
         let font_key = self.face_for_glyph(glyph_key, false)?;
         let face = self.faces.get(&font_key).unwrap();
         let index = face.ft_face.get_char_index(glyph_key.c as usize);
@@ -294,62 +342,14 @@ impl FreeTypeRasterizer {
 
         let (pixel_width, buf) = Self::normalize_buffer(&glyph.bitmap())?;
 
-        // Render a custom symbol for the underline and beam cursor
-        match glyph_key.c {
-            super::UNDERLINE_CURSOR_CHAR => {
-                // Get the primary face metrics
-                // This always loads the default face
-                let face = self.faces.get(glyph_key.font_key)?;
-                let size_metrics = face.ft_face
-                    .size_metrics()
-                    .ok_or(Error::MissingSizeMetrics)?;
-
-                // Get the bottom of the bounding box
-                let descent = (size_metrics.descender / 64) as i32;
-
-                // Get the width of the cell
-                let width = (size_metrics.max_advance / 64) as i32;
-
-                // Return the new custom glyph
-                super::get_underline_cursor_glyph(descent, width)
-            }
-            super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
-                // Get the primary face metrics
-                // This always loads the default face
-                let face = self.faces.get(glyph_key.font_key)?;
-                let size_metrics = face.ft_face
-                    .size_metrics()
-                    .ok_or(Error::MissingSizeMetrics)?;
-
-                // Get the height of the cell
-                let height = (size_metrics.height / 64) as i32;
-
-                // Get the top of the bounding box
-                let descent = (size_metrics.descender / 64) as i32;
-                let ascent = height + descent;
-
-                // Get the width of the cell
-                let width = (size_metrics.max_advance / 64) as i32;
-
-                // Return the new custom glyph
-                if glyph_key.c == super::BEAM_CURSOR_CHAR {
-                    super::get_beam_cursor_glyph(ascent, height, width)
-                } else {
-                    super::get_box_cursor_glyph(ascent, height, width)
-                }
-            }
-            _ => {
-                // If it's not a special char, return the normal glyph
-                Ok(RasterizedGlyph {
-                    c: glyph_key.c,
-                    top: glyph.bitmap_top(),
-                    left: glyph.bitmap_left(),
-                    width: pixel_width,
-                    height: glyph.bitmap().rows(),
-                    buf: buf,
-                })
-            }
-        }
+        Ok(RasterizedGlyph {
+            c: glyph_key.c,
+            top: glyph.bitmap_top(),
+            left: glyph.bitmap_left(),
+            width: pixel_width,
+            height: glyph.bitmap().rows(),
+            buf: buf,
+        })
     }
 
     fn ft_load_flags(pat: &fc::Pattern) -> freetype::face::LoadFlag {

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -60,6 +60,7 @@ pub use darwin::*;
 
 /// Character used for the underline cursor
 #[cfg(not(target_os = "macos"))]
+// This is part of the private use area and should not conflict with any font
 pub const UNDERLINE_CURSOR_CHAR: char = '􊏢';
 #[cfg(target_os = "macos")]
 pub const UNDERLINE_CURSOR_CHAR: char = '▁';

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -58,6 +58,9 @@ mod darwin;
 #[cfg(target_os = "macos")]
 pub use darwin::*;
 
+/// Width/Height of the cursor relative to the font width
+pub const CURSOR_WIDTH_PERCENTAGE: i32 = 15;
+
 /// Character used for the underline cursor
 // This is part of the private use area and should not conflict with any font
 pub const UNDERLINE_CURSOR_CHAR: char = '\u{10a3e2}';
@@ -65,8 +68,10 @@ pub const UNDERLINE_CURSOR_CHAR: char = '\u{10a3e2}';
 /// Character used for the beam cursor
 // This is part of the private use area and should not conflict with any font
 pub const BEAM_CURSOR_CHAR: char = '\u{10a3e3}';
-/// Width of the beam cursor relative to the font width
-pub const BEAM_CURSOR_WIDTH_PERCENTAGE: i32 = 15;
+
+/// Character used for the empty box cursor
+// This is part of the private use area and should not conflict with any font
+pub const BOX_CURSOR_CHAR: char = '\u{10a3e4}';
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FontDesc {
@@ -214,9 +219,8 @@ impl Default for RasterizedGlyph {
 
 // Returns a custom underline cursor character
 pub fn get_underline_cursor_glyph(descent: i32, width: i32) -> Result<RasterizedGlyph, Error> {
-    // Create a new rectangle, the height is half the distance between
-    // bounding box bottom and the baseline
-    let height = cmp::max(i32::abs(descent / 2), 1);
+    // Create a new rectangle, the height is relative to the font width
+    let height = cmp::max(width * CURSOR_WIDTH_PERCENTAGE / 100, 1);
     let buf = vec![255u8; (width * height * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
@@ -237,7 +241,7 @@ pub fn get_beam_cursor_glyph(
     width: i32,
 ) -> Result<RasterizedGlyph, Error> {
     // Create a new rectangle that is at least one pixel wide
-    let beam_width = cmp::max(width * BEAM_CURSOR_WIDTH_PERCENTAGE / 100, 1);
+    let beam_width = cmp::max(width * CURSOR_WIDTH_PERCENTAGE / 100, 1);
     let buf = vec![255u8; (beam_width * height * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
@@ -247,6 +251,37 @@ pub fn get_beam_cursor_glyph(
         left: 0,
         height,
         width: beam_width,
+        buf: buf,
+    });
+}
+
+// Returns a custom beam cursor character
+pub fn get_box_cursor_glyph(
+    ascent: i32,
+    height: i32,
+    width: i32,
+) -> Result<RasterizedGlyph, Error> {
+    // Create a new box outline rectangle
+    let border_width = cmp::max(width * CURSOR_WIDTH_PERCENTAGE / 100, 1);
+    let mut buf = Vec::with_capacity((width * height * 3) as usize);
+    for y in 0..height {
+        for x in 0..width {
+            if y < border_width || y >= height - border_width ||
+               x < border_width || x >= width - border_width {
+                buf.append(&mut vec![255u8; 3]);
+            } else {
+                buf.append(&mut vec![0u8; 3]);
+            }
+        }
+    }
+
+    // Create a custom glyph with the rectangle data attached to it
+    return Ok(RasterizedGlyph {
+        c: BOX_CURSOR_CHAR,
+        top: ascent,
+        left: 0,
+        height,
+        width,
         buf: buf,
     });
 }

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -61,7 +61,7 @@ pub use darwin::*;
 /// Character used for the underline cursor
 #[cfg(not(target_os = "macos"))]
 // This is part of the private use area and should not conflict with any font
-pub const UNDERLINE_CURSOR_CHAR: char = '􊏢';
+pub const UNDERLINE_CURSOR_CHAR: char = '\u{10a3e2}';
 #[cfg(target_os = "macos")]
 pub const UNDERLINE_CURSOR_CHAR: char = '▁';
 

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -65,6 +65,13 @@ pub const UNDERLINE_CURSOR_CHAR: char = '\u{10a3e2}';
 #[cfg(target_os = "macos")]
 pub const UNDERLINE_CURSOR_CHAR: char = '▁';
 
+/// Character used for the beam cursor
+#[cfg(not(target_os = "macos"))]
+// This is part of the private use area and should not conflict with any font
+pub const BEAM_CURSOR_CHAR: char = '\u{10a3e3}';
+#[cfg(target_os = "macos")]
+pub const BEAM_CURSOR_CHAR: char = '▎';
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FontDesc {
     name: String,
@@ -207,6 +214,41 @@ impl Default for RasterizedGlyph {
             buf: Vec::new(),
         }
     }
+}
+
+// Returns a custom underline cursor character
+pub fn get_underline_cursor_glyph(descent: i32, width: i32) -> Result<RasterizedGlyph, Error> {
+    // Create a new rectangle, the height is half the distance between
+    // bounding box bottom and the baseline
+    let height = i32::abs(descent / 2);
+    let buf = vec![255u8; (width * height * 3) as usize];
+
+    // Create a custom glyph with the rectangle data attached to it
+    return Ok(RasterizedGlyph {
+        c: UNDERLINE_CURSOR_CHAR,
+        top: descent + height,
+        left: 0,
+        height,
+        width,
+        buf: buf,
+    });
+}
+
+// Returns a custom beam cursor character
+pub fn get_beam_cursor_glyph(ascent: i32, height: i32, width: i32) -> Result<RasterizedGlyph, Error> {
+    // Create a new rectangle
+    let beam_width = (f64::from(width) / 5.) as i32;
+    let buf = vec![255u8; (beam_width * height * 3) as usize];
+
+    // Create a custom glyph with the rectangle data attached to it
+    return Ok(RasterizedGlyph {
+        c: BEAM_CURSOR_CHAR,
+        top: ascent,
+        left: 0,
+        height,
+        width: beam_width,
+        buf: buf,
+    });
 }
 
 struct BufDebugger<'a>(&'a [u8]);

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -255,7 +255,7 @@ pub fn get_beam_cursor_glyph(
     });
 }
 
-// Returns a custom beam cursor character
+// Returns a custom box cursor character
 pub fn get_box_cursor_glyph(
     ascent: i32,
     height: i32,

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -58,6 +58,12 @@ mod darwin;
 #[cfg(target_os = "macos")]
 pub use darwin::*;
 
+/// Character used for the underline cursor
+#[cfg(not(target_os = "macos"))]
+pub const UNDERLINE_CURSOR_CHAR: char = '􊏢';
+#[cfg(target_os = "macos")]
+pub const UNDERLINE_CURSOR_CHAR: char = '▁';
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FontDesc {
     name: String,

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -59,18 +59,12 @@ mod darwin;
 pub use darwin::*;
 
 /// Character used for the underline cursor
-#[cfg(not(target_os = "macos"))]
 // This is part of the private use area and should not conflict with any font
 pub const UNDERLINE_CURSOR_CHAR: char = '\u{10a3e2}';
-#[cfg(target_os = "macos")]
-pub const UNDERLINE_CURSOR_CHAR: char = '▁';
 
 /// Character used for the beam cursor
-#[cfg(not(target_os = "macos"))]
 // This is part of the private use area and should not conflict with any font
 pub const BEAM_CURSOR_CHAR: char = '\u{10a3e3}';
-#[cfg(target_os = "macos")]
-pub const BEAM_CURSOR_CHAR: char = '▎';
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FontDesc {
@@ -217,6 +211,7 @@ impl Default for RasterizedGlyph {
 }
 
 // Returns a custom underline cursor character
+// TODO: Make sure this works with positive/0 descent -> small fonts
 pub fn get_underline_cursor_glyph(descent: i32, width: i32) -> Result<RasterizedGlyph, Error> {
     // Create a new rectangle, the height is half the distance between
     // bounding box bottom and the baseline
@@ -235,6 +230,7 @@ pub fn get_underline_cursor_glyph(descent: i32, width: i32) -> Result<Rasterized
 }
 
 // Returns a custom beam cursor character
+// TODO: Make sure this works with positive/0 descent -> small fonts
 pub fn get_beam_cursor_glyph(ascent: i32, height: i32, width: i32) -> Result<RasterizedGlyph, Error> {
     // Create a new rectangle
     let beam_width = (f64::from(width) / 5.) as i32;

--- a/src/display.rs
+++ b/src/display.rs
@@ -354,6 +354,7 @@ impl Display {
                 //
                 // TODO I wonder if the renderable cells iter could avoid the
                 // mutable borrow
+                let window_focused = self.window.is_focused;
                 self.renderer.with_api(config, &size_info, visual_bell_intensity, |mut api| {
                     // Clear screen to update whole background with new color
                     if background_color_changed {
@@ -361,7 +362,10 @@ impl Display {
                     }
 
                     // Draw the grid
-                    api.render_cells(terminal.renderable_cells(config, selection), glyph_cache);
+                    api.render_cells(
+                        terminal.renderable_cells(config, selection, window_focused),
+                        glyph_cache,
+                    );
                 });
             }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -330,6 +330,7 @@ impl<N: Notify> Processor<N> {
                             processor.ctx.terminal.dirty = true;
                             processor.ctx.terminal.next_is_urgent = Some(false);
                         } else {
+                            processor.ctx.terminal.dirty = true;
                             *hide_cursor = false;
                         }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -181,7 +181,7 @@ impl<'a> RenderableCellsIter<'a> {
         });
 
         let cursor_color = self.text_cursor_color(&cursor_cell);
-        cursor_cell.c = '▎';
+        cursor_cell.c = font::BEAM_CURSOR_CHAR;
         cursor_cell.fg = cursor_color;
         self.cursor_cells.push_back(Indexed {
             line: self.cursor.line,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -207,7 +207,8 @@ impl<'a> RenderableCellsIter<'a> {
         });
 
         let cursor_color = self.text_cursor_color(&cursor_cell);
-        cursor_cell.c = '▁';
+        // This is part of the private use area and shouldn't be used by any font
+        cursor_cell.c = '􊏢';
         cursor_cell.fg = cursor_color;
         self.cursor_cells.push_back(Indexed {
             line: self.cursor.line,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -208,7 +208,6 @@ impl<'a> RenderableCellsIter<'a> {
         });
 
         let cursor_color = self.text_cursor_color(&cursor_cell);
-        // This is part of the private use area and shouldn't be used by any font
         cursor_cell.c = font::UNDERLINE_CURSOR_CHAR;
         cursor_cell.fg = cursor_color;
         self.cursor_cells.push_back(Indexed {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 use arraydeque::ArrayDeque;
 use unicode_width::UnicodeWidthChar;
 
+use font;
 use ansi::{self, Color, NamedColor, Attr, Handler, CharsetIndex, StandardCharset, CursorStyle};
 use grid::{BidirectionalIterator, Grid, ClearRegion, ToRange, Indexed};
 use index::{self, Point, Column, Line, Linear, IndexRange, Contains, RangeInclusive};
@@ -208,7 +209,7 @@ impl<'a> RenderableCellsIter<'a> {
 
         let cursor_color = self.text_cursor_color(&cursor_cell);
         // This is part of the private use area and shouldn't be used by any font
-        cursor_cell.c = '􊏢';
+        cursor_cell.c = font::UNDERLINE_CURSOR_CHAR;
         cursor_cell.fg = cursor_color;
         self.cursor_cells.push_back(Indexed {
             line: self.cursor.line,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -136,12 +136,7 @@ impl<'a> RenderableCellsIter<'a> {
         }.initialize(cursor_style, window_focused)
     }
 
-    fn populate_block_cursor(&mut self, window_focused: bool) {
-        if !window_focused {
-            self.populate_cursor(font::BOX_CURSOR_CHAR, ' ');
-            return;
-        }
-
+    fn populate_block_cursor(&mut self) {
         let (text_color, cursor_color) = if self.config.custom_cursor_colors() {
             (
                 Color::Named(NamedColor::CursorText),
@@ -233,15 +228,20 @@ impl<'a> RenderableCellsIter<'a> {
 
     fn initialize(mut self, cursor_style: CursorStyle, window_focused: bool) -> Self {
         if self.cursor_is_visible() {
-            match cursor_style {
-                CursorStyle::Block => {
-                    self.populate_block_cursor(window_focused);
-                },
-                CursorStyle::Beam => {
-                    self.populate_beam_cursor();
-                },
-                CursorStyle::Underline => {
-                    self.populate_underline_cursor();
+            if !window_focused {
+                // Render the box cursor if the window is not focused
+                self.populate_cursor(font::BOX_CURSOR_CHAR, ' ');
+            } else {
+                match cursor_style {
+                    CursorStyle::Block => {
+                        self.populate_block_cursor();
+                    },
+                    CursorStyle::Beam => {
+                        self.populate_beam_cursor();
+                    },
+                    CursorStyle::Underline => {
+                        self.populate_underline_cursor();
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
As mentioned in jwilm/alacritty#931, it can be troublesome if a font has
an underline symbol outside of the glyph's bounding box. This can lead
to the underline disappearing at the bottom of the terminal.

As a solution a symbol from the private use area was used as the
character code for the underline symbol. Whenever this symbol is
encountered, instead of rendering it, a custom block is rendered.

In this implementation the block has the full character as width and
sits flush with the bottom of the glyph's bounding box. The height is
half the distance between the baseline and the bottom of the bounding
box.

Here are some screenshots of how this underline looks now:
![Small](https://u.teknik.io/58RVG.png)
![Normal](https://u.teknik.io/hDJSo.png)
![Big](https://u.teknik.io/PguV1.png)
![Huge](https://u.teknik.io/bW9dl.png)

This fixes #931 