### PR TITLE
Support config to control width of ambiguous width characters

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -145,6 +145,10 @@ font:
   # effect.
   use_thin_strokes: true
 
+  # Fonts for some east asian languages (mainly CJK) usually expects
+  # that some additional characters are wide.
+  east_asian_fullwidth: false
+
 # Display the time it takes to redraw each frame.
 render_timer: false
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2052,6 +2052,10 @@ pub struct Font {
     // TODO: Deprecated
     #[serde(deserialize_with = "deserialize_scale_with_dpi")]
     scale_with_dpi: Option<()>,
+
+    /// Whether to use fullwidth for east asian (ambiguous) characters
+    #[serde(default, deserialize_with = "failure_default")]
+    east_asian_fullwidth: bool,
 }
 
 impl Default for Font {
@@ -2066,6 +2070,7 @@ impl Default for Font {
             scale_with_dpi: Default::default(),
             glyph_offset: Default::default(),
             offset: Default::default(),
+            east_asian_fullwidth: Default::default(),
         }
     }
 }
@@ -2087,6 +2092,12 @@ impl Font {
     #[inline]
     pub fn glyph_offset(&self) -> &Delta<i8> {
         &self.glyph_offset
+    }
+
+    /// Get east asian characters width
+    #[inline]
+    pub fn east_asian_fullwidth(&self) -> bool {
+        self.east_asian_fullwidth
     }
 
     /// Get a font clone with a size modification

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -753,6 +753,9 @@ pub struct Term {
     pub font_size: Size,
     original_font_size: Size,
 
+    /// Width of east asian characters
+    east_asian_fullwidth: bool,
+
     /// Size
     size_info: SizeInfo,
 
@@ -911,6 +914,7 @@ impl Term {
             alt: false,
             font_size: config.font().size(),
             original_font_size: config.font().size(),
+            east_asian_fullwidth: config.font().east_asian_fullwidth(),
             active_charset: Default::default(),
             cursor: Default::default(),
             cursor_save: Default::default(),
@@ -1379,7 +1383,12 @@ impl ansi::Handler for Term {
         }
 
         // Number of cells the char will occupy
-        if let Some(width) = c.width() {
+        let width = if self.east_asian_fullwidth {
+            c.width_cjk()
+        } else {
+            c.width()
+        };
+        if let Some(width) = width {
             let num_cols = self.grid.num_cols();
 
             // If in insert mode, first shift cells to the right.


### PR DESCRIPTION
Fonts for some languages (mainly CJK) expects east asian width characters to be full-width.
This pull request provides a way to let users choose width for such characters.

For example, Ricty font with `east_asian_fullwidth: true`, seems correct:
![ambiwidth=full](https://user-images.githubusercontent.com/1246590/35299227-fc5c3e3e-00c7-11e8-958c-1c35001ca2b3.png)
Ricty font with `east_asian_fullwidth: false`:
![ambiwidth=half](https://user-images.githubusercontent.com/1246590/35299241-06051bae-00c8-11e8-96ce-6cd8780c2fec.png)

`east_asian_fullwidth: false` is behaviour before this PR (and default config value).
In this example, `…` has full-width for the font but treated as half-width on terminal, so display is broken and cursor doesn't works correctly.