### PR TITLE
Expand key binding config documentation

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -238,13 +238,16 @@ live_config_reload: true
 #
 # You can set shell.program to the path of your favorite shell, e.g. /bin/fish.
 # Entries in shell.args are passed unmodified as arguments to the shell.
+#
 # shell:
 #   program: /bin/bash
 #   args:
 #     - --login
 
-
 # Key bindings
+#
+# A list with all available `key` names can be found here:
+# https://docs.rs/glutin/0.12.0/glutin/enum.VirtualKeyCode.html#variants
 #
 # Each binding is defined as an object with some properties. Most of the
 # properties are optional. All of the alphabetical keys should have a letter for

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -246,15 +246,15 @@ live_config_reload: true
 
 # Key bindings
 #
-# A list with all available `key` names can be found here:
-# https://docs.rs/glutin/0.12.0/glutin/enum.VirtualKeyCode.html#variants
-#
 # Each binding is defined as an object with some properties. Most of the
 # properties are optional. All of the alphabetical keys should have a letter for
 # the `key` value such as `V`. Function keys are probably what you would expect
 # as well (F1, F2, ..). The number keys above the main keyboard are encoded as
 # `Key1`, `Key2`, etc. Keys on the number pad are encoded `Number1`, `Number2`,
 # etc.  These all match the glutin::VirtualKeyCode variants.
+#
+# A list with all available `key` names can be found here:
+# https://docs.rs/glutin/0.12.0/glutin/enum.VirtualKeyCode.html#variants
 #
 # Possible values for `mods`
 # `Command`, `Super` refer to the super/command/windows key

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -254,7 +254,7 @@ live_config_reload: true
 # etc.  These all match the glutin::VirtualKeyCode variants.
 #
 # A list with all available `key` names can be found here:
-# https://docs.rs/glutin/0.12.0/glutin/enum.VirtualKeyCode.html#variants
+# https://docs.rs/glutin/*/glutin/enum.VirtualKeyCode.html#variants
 #
 # Possible values for `mods`
 # `Command`, `Super` refer to the super/command/windows key

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -235,7 +235,7 @@ live_config_reload: true
 # etc.  These all match the glutin::VirtualKeyCode variants.
 #
 # A list with all available `key` names can be found here:
-# https://docs.rs/glutin/0.12.0/glutin/enum.VirtualKeyCode.html#variants
+# https://docs.rs/glutin/*/glutin/enum.VirtualKeyCode.html#variants
 #
 # Possible values for `mods`
 # `Command`, `Super` refer to the super/command/windows key

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -227,15 +227,15 @@ live_config_reload: true
 
 # Key bindings
 #
-# A list with all available `key` names can be found here:
-# https://docs.rs/glutin/0.12.0/glutin/enum.VirtualKeyCode.html#variants
-#
 # Each binding is defined as an object with some properties. Most of the
 # properties are optional. All of the alphabetical keys should have a letter for
 # the `key` value such as `V`. Function keys are probably what you would expect
 # as well (F1, F2, ..). The number keys above the main keyboard are encoded as
 # `Key1`, `Key2`, etc. Keys on the number pad are encoded `Number1`, `Number2`,
 # etc.  These all match the glutin::VirtualKeyCode variants.
+#
+# A list with all available `key` names can be found here:
+# https://docs.rs/glutin/0.12.0/glutin/enum.VirtualKeyCode.html#variants
 #
 # Possible values for `mods`
 # `Command`, `Super` refer to the super/command/windows key

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -227,6 +227,9 @@ live_config_reload: true
 
 # Key bindings
 #
+# A list with all available `key` names can be found here:
+# https://docs.rs/glutin/0.12.0/glutin/enum.VirtualKeyCode.html#variants
+#
 # Each binding is defined as an object with some properties. Most of the
 # properties are optional. All of the alphabetical keys should have a letter for
 # the `key` value such as `V`. Function keys are probably what you would expect


### PR DESCRIPTION
A link to all variants available as `key` has been added at the top of
the key bindings documentation, to help users with finding the right
place for mapping key codes.