### PR TITLE
Add config for unfocused window cursor change

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -231,6 +231,9 @@ hide_cursor_when_typing: false
 # - Beam
 cursor_style: Block
 
+# Whether the cursor should be a hollow block on window focus loss
+cursor_hollow_unfocused: true
+
 # Live config reload (changes require restart)
 live_config_reload: true
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -232,7 +232,7 @@ hide_cursor_when_typing: false
 cursor_style: Block
 
 # Whether the cursor should be a hollow block on window focus loss
-cursor_hollow_unfocused: true
+unfocused_hollow_cursor: true
 
 # Live config reload (changes require restart)
 live_config_reload: true

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -213,7 +213,7 @@ hide_cursor_when_typing: false
 cursor_style: Block
 
 # Whether the cursor should be a hollow block on window focus loss
-cursor_hollow_unfocused: true
+unfocused_hollow_cursor: true
 
 # Live config reload (changes require restart)
 live_config_reload: true

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -212,6 +212,9 @@ hide_cursor_when_typing: false
 # - Beam
 cursor_style: Block
 
+# Whether the cursor should be a hollow block on window focus loss
+cursor_hollow_unfocused: true
+
 # Live config reload (changes require restart)
 live_config_reload: true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -391,7 +391,7 @@ pub struct Config {
 
     /// Use hollow block cursor when unfocused
     #[serde(default="true_bool", deserialize_with = "default_true_bool")]
-    cursor_hollow_unfocused: bool,
+    unfocused_hollow_cursor: bool,
 
     /// Live config reload
     #[serde(default="true_bool", deserialize_with = "default_true_bool")]
@@ -1368,8 +1368,8 @@ impl Config {
 
     /// Use hollow block cursor when unfocused
     #[inline]
-    pub fn cursor_hollow_unfocused(&self) -> bool {
-        self.cursor_hollow_unfocused
+    pub fn unfocused_hollow_cursor(&self) -> bool {
+        self.unfocused_hollow_cursor
     }
 
     /// Live config reload

--- a/src/config.rs
+++ b/src/config.rs
@@ -389,6 +389,10 @@ pub struct Config {
     #[serde(default, deserialize_with = "failure_default")]
     cursor_style: CursorStyle,
 
+    /// Use hollow block cursor when unfocused
+    #[serde(default="true_bool", deserialize_with = "default_true_bool")]
+    cursor_hollow_unfocused: bool,
+
     /// Live config reload
     #[serde(default="true_bool", deserialize_with = "default_true_bool")]
     live_config_reload: bool,
@@ -1360,6 +1364,12 @@ impl Config {
     #[inline]
     pub fn cursor_style(&self) -> CursorStyle {
         self.cursor_style
+    }
+
+    /// Use hollow block cursor when unfocused
+    #[inline]
+    pub fn cursor_hollow_unfocused(&self) -> bool {
+        self.cursor_hollow_unfocused
     }
 
     /// Live config reload

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -995,7 +995,7 @@ impl Term {
     ) -> RenderableCellsIter {
         let selection = selection.and_then(|s| s.to_span(self))
             .map(|span| span.to_range());
-        let cursor = if window_focused || !config.cursor_hollow_unfocused() {
+        let cursor = if window_focused || !config.unfocused_hollow_cursor() {
             self.cursor_style.unwrap_or(self.default_cursor_style)
         } else {
             CursorStyle::HollowBlock

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -995,7 +995,7 @@ impl Term {
     ) -> RenderableCellsIter {
         let selection = selection.and_then(|s| s.to_span(self))
             .map(|span| span.to_range());
-        let cursor = if window_focused {
+        let cursor = if window_focused || !config.cursor_hollow_unfocused() {
             self.cursor_style.unwrap_or(self.default_cursor_style)
         } else {
             CursorStyle::HollowBlock


### PR DESCRIPTION
Currently Alacritty changes the cursor to a hollow block shape when the window loses focus. While it's a reasonable default, some may prefer their normal configured cursor. This PR adds a config toggle for this, defaulting to using the hollow block.