### PR TITLE
Memorize the input source for MacOS

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -348,7 +348,9 @@ impl<N: Notify> Processor<N> {
                             *hide_cursor = false;
                         }
 
-                        if cfg!(target_os="macos") {
+
+                        #[cfg(target_os="macos")]
+                        {
                             if is_focused {
                                 unsafe { TISSelectInputSource(processor.ctx.macos_input_source) };
                             }
@@ -452,7 +454,9 @@ impl<N: Notify> Processor<N> {
 
                 window.poll_events(process);
             }
-            if cfg!(target_os = "macos") {
+
+            #[cfg(target_os="macos")]
+            {
                 self.macos_input_source = processor.ctx.macos_input_source;
             }
             if self.hide_cursor_when_typing {


### PR DESCRIPTION
This PR tries to partially fix the #909. Specifically, memorising the input source when window loses focus and restoring it once focus is received.

I'm new to Rust and have no MacOS API experience, so the code is quite naive, but solves the problem I'm having. I would appreciate an advice on how to make it better / more idiomatic.

@kalekseev, do mind giving it a whirl?