### PR TITLE
Make normal scrolling line amount configurable

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -33,8 +33,24 @@ window:
   # Setting this to false will result in window without borders and title bar.
   decorations: true
 
-# How many lines of scrollback to keep
-scroll_history: 10000
+scrolling:
+  # How many lines of scrollback to keep,
+  # '0' will disable scrolling.
+  history: 10000
+
+  # Number of lines the viewport will move for every line
+  # scrolled when scrollback is enabled (history > 0).
+  multiplier: 1
+
+  # Faux Scrolling
+  #
+  # The `faux_multiplier` setting controls the number
+  # of lines the terminal should scroll when the alternate
+  # screen buffer is active. This is used to allow mouse
+  # scrolling for applications like `man`.
+  #
+  # To disable this completely, set `faux_multiplier` to 0.
+  faux_multiplier: 3
 
 # Display tabs using this many cells (changes require restart)
 tabspaces: 8
@@ -208,22 +224,6 @@ mouse:
   # or triple click.
   double_click: { threshold: 300 }
   triple_click: { threshold: 300 }
-
-  # Faux Scrollback
-  #
-  # The `faux_scrollback_lines` setting controls the number
-  # of lines the terminal should scroll when the alternate
-  # screen buffer is active. This is used to allow mouse
-  # scrolling for applications like `man`.
-  #
-  # To disable this completely, set `faux_scrollback_lines` to 0.
-  faux_scrollback_lines: 1
-
-  # Normal Scrolling
-  #
-  # Number of lines the viewport will move when scrolling in
-  # the terminal with scrollback enabled (>0).
-  normal_scrolling_lines: 3
 
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -40,7 +40,7 @@ scrolling:
 
   # Number of lines the viewport will move for every line
   # scrolled when scrollback is enabled (history > 0).
-  multiplier: 1
+  multiplier: 3
 
   # Faux Scrolling
   #

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -223,7 +223,7 @@ mouse:
   #
   # Number of lines the viewport will move when scrolling in
   # the terminal with scrollback enabled (>0).
-  normal_scrolling_lines: 300
+  normal_scrolling_lines: 3
 
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -219,6 +219,12 @@ mouse:
   # To disable this completely, set `faux_scrollback_lines` to 0.
   faux_scrollback_lines: 1
 
+  # Normal Scrolling
+  #
+  # Number of lines the viewport will move when scrolling in
+  # the terminal with scrollback enabled (>0).
+  normal_scrolling_lines: 300
+
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -31,8 +31,24 @@ window:
   # Setting this to false will result in window without borders and title bar.
   decorations: true
 
-# How many lines of scrollback to keep
-scroll_history: 10000
+scrolling:
+  # How many lines of scrollback to keep,
+  # '0' will disable scrolling.
+  history: 10000
+
+  # Number of lines the viewport will move for every line
+  # scrolled when scrollback is enabled (history > 0).
+  multiplier: 3
+
+  # Faux Scrolling
+  #
+  # The `faux_multiplier` setting controls the number
+  # of lines the terminal should scroll when the alternate
+  # screen buffer is active. This is used to allow mouse
+  # scrolling for applications like `man`.
+  #
+  # To disable this completely, set `faux_multiplier` to 0.
+  faux_multiplier: 3
 
 # Display tabs using this many cells (changes require restart)
 tabspaces: 8
@@ -189,22 +205,6 @@ mouse:
   # or triple click.
   double_click: { threshold: 300 }
   triple_click: { threshold: 300 }
-
-  # Faux Scrollback
-  #
-  # The `faux_scrollback_lines` setting controls the number
-  # of lines the terminal should scroll when the alternate
-  # screen buffer is active. This is used to allow mouse
-  # scrolling for applications like `man`.
-  #
-  # To disable this completely, set `faux_scrollback_lines` to 0.
-  faux_scrollback_lines: 1
-
-  # Normal Scrolling
-  #
-  # Number of lines the viewport will move when scrolling in
-  # the terminal with scrollback enabled (>0).
-  normal_scrolling_lines: 3
 
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -200,6 +200,12 @@ mouse:
   # To disable this completely, set `faux_scrollback_lines` to 0.
   faux_scrollback_lines: 1
 
