### PR TITLE
Update README.md for current state of macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ makepkg -isr
 1. Alacritty requires the most recent stable Rust compiler; it can be installed with
    `rustup`.
 
-    Note: **DO NOT** use the Homebrew Rust compiler on macOS (see [FAQ][faq] for
-    explanation).
-
 #### Installing Rust compiler with `rustup`
 
 1. Install [`rustup.rs`](https://rustup.rs/).
@@ -208,8 +205,7 @@ cargo build --release
 
 If all goes well, this should place a binary at `target/release/alacritty`.
 **BEFORE YOU RUN IT:** Install the config file as described below; otherwise,
-many things (such as arrow keys) will not work. If you're on macOS, you'll need
-to change the `monospace` font family to something like `Menlo`.
+many things (such as arrow keys) will not work.
 
 ### Desktop Entry
 
@@ -260,9 +256,6 @@ Just Works.
 
 ## FAQ
 
-- _proc-macro derive panicked during macOS build; what's wrong?_ There's an
-  issue with the Rust compiler from Homebrew. Please follow the instructions
-  and use `rustup`.
 - _Is it really the fastest terminal emulator?_ In the terminals I've
   benchmarked against, alacritty is either faster, WAY faster, or at least
   neutral. There are no benchmarks in which I've found Alacritty to be slower.


### PR DESCRIPTION
Homebrew Rust will correctly compile `alacritty` now, and the monospace
font is automatically set to `Menlo` at first launch.