### PR TITLE
Honour working dir on linux

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ extern crate log;
 
 use std::error::Error;
 use std::sync::Arc;
-use std::env;
 
 use alacritty::cli;
 use alacritty::config::{self, Config};

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,6 @@ fn main() {
     let config = load_config(&options);
 
     // Switch to home directory
-    env::set_current_dir(env::home_dir().unwrap()).unwrap();
     #[cfg(target_os = "macos")]
     locale::set_locale_environment();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,6 @@ fn main() {
     let options = cli::Options::load();
     let config = load_config(&options);
 
-    // Switch to home directory
     #[cfg(target_os = "macos")]
     locale::set_locale_environment();
 


### PR DESCRIPTION
Apparently switching to the home directory on startup was primarily done for macos, however the default behavior on linux is to start the terminal emulator in the working directory.

This just doesn't switch to the home directory when alacritty is run on linux.
If there is any more to it, please let me know.

This fixes #961.