### PR TITLE
Improve ability of alacritty to deal with broken config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -53,11 +53,20 @@ pub struct ClickHandler {
     pub threshold: Duration,
 }
 
+fn default_threshold_ms() -> Duration {
+    Duration::from_millis(300)
+}
+
 fn deserialize_duration_ms<'a, D>(deserializer: D) -> ::std::result::Result<Duration, D::Error>
     where D: de::Deserializer<'a>
 {
-    let threshold_ms = u64::deserialize(deserializer)?;
-    Ok(Duration::from_millis(threshold_ms))
+    match u64::deserialize(deserializer) {
+        Ok(threshold_ms) => Ok(Duration::from_millis(threshold_ms)),
+        Err(err) => {
+            eprintln!("problem with config: {}; Using default value", err);
+            Ok(default_threshold_ms())
+        },
+    }
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,16 +71,8 @@ fn load_config(options: &cli::Options) -> Config {
         });
 
     Config::load_from(&*config_path).unwrap_or_else(|err| {
-        match err {
-            config::Error::NotFound => {
-                die!("Config file not found at: {}", config_path.display());
-            },
-            config::Error::Empty => {
-                eprintln!("Empty config; Loading defaults");
-                Config::default()
-            },
-            _ => die!("{}", err),
-        }
+        eprintln!("Error: {}; Loading default config", err);
+        Config::default()
     })
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -444,8 +444,6 @@ pub mod mode {
 
 pub use self::mode::TermMode;
 
-pub const TAB_SPACES: usize = 8;
-
 trait CharsetMapping {
     fn map(&self, c: char) -> char {
         c
@@ -720,6 +718,9 @@ pub struct Term {
     default_cursor_style: CursorStyle,
 
     dynamic_title: bool,
+
+    /// Number of spaces in one tab
+    tabspaces: usize,
 }
 
 /// Terminal size info
@@ -797,8 +798,9 @@ impl Term {
 
         let grid = Grid::new(num_lines, num_cols, &template);
 
+        let tabspaces = config.tabspaces();
         let tabs = IndexRange::from(Column(0)..grid.num_cols())
-            .map(|i| (*i as usize) % TAB_SPACES == 0)
+            .map(|i| (*i as usize) % tabspaces == 0)
             .collect::<Vec<bool>>();
 
         let alt = grid.clone();
@@ -830,6 +832,7 @@ impl Term {
             cursor_style: None,
             default_cursor_style: config.cursor_style(),
             dynamic_title: config.dynamic_title(),
+            tabspaces,
         }
     }
 
@@ -1070,7 +1073,7 @@ impl Term {
 
         // Recreate tabs list
         self.tabs = IndexRange::from(Column(0)..self.grid.num_cols())
-            .map(|i| (*i as usize) % TAB_SPACES == 0)
+            .map(|i| (*i as usize) % self.tabspaces == 0)
             .collect::<Vec<bool>>();
 
         if num_lines > old_lines {


### PR DESCRIPTION
When part of the config is broken, alacritty shouldn't instantly try to
recover to the default config, but instead try to use defaults only for
the parts of the config which are broken.

The primary fields which are still breaking the complete config when
they are not configured properly are fonts, mouse bindings and key
bindings. In those cases alacritty falls back to the default config.

This fixes #954.

I think it might be possible to prevent the mouse and keyboard shortcuts from destroying everything with a custom deserializer over the whole vec, I'll look into that.
I'm not sure about the fonts though.
  
**Update**: Mouse and Keyboard bindings should work now too. Only invalid yaml should be able to break the config now.