### PR TITLE
Add caret key

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1883,6 +1883,7 @@ enum Key {
     WebSearch,
     WebStop,
     Yen,
+    Caret,
 }
 
 impl Key {
@@ -2040,6 +2041,7 @@ impl Key {
             Key::WebSearch => WebSearch,
             Key::WebStop => WebStop,
             Key::Yen => Yen,
+            Key::Caret => Caret,
         }
     }
 }


### PR DESCRIPTION
This fixes #680

It is rather old but it took some time for the winit changes to get into master + get the version bump into glutin.

Ref: https://github.com/tomaka/winit/pull/380

It allows on my germany keyboard to enter ^ (Caret) with the given configuration:

```
  - { key: Caret,                         chars: "\x5e"                          }
```

Mainly created to use VIM like I used to :-D