+  # Normal Scrolling
+  #
+  # Number of lines the viewport will move when scrolling in
+  # the terminal with scrollback enabled (>0).
+  normal_scrolling_lines: 3
+
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,21 +85,42 @@ pub struct Mouse {
     /// up/down arrows sent when scrolling in alt screen buffer
     #[serde(deserialize_with = "deserialize_faux_scrollback_lines")]
     #[serde(default="default_faux_scrollback_lines")]
-    pub faux_scrollback_lines: usize,
+    pub faux_scrollback_lines: u8,
+
+    /// Number of lines scrolled in normal buffer with scrollback
+    #[serde(deserialize_with = "deserialize_normal_scrolling_lines")]
+    #[serde(default="default_normal_scrolling_lines")]
+    pub normal_scrolling_lines: u8,
 }
 
-fn default_faux_scrollback_lines() -> usize {
+fn default_faux_scrollback_lines() -> u8 {
     1
 }
 
-fn deserialize_faux_scrollback_lines<'a, D>(deserializer: D) -> ::std::result::Result<usize, D::Error>
+fn default_normal_scrolling_lines() -> u8 {
+    3
+}
+
+fn deserialize_faux_scrollback_lines<'a, D>(deserializer: D) -> ::std::result::Result<u8, D::Error>
     where D: de::Deserializer<'a>
 {
-    match usize::deserialize(deserializer) {
+    match u8::deserialize(deserializer) {
         Ok(lines) => Ok(lines),
         Err(err) => {
             eprintln!("problem with config: {}; Using default value", err);
             Ok(default_faux_scrollback_lines())
+        },
+    }
+}
+
+fn deserialize_normal_scrolling_lines<'a, D>(deserializer: D) -> ::std::result::Result<u8, D::Error>
+    where D: de::Deserializer<'a>
+{
+    match u8::deserialize(deserializer) {
+        Ok(lines) => Ok(lines),
+        Err(err) => {
+            eprintln!("problem with config: {}; Using default value", err);
+            Ok(default_normal_scrolling_lines())
         },
     }
 }
@@ -113,7 +134,8 @@ impl Default for Mouse {
             triple_click: ClickHandler {
                 threshold: Duration::from_millis(300),
             },
-            faux_scrollback_lines: 1,
+            faux_scrollback_lines: default_faux_scrollback_lines(),
+            normal_scrolling_lines: default_normal_scrolling_lines(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -385,18 +385,6 @@ pub struct Config {
     scrolling: Scrolling,
 }
 
-fn deserialize_scroll_history<'a, D>(deserializer: D) -> ::std::result::Result<u32, D::Error>
-    where D: de::Deserializer<'a>
-{
-    match u32::deserialize(deserializer) {
-        Ok(lines) => Ok(lines),
-        Err(err) => {
-            eprintln!("problem with config: {}; Using default value", err);
-            Ok(default_scroll_history())
-        },
-    }
-}
-
 fn failure_default_vec<'a, D, T>(deserializer: D) -> ::std::result::Result<Vec<T>, D::Error>
     where D: de::Deserializer<'a>,
           T: Deserialize<'a>

--- a/src/event.rs
+++ b/src/event.rs
@@ -191,6 +191,7 @@ pub struct Processor<N> {
     key_bindings: Vec<KeyBinding>,
     mouse_bindings: Vec<MouseBinding>,
     mouse_config: config::Mouse,
+    scrolling_config: config::Scrolling,
     print_events: bool,
     wait_for_event: bool,
     notifier: N,
@@ -232,6 +233,7 @@ impl<N: Notify> Processor<N> {
             key_bindings: config.key_bindings().to_vec(),
             mouse_bindings: config.mouse_bindings().to_vec(),
             mouse_config: config.mouse().to_owned(),
+            scrolling_config: config.scrolling(),
             print_events: options.print_events,
             wait_for_event: true,
             notifier,
@@ -395,6 +397,7 @@ impl<N: Notify> Processor<N> {
 
             processor = input::Processor {
                 ctx: context,
+                scrolling_config: &self.scrolling_config,
                 mouse_config: &self.mouse_config,
                 key_bindings: &self.key_bindings[..],
                 mouse_bindings: &self.mouse_bindings[..],

--- a/src/input.rs
+++ b/src/input.rs
@@ -34,8 +34,6 @@ use term::SizeInfo;
 use term::mode::{self, TermMode};
 use util::fmt::Red;
 
-const SCROLL_MULTIPLIER: usize = 3;
-
 /// Processes input from glutin.
 ///
 /// An escape sequence may be emitted in case specific keys or key combinations
@@ -399,8 +397,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                     65
                 };
 
+                let scrolling_multiplier = self.mouse_config.normal_scrolling_lines;
                 for _ in 0..(to_scroll.abs() as usize) {
-                    self.scroll_terminal(mouse_modes, code, modifiers, SCROLL_MULTIPLIER)
+                    self.scroll_terminal(mouse_modes, code, modifiers, scrolling_multiplier)
                 }
 
                 self.ctx.mouse_mut().lines_scrolled = to_scroll % 1.0;
@@ -433,10 +432,10 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         }
     }
 
-    fn scroll_terminal(&mut self, mouse_modes: TermMode, code: u8, modifiers: ModifiersState, scroll_multiplier: usize) {
+    fn scroll_terminal(&mut self, mouse_modes: TermMode, code: u8, modifiers: ModifiersState, scroll_multiplier: u8) {
         debug_assert!(code == 64 || code == 65);
 
-        let faux_scrollback_lines = self.mouse_config.faux_scrollback_lines;
+        let faux_scrollback_lines = self.mouse_config.faux_scrollback_lines as usize;
         if self.ctx.terminal_mode().intersects(mouse_modes) {
             self.mouse_report(code, ElementState::Pressed);
         } else if self.ctx.terminal_mode().contains(TermMode::ALT_SCREEN)

--- a/src/input.rs
+++ b/src/input.rs
@@ -398,7 +398,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                     65
                 };
 
-                let scrolling_multiplier = self.mouse_config.normal_scrolling_lines;
+                let scrolling_multiplier = self.scrolling_config.multiplier;
                 for _ in 0..(to_scroll.abs() as usize) {
                     self.scroll_terminal(mouse_modes, code, modifiers, scrolling_multiplier)
                 }
@@ -436,7 +436,11 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     fn scroll_terminal(&mut self, mouse_modes: TermMode, code: u8, modifiers: ModifiersState, scroll_multiplier: u8) {
         debug_assert!(code == 64 || code == 65);
 
-        let faux_scrollback_lines = self.mouse_config.faux_scrollback_lines as usize;
+        // Make sure the new and deprecated setting are both allowed
+        let faux_scrollback_lines = self.mouse_config
+            .faux_scrollback_lines
+            .unwrap_or(self.scrolling_config.faux_multiplier as usize);
+
         if self.ctx.terminal_mode().intersects(mouse_modes) {
             self.mouse_report(code, ElementState::Pressed);
         } else if self.ctx.terminal_mode().contains(TermMode::ALT_SCREEN)

--- a/src/input.rs
+++ b/src/input.rs
@@ -44,6 +44,7 @@ pub struct Processor<'a, A: 'a> {
     pub key_bindings: &'a [KeyBinding],
     pub mouse_bindings: &'a [MouseBinding],
     pub mouse_config: &'a config::Mouse,
+    pub scrolling_config: &'a config::Scrolling,
     pub ctx: A,
 }
 
@@ -711,8 +712,9 @@ mod tests {
                         triple_click: ClickHandler {
                             threshold: Duration::from_millis(1000),
                         },
-                        faux_scrollback_lines: 1,
+                        faux_scrollback_lines: None,
                     },
+                    scrolling_config: &config::Scrolling::default(),
                     key_bindings: &config.key_bindings()[..],
                     mouse_bindings: &config.mouse_bindings()[..],
                 };

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -847,7 +847,8 @@ impl Term {
         let num_cols = size.cols();
         let num_lines = size.lines();
 
-        let grid = Grid::new(num_lines, num_cols, config.scroll_history(), template);
+        let history_size = config.scrolling().history as usize;
+        let grid = Grid::new(num_lines, num_cols, history_size, template);
 
         let tabspaces = config.tabspaces();
         let tabs = IndexRange::from(Column(0)..grid.num_cols())


### PR DESCRIPTION
It is now possible to configure the amount of lines the viewport should
scroll when using the normal scrolling mode.

This fixes #1160.