### PR TITLE
Add Void Linux to distrobutions with packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ built from source.
 ## Installation
 
 Instructions are provided for macOS and many Linux variants to compile Alacritty
-from source. With the exception of Arch (which has a package in the AUR) and
+from source. With the exception of Arch (which has a package in the AUR), Void Linux (in main repository) and
 [NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/alacritty/default.nix)
 (at the moment in unstable, will be part of 17.09), please first read the
 [prerequisites](#prerequisites) section, then find the section for your OS, and
@@ -48,6 +48,12 @@ finally go to [building](#building) and [configuration](#configuration).
 git clone https://aur.archlinux.org/alacritty-git.git
 cd alacritty-git
 makepkg -isr
+```
+
+### Void Linux
+
+```sh
+xbps-install alacritty
 ```
 
 ## Manual Installation


### PR DESCRIPTION
Void Linux has the alacritty package in the main repository's, so compilation from source isn't needed.