### PR TITLE
Fix scrolling outside of u8 range

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -29,7 +29,7 @@ use glutin::{ElementState, VirtualKeyCode, MouseButton, TouchPhase, MouseScrollD
 
 use config;
 use event::{ClickState, Mouse};
-use index::{Line, Column, Side, Point};
+use index::{Side, Point};
 use term::SizeInfo;
 use term::mode::{self, TermMode};
 use util::fmt::Red;

--- a/src/input.rs
+++ b/src/input.rs
@@ -294,18 +294,20 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     pub fn normal_mouse_report(&mut self, button: u8) {
         let (line, column) = (self.ctx.mouse_mut().line, self.ctx.mouse_mut().column);
 
-        if line < Line(223) && column < Column(223) {
-            let msg = vec![
-                b'\x1b',
-                b'[',
-                b'M',
-                32 + button,
-                32 + 1 + column.0 as u8,
-                32 + 1 + line.0 as u8,
-            ];
+        // If mouse report is beyond line/column 222, report it as 222
+        let column = (column.0 as u8).saturating_add(32 + 1);
+        let line = (line.0 as u8).saturating_add(32 + 1);
 
-            self.ctx.write_to_pty(msg);
-        }
+        let msg = vec![
+            b'\x1b',
+            b'[',
+            b'M',
+            32 + button,
+            column,
+            line,
+        ];
+
+        self.ctx.write_to_pty(msg);
     }
 
     pub fn sgr_mouse_report(&mut self, button: u8, release: bool) {


### PR DESCRIPTION
Until now scrolling past column and line 222 has been ignored. With this
patch it now reports scrolling beyond these lines as scrolling at the
limits (222).

I'm not entirely sure if there is a way to report numbers outside of the
u8 range, however I do not see any separator between line and column and
have choosen to just report these as line/column 222 for now. If someone
knows more about this, please let me know.

This fixes #698.