### PR TITLE
Add configuration option for faux scrollback

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -197,9 +197,21 @@ background_opacity: 1.0
 mouse_bindings:
   - { mouse: Middle, action: PasteSelection }
 
+# Mouse settings
+#
+# The `faux_scrollback_lines` setting controls the number
+# of lines the terminal should scroll when the alternate
+# screen buffer is active. This is used to allow mouse
+# scrolling for applications like `man`.
+# To disable this completely, set `faux_scrollback_lines` to 0.
+#
+# The `double_click` and `triple_click` settings control the time
+# alacritty should wait for accepting multiple clicks as one double
+# or triple click.
 mouse:
   double_click: { threshold: 300 }
   triple_click: { threshold: 300 }
+  faux_scrollback_lines: 1
 
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -197,20 +197,23 @@ background_opacity: 1.0
 mouse_bindings:
   - { mouse: Middle, action: PasteSelection }
 
-# Mouse settings
-#
-# The `faux_scrollback_lines` setting controls the number
-# of lines the terminal should scroll when the alternate
-# screen buffer is active. This is used to allow mouse
-# scrolling for applications like `man`.
-# To disable this completely, set `faux_scrollback_lines` to 0.
-#
-# The `double_click` and `triple_click` settings control the time
-# alacritty should wait for accepting multiple clicks as one double
-# or triple click.
 mouse:
+  # Click settings
+  #
+  # The `double_click` and `triple_click` settings control the time
+  # alacritty should wait for accepting multiple clicks as one double
+  # or triple click.
   double_click: { threshold: 300 }
   triple_click: { threshold: 300 }
+
+  # Faux Scrollback
+  #
+  # The `faux_scrollback_lines` setting controls the number
+  # of lines the terminal should scroll when the alternate
+  # screen buffer is active. This is used to allow mouse
+  # scrolling for applications like `man`.
+  #
+  # To disable this completely, set `faux_scrollback_lines` to 0.
   faux_scrollback_lines: 1
 
 selection:

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -178,9 +178,21 @@ background_opacity: 1.0
 mouse_bindings:
   - { mouse: Middle, action: PasteSelection }
 
+# Mouse settings
+#
+# The `faux_scrollback_lines` setting controls the number
+# of lines the terminal should scroll when the alternate
+# screen buffer is active. This is used to allow mouse
+# scrolling for applications like `man`.
+# To disable this completely, set `faux_scrollback_lines` to 0.
+#
+# The `double_click` and `triple_click` settings control the time
+# alacritty should wait for accepting multiple clicks as one double
+# or triple click.
 mouse:
   double_click: { threshold: 300 }
   triple_click: { threshold: 300 }
+  faux_scrollback_lines: 1
 
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -178,20 +178,23 @@ background_opacity: 1.0
 mouse_bindings:
   - { mouse: Middle, action: PasteSelection }
 
-# Mouse settings
-#
-# The `faux_scrollback_lines` setting controls the number
-# of lines the terminal should scroll when the alternate
-# screen buffer is active. This is used to allow mouse
-# scrolling for applications like `man`.
-# To disable this completely, set `faux_scrollback_lines` to 0.
-#
-# The `double_click` and `triple_click` settings control the time
-# alacritty should wait for accepting multiple clicks as one double
-# or triple click.
 mouse:
+  # Click settings
+  #
+  # The `double_click` and `triple_click` settings control the time
+  # alacritty should wait for accepting multiple clicks as one double
+  # or triple click.
   double_click: { threshold: 300 }
   triple_click: { threshold: 300 }
