### PR TITLE
Prevent font_size_modifier from sinking too low

### DIFF
--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -166,7 +166,7 @@ impl Hash for GlyphKey {
 }
 
 /// Font size stored as integer
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Size(i16);
 
 impl Size {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1469,7 +1469,7 @@ impl Font {
     /// Get a font clone with a size modification
     pub fn with_size(self, size: Size) -> Font {
         Font {
-            size : Size::new(size.as_f32_pts()),
+            size,
             .. self
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1467,13 +1467,9 @@ impl Font {
     }
 
     /// Get a font clone with a size modification
-    pub fn with_size_delta(self, delta: f32) -> Font {
-        let mut new_size = self.size.as_f32_pts() + delta;
-        if new_size < 1.0 {
-            new_size = 1.0;
-        }
+    pub fn with_size(self, size: Size) -> Font {
         Font {
-            size : Size::new(new_size),
+            size : Size::new(size.as_f32_pts()),
             .. self
         }
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -286,7 +286,7 @@ impl Display {
         if terminal.font_size_modifier != self.font_size_modifier {
             // Make sure the font size is at least 1
             let config_font_size = config.font().size().as_f32_pts() as i8;
-            if terminal.font_size_modifier + config_font_size < 1 {
+            if (terminal.font_size_modifier as i16 + config_font_size as i16) < 1 {
                 terminal.font_size_modifier = 1 - config_font_size;
                 return;
             }

--- a/src/display.rs
+++ b/src/display.rs
@@ -96,7 +96,7 @@ pub struct Display {
     rx: mpsc::Receiver<(u32, u32)>,
     tx: mpsc::Sender<(u32, u32)>,
     meter: Meter,
-    font_size_modifier: i8,
+    font_size: font::Size,
     size_info: SizeInfo,
     last_background_color: Rgb,
 }
@@ -150,7 +150,7 @@ impl Display {
         let mut renderer = QuadRenderer::new(config, viewport_size)?;
 
         let (glyph_cache, cell_width, cell_height) =
-            Self::new_glyph_cache(&window, &mut renderer, config, 0)?;
+            Self::new_glyph_cache(&window, &mut renderer, config)?;
 
 
         let dimensions = options.dimensions()
@@ -205,17 +205,16 @@ impl Display {
             tx: tx,
             rx: rx,
             meter: Meter::new(),
-            font_size_modifier: 0,
+            font_size: font::Size::new(0.),
             size_info: size_info,
             last_background_color: background_color,
         })
     }
 
-    fn new_glyph_cache(window : &Window, renderer : &mut QuadRenderer,
-                       config: &Config, font_size_delta: i8)
+    fn new_glyph_cache(window : &Window, renderer : &mut QuadRenderer, config: &Config)
         -> Result<(GlyphCache, f32, f32), Error>
     {
-        let font = config.font().clone().with_size_delta(font_size_delta as f32);
+        let font = config.font().clone();
         let dpr = window.hidpi_factor();
         let rasterizer = font::Rasterizer::new(dpr, config.use_thin_strokes())?;
 
@@ -245,10 +244,11 @@ impl Display {
         Ok((glyph_cache, cell_width as f32, cell_height as f32))
     }
 
-    pub fn update_glyph_cache(&mut self, config: &Config, font_size_delta: i8) {
+    pub fn update_glyph_cache(&mut self, config: &Config) {
         let cache = &mut self.glyph_cache;
+        let size = self.font_size;
         self.renderer.with_loader(|mut api| {
-            let _ = cache.update_font_size(config.font(), font_size_delta, &mut api);
+            let _ = cache.update_font_size(config.font(), size, &mut api);
         });
 
         let metrics = cache.font_metrics();
@@ -283,16 +283,9 @@ impl Display {
         }
 
         // Font size modification detected
-        if terminal.font_size_modifier != self.font_size_modifier {
-            // Make sure the font size is at least 1
-            let config_font_size = config.font().size().as_f32_pts() as i8;
-            if (terminal.font_size_modifier as i16 + config_font_size as i16) < 1 {
-                terminal.font_size_modifier = 1 - config_font_size;
-                return;
-            }
-
-            self.font_size_modifier = terminal.font_size_modifier;
-            self.update_glyph_cache(config, terminal.font_size_modifier);
+        if terminal.font_size != self.font_size {
+            self.font_size = terminal.font_size;
+            self.update_glyph_cache(config);
 
             if new_size == None {
                 // Force a resize to refresh things

--- a/src/display.rs
+++ b/src/display.rs
@@ -282,8 +282,14 @@ impl Display {
             new_size = Some(sz);
         }
 
+        // Font size modification detected
         if terminal.font_size_modifier != self.font_size_modifier {
-            // Font size modification detected
+            // Make sure the font size is at least 1
+            let config_font_size = config.font().size().as_f32_pts() as i8;
+            if terminal.font_size_modifier + config_font_size < 1 {
+                terminal.font_size_modifier = 1 - config_font_size;
+                return;
+            }
 
             self.font_size_modifier = terminal.font_size_modifier;
             self.update_glyph_cache(config, terminal.font_size_modifier);

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -295,7 +295,7 @@ impl GlyphCache {
     pub fn update_font_size<L: LoadGlyph>(
         &mut self,
         font: &config::Font,
-        delta: i8,
+        size: font::Size,
         loader: &mut L
     ) -> Result<(), font::Error> {
         // Clear currently cached data in both GL and the registry
@@ -303,7 +303,7 @@ impl GlyphCache {
         self.cache = HashMap::default();
 
         // Recompute font keys
-        let font = font.to_owned().with_size_delta(delta as _);
+        let font = font.to_owned().with_size(size);
         info!("Font size changed: {:?}", font.size);
         let (regular, bold, italic) = Self::compute_font_keys(&font, &mut self.rasterizer)?;
         self.rasterizer.get_glyph(&GlyphKey { font_key: regular, c: 'm', size: font.size() })?;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -304,7 +304,7 @@ impl GlyphCache {
 
         // Recompute font keys
         let font = font.to_owned().with_size_delta(delta as _);
-        println!("{:?}", font.size);
+        info!("Font size changed: {:?}", font.size);
         let (regular, bold, italic) = Self::compute_font_keys(&font, &mut self.rasterizer)?;
         self.rasterizer.get_glyph(&GlyphKey { font_key: regular, c: 'm', size: font.size() })?;
         let metrics = self.rasterizer.metrics(regular)?;


### PR DESCRIPTION
This change prevents the `font_size_modifier` of the terminal from going
below the font size 1. If this is not done, it is possible to decrease
the `font_size_modifier` without the font size itself changing. So when
raising it again, nothing happens until the `font_size_modifier` is back
at a reasonable level.

This fixes this by making sure the `font_size_modifier` never goes below
`1 - original_font_size`. So if the original font size is 12, the
`font_size_modifier` will always bee `-11` or bigger. Effectively limiting
it to the value where the font is 1. (`12 - 11 = 1`)

This fixes #955.