### PR TITLE
Add info about default configuration for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,10 @@ cp -r target/release/osx/Alacritty.app /Applications/
 
 Although it's possible the default configuration would work on your system,
 you'll probably end up wanting to customize it anyhow. There is a default
-`alacritty.yml` at the git repository root. Alacritty looks for the
-configuration file as the following paths:
+`alacritty.yml` and `alacritty_macos.yml` at the git repository root for
+Linux and macOS repsectively.
+
+Alacritty looks for the configuration file at the following paths:
 
 1. `$XDG_CONFIG_HOME/alacritty/alacritty.yml`
 2. `$XDG_CONFIG_HOME/alacritty.yml`
@@ -252,7 +254,7 @@ the config file. The only exception is the `font` and `dimensions` sections
 which requires Alacritty to be restarted. For further explanation of the config
 file, please consult the comments in the default config file.
 
-## Issues (known, unknown, feature requests, etc)
+## Issues (known, unknown, feature requests, etc.)
 
 If you run into a problem with Alacritty, please file an issue. If you've got a
 feature request, feel free to ask about it. Keep in mind that Alacritty is very


### PR DESCRIPTION
Updated README.md to include information for default macOS configuration file: `alacritty_macos.yml`