+
+  # Faux Scrollback
+  #
+  # The `faux_scrollback_lines` setting controls the number
+  # of lines the terminal should scroll when the alternate
+  # screen buffer is active. This is used to allow mouse
+  # scrolling for applications like `man`.
+  #
+  # To disable this completely, set `faux_scrollback_lines` to 0.
   faux_scrollback_lines: 1
 
 selection:

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,10 @@ fn deserialize_duration_ms<'a, D>(deserializer: D) -> ::std::result::Result<Dura
 pub struct Mouse {
     pub double_click: ClickHandler,
     pub triple_click: ClickHandler,
+
+    /// Send up/down arrow when scrolling in alt screen buffer
+    #[serde(default="true_bool")]
+    pub faux_scrollback: bool,
 }
 
 impl Default for Mouse {
@@ -75,7 +79,8 @@ impl Default for Mouse {
             },
             triple_click: ClickHandler {
                 threshold: Duration::from_millis(300),
-            }
+            },
+            faux_scrollback: true,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,9 +66,13 @@ pub struct Mouse {
     pub double_click: ClickHandler,
     pub triple_click: ClickHandler,
 
-    /// Send up/down arrow when scrolling in alt screen buffer
-    #[serde(default="true_bool")]
-    pub faux_scrollback: bool,
+    /// up/down arrows sent when scrolling in alt screen buffer
+    #[serde(default="default_faux_scrollback_lines")]
+    pub faux_scrollback_lines: usize,
+}
+
+fn default_faux_scrollback_lines() -> usize {
+    1
 }
 
 impl Default for Mouse {
@@ -80,7 +84,7 @@ impl Default for Mouse {
             triple_click: ClickHandler {
                 threshold: Duration::from_millis(300),
             },
-            faux_scrollback: true,
+            faux_scrollback_lines: 1,
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -381,7 +381,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 };
 
                 for _ in 0..(to_scroll.abs() as usize) {
-                    if self.ctx.terminal_mode().intersects(mode::TermMode::ALT_SCREEN) {
+                    if self.mouse_config.faux_scrollback &&
+                        self.ctx.terminal_mode().intersects(mode::TermMode::ALT_SCREEN)
+                    {
                         // Faux scrolling
                         if code == 64 {
                             // Scroll up one line
@@ -416,7 +418,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                                 65
                             };
 
-                            if self.ctx.terminal_mode().intersects(mode::TermMode::ALT_SCREEN) {
+                            if self.mouse_config.faux_scrollback &&
+                                self.ctx.terminal_mode().intersects(mode::TermMode::ALT_SCREEN)
+                            {
                                 // Faux scrolling
                                 if button == 64 {
                                     // Scroll up one line

--- a/src/input.rs
+++ b/src/input.rs
@@ -365,9 +365,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     }
 
     pub fn on_mouse_wheel(&mut self, delta: MouseScrollDelta, phase: TouchPhase) {
-        let modes = mode::TermMode::MOUSE_REPORT_CLICK | mode::TermMode::MOUSE_MOTION | mode::TermMode::SGR_MOUSE |
-            mode::TermMode::ALT_SCREEN;
-        if !self.ctx.terminal_mode().intersects(modes) {
+        let mouse_modes = mode::TermMode::MOUSE_REPORT_CLICK | mode::TermMode::MOUSE_MOTION | mode::TermMode::SGR_MOUSE;
+        if !self.ctx.terminal_mode().intersects(mouse_modes | mode::TermMode::ALT_SCREEN) {
             return;
         }
 
@@ -381,20 +380,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 };
 
                 for _ in 0..(to_scroll.abs() as usize) {
-                    if self.mouse_config.faux_scrollback &&
-                        self.ctx.terminal_mode().intersects(mode::TermMode::ALT_SCREEN)
-                    {
-                        // Faux scrolling
-                        if code == 64 {
-                            // Scroll up one line
-                            self.ctx.write_to_pty("\x1bOA".as_bytes());
-                        } else {
-                            // Scroll down one line
-                            self.ctx.write_to_pty("\x1bOB".as_bytes());
-                        }
-                    } else {
-                        self.normal_mouse_report(code);
-                    }
+                    self.scroll_terminal(mouse_modes, code)
                 }
 
                 self.ctx.mouse_mut().lines_scrolled = to_scroll % 1.0;
@@ -410,7 +396,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                         let height = self.ctx.size_info().cell_height as i32;
 
                         while self.ctx.mouse_mut().scroll_px.abs() >= height {
-                            let button = if self.ctx.mouse_mut().scroll_px > 0 {
+                            let code = if self.ctx.mouse_mut().scroll_px > 0 {
                                 self.ctx.mouse_mut().scroll_px -= height;
                                 64
                             } else {
@@ -418,24 +404,35 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                                 65
                             };
 
-                            if self.mouse_config.faux_scrollback &&
-                                self.ctx.terminal_mode().intersects(mode::TermMode::ALT_SCREEN)
-                            {
-                                // Faux scrolling
-                                if button == 64 {
-                                    // Scroll up one line
-                                    self.ctx.write_to_pty("\x1bOA".as_bytes());
-                                } else {
-                                    // Scroll down one line
-                                    self.ctx.write_to_pty("\x1bOB".as_bytes());
-                                }
-                            } else {
-                                self.normal_mouse_report(button);
-                            }
+                            self.scroll_terminal(mouse_modes, code)
                         }
                     },
                     _ => (),
                 }
+            }
+        }
+    }
+
+    fn scroll_terminal(&mut self, mouse_modes: TermMode, code: u8) {
+        let faux_scrollback_lines = self.mouse_config.faux_scrollback_lines;
+        if self.ctx.terminal_mode().intersects(mouse_modes) {
+            self.normal_mouse_report(code);
+        } else if faux_scrollback_lines > 0 {
+            // Faux scrolling
+            if code == 64 {
+                // Scroll up by `faux_scrollback_lines`
+                let mut content = String::with_capacity(faux_scrollback_lines * 3);
+                for _ in 0..faux_scrollback_lines {
+                    content = content + "\x1bOA";
+                }
+                self.ctx.write_to_pty(content.into_bytes());
+            } else {
+                // Scroll down by `faux_scrollback_lines`
+                let mut content = String::with_capacity(faux_scrollback_lines * 3);
+                for _ in 0..faux_scrollback_lines {
+                    content = content + "\x1bOB";
+                }
+                self.ctx.write_to_pty(content.into_bytes());
             }
         }
     }
@@ -692,7 +689,8 @@ mod tests {
                         },
                         triple_click: ClickHandler {
                             threshold: Duration::from_millis(1000),
-                        }
+                        },
+                        faux_scrollback_lines: 1,
                     },
                     key_bindings: &config.key_bindings()[..],
                     mouse_bindings: &config.mouse_bindings()[..],


### PR DESCRIPTION
Some people have complained about the behavior of faux scrollback inside
of vim/tmux, however from what I can tell, alacritty behaves the same
way as other terminal emulators that support faux scrollback.

However there are a lot of terminal emulators that do not support faux
scrollback at all, which leads to people complaining about unusual
scroll behavior.

This is my proposal on how to solve this issue, by giving people that do
not like the VTE-Style faux scrolling the option to opt-out.