### PR TITLE
Add centos missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ missing, please open an issue.
 
 ```sh
 yum install cmake freetype-devel fontconfig-devel xclip
+yum group install "Development Tools" 
 ```
 
 #### openSUSE


### PR DESCRIPTION
CentOS was missing the development tools dependency to build alacritty.