### PR TITLE
Implement `reset_state` of Term struct

### DIFF
--- a/src/term/color.rs
+++ b/src/term/color.rs
@@ -13,6 +13,7 @@ pub const COUNT: usize = 268;
 /// the configured foreground color, item 257 is the configured background
 /// color, item 258 is the cursor foreground color, item 259 is the cursor
 /// background color. Following that are 8 positions for dim colors.
+#[derive(Copy, Clone)]
 pub struct List([Rgb; COUNT]);
 
 impl<'a> From<&'a Colors> for List {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1756,9 +1756,23 @@ impl ansi::Handler for Term {
         }
     }
 
+    // Reset all important fields in the term struct
     #[inline]
     fn reset_state(&mut self) {
-        trace!("[unimplemented] reset_state");
+        self.input_needs_wrap = false;
+        self.next_title = None;
+        self.next_mouse_cursor = None;
+        self.alt = false;
+        self.cursor = Default::default();
+        self.active_charset = Default::default();
+        self.mode = Default::default();
+        self.font_size = self.original_font_size;
+        self.next_is_urgent = None;
+        self.cursor_save = Default::default();
+        self.cursor_save_alt = Default::default();
+        self.colors = self.original_colors;
+        self.color_modified = [false; color::COUNT];
+        self.cursor_style = None;
     }
 
     #[inline]


### PR DESCRIPTION
Up to this point the `reset_state` method of the `Term` struct has been
just a placeholder. This has been changed and all important state has
been reset.

The only state that has not been reset is stuff which is retrieved from
the config and isn't stored as default on the `Term` struct either. From
what I can tell these are all never changed though.

This fixes jwilm/alacritty#1033.

After doing some more testing trying to figure out how to fix that all
glyphs are messed up after doing `cat /dev/urandom`, I was able to
confirm that resetting `Term::cursor` fixes the glyphs and restores
everything to normal.

So this also fixes jwilm/alacritty#804.