### PR TITLE
Make Mac app installation steps idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ To build an application for macOS, run
 
 ```sh
 make app
-cp -r target/release/osx/Alacritty.app /Applications/Alacritty.app
+cp -r target/release/osx/Alacritty.app /Applications/
 ```
 
 ## Configuration


### PR DESCRIPTION
* Repeated uses of `cp -r target/release/osx/Alacritty.app
  /Applications/Alacritty.app` will result in copying Alacritty.app to
  `/Applications/Alacritty.app/Alacritty.app`.