### PR TITLE
Add --needed to pacman command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ On Arch Linux, you need a few extra libraries to build Alacritty. Here's a
 to be missing, please open an issue.
 
 ```sh
-pacman -S cmake freetype2 fontconfig pkg-config make xclip
+pacman -S --needed cmake freetype2 fontconfig pkg-config make xclip
 ```
 
 #### Fedora


### PR DESCRIPTION
By default, `pacman` _reinstalls_ any package specified that is already installed. The `--needed` flag says "if this package is already installed, just ignore it". From the man page:

```
       --needed
           Do not reinstall the targets that are already up-to-date.
```

I quickly glanced through the other distributions listed, and I couldn't immediately find any others that have the same behavior. However, I haven't used most of them, so I'm not sure.