### PR TITLE
Implement faux scrolling

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -407,24 +407,24 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                         let height = self.ctx.size_info().cell_height as i32;
 
                         while self.ctx.mouse_mut().scroll_px.abs() >= height {
+                            let button = if self.ctx.mouse_mut().scroll_px > 0 {
+                                self.ctx.mouse_mut().scroll_px -= height;
+                                64
+                            } else {
+                                self.ctx.mouse_mut().scroll_px += height;
+                                65
+                            };
+
                             if self.ctx.terminal_mode().intersects(mode::ALT_SCREEN_BUF) {
                                 // Faux scrolling
-                                if self.ctx.mouse_mut().scroll_px > 0 {
-                                    // Scroll up three lines
-                                    self.ctx.write_to_pty("\x1bOA\x1bOA\x1bOA".as_bytes());
+                                if button == 64 {
+                                    // Scroll up one line
+                                    self.ctx.write_to_pty("\x1bOA".as_bytes());
                                 } else {
-                                    // Scroll down three lines
-                                    self.ctx.write_to_pty("\x1bOB\x1bOB\x1bOB".as_bytes());
+                                    // Scroll down one line
+                                    self.ctx.write_to_pty("\x1bOB".as_bytes());
                                 }
                             } else {
-                                let button = if self.ctx.mouse_mut().scroll_px > 0 {
-                                    self.ctx.mouse_mut().scroll_px -= height;
-                                    64
-                                } else {
-                                    self.ctx.mouse_mut().scroll_px += height;
-                                    65
-                                };
-
                                 self.normal_mouse_report(button);
                             }
                         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -365,7 +365,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     }
 
     pub fn on_mouse_wheel(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
-        let modes = mode::MOUSE_REPORT_CLICK | mode::MOUSE_MOTION | mode::SGR_MOUSE | mode::ALT_SCREEN_BUF;
+        let modes = mode::MOUSE_REPORT_CLICK | mode::MOUSE_MOTION | mode::SGR_MOUSE |
+            mode::ALT_SCREEN;
         if !self.ctx.terminal_mode().intersects(modes) {
             return;
         }
@@ -380,7 +381,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 };
 
                 for _ in 0..(to_scroll.abs() as usize) {
-                    if self.ctx.terminal_mode().intersects(mode::ALT_SCREEN_BUF) {
+                    if self.ctx.terminal_mode().intersects(mode::ALT_SCREEN) {
                         // Faux scrolling
                         if code == 64 {
                             // Scroll up one line
@@ -415,7 +416,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                                 65
                             };
 
-                            if self.ctx.terminal_mode().intersects(mode::ALT_SCREEN_BUF) {
+                            if self.ctx.terminal_mode().intersects(mode::ALT_SCREEN) {
                                 // Faux scrolling
                                 if button == 64 {
                                     // Scroll up one line

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -428,7 +428,7 @@ pub mod mode {
             const ORIGIN              = 0b0001000000000;
             const INSERT              = 0b0010000000000;
             const FOCUS_IN_OUT        = 0b0100000000000;
-            const ALT_SCREEN_BUF      = 0b1000000000000;
+            const ALT_SCREEN          = 0b1000000000000;
             const ANY                 = 0b1111111111111;
             const NONE                = 0;
         }
@@ -1790,7 +1790,7 @@ impl ansi::Handler for Term {
         trace!("set_mode: {:?}", mode);
         match mode {
             ansi::Mode::SwapScreenAndSetRestoreCursor => {
-                self.mode.insert(mode::ALT_SCREEN_BUF);
+                self.mode.insert(mode::ALT_SCREEN);
                 self.save_cursor_position();
                 if !self.alt {
                     self.swap_alt();
@@ -1820,7 +1820,7 @@ impl ansi::Handler for Term {
         trace!("unset_mode: {:?}", mode);
         match mode {
             ansi::Mode::SwapScreenAndSetRestoreCursor => {
-                self.mode.remove(mode::ALT_SCREEN_BUF);
+                self.mode.remove(mode::ALT_SCREEN);
                 self.restore_cursor_position();
                 if self.alt {
                     self.swap_alt();

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -416,19 +416,20 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
 pub mod mode {
     bitflags! {
         pub struct TermMode: u16 {
-            const SHOW_CURSOR         = 0b000000000001;
-            const APP_CURSOR          = 0b000000000010;
-            const APP_KEYPAD          = 0b000000000100;
-            const MOUSE_REPORT_CLICK  = 0b000000001000;
-            const BRACKETED_PASTE     = 0b000000010000;
-            const SGR_MOUSE           = 0b000000100000;
-            const MOUSE_MOTION        = 0b000001000000;
-            const LINE_WRAP           = 0b000010000000;
-            const LINE_FEED_NEW_LINE  = 0b000100000000;
-            const ORIGIN              = 0b001000000000;
-            const INSERT              = 0b010000000000;
-            const FOCUS_IN_OUT        = 0b100000000000;
-            const ANY                 = 0b111111111111;
+            const SHOW_CURSOR         = 0b0000000000001;
+            const APP_CURSOR          = 0b0000000000010;
+            const APP_KEYPAD          = 0b0000000000100;
+            const MOUSE_REPORT_CLICK  = 0b0000000001000;
+            const BRACKETED_PASTE     = 0b0000000010000;
+            const SGR_MOUSE           = 0b0000000100000;
+            const MOUSE_MOTION        = 0b0000001000000;
+            const LINE_WRAP           = 0b0000010000000;
+            const LINE_FEED_NEW_LINE  = 0b0000100000000;
+            const ORIGIN              = 0b0001000000000;
+            const INSERT              = 0b0010000000000;
+            const FOCUS_IN_OUT        = 0b0100000000000;
+            const ALT_SCREEN_BUF      = 0b1000000000000;
+            const ANY                 = 0b1111111111111;
             const NONE                = 0;
         }
     }
@@ -1789,6 +1790,7 @@ impl ansi::Handler for Term {
         trace!("set_mode: {:?}", mode);
         match mode {
             ansi::Mode::SwapScreenAndSetRestoreCursor => {
+                self.mode.insert(mode::ALT_SCREEN_BUF);
                 self.save_cursor_position();
                 if !self.alt {
                     self.swap_alt();
@@ -1818,6 +1820,7 @@ impl ansi::Handler for Term {
         trace!("unset_mode: {:?}", mode);
         match mode {
             ansi::Mode::SwapScreenAndSetRestoreCursor => {
+                self.mode.remove(mode::ALT_SCREEN_BUF);
                 self.restore_cursor_position();
                 if self.alt {
                     self.swap_alt();


### PR DESCRIPTION
This patch implements faux scrolling inside the alternate screen buffer.

Whenever the user scrolls up or down while the alternate screen buffer
is active, instead of actual scrolling three up/down arrow keys are
inserted.

This fixes #550.

**Important:** I wasn't able to test this on a touch device, because I do not own one, so if anyone could test it, that would be nice.

Also I've tested termite and they seem to scroll 7 lines, I've settled for 3 lines for now, but any feedback is appreciated.