### PR TITLE
Fix selection in scrollback

### DIFF
--- a/out
+++ b/out
@@ -1,0 +1,104 @@
+   Compiling alacritty v0.1.0 (file:///home/undeadleech/programming/rust/alacritty)
+warning: unused variable: `count`
+  --> src/input.rs:69:26
+   |
+69 |     fn scroll(&mut self, count: isize) {}
+   |                          ^^^^^ help: consider using `_count` instead
+   |
+   = note: #[warn(unused_variables)] on by default
+
+warning: unused variable: `previous_scroll_limit`
+   --> src/grid/mod.rs:217:13
+    |
+217 |         let previous_scroll_limit = self.scroll_limit;
+    |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using `_previous_scroll_limit` instead
+
+warning: value assigned to `start` is never read
+   --> src/selection.rs:184:13
+    |
+184 |         let mut start = initial_expansion.start;
+    |             ^^^^^^^^^
+    |
+    = note: #[warn(unused_assignments)] on by default
+
+warning: value assigned to `end` is never read
+   --> src/selection.rs:185:13
+    |
+185 |         let mut end = initial_expansion.end;
+    |             ^^^^^^^
+
+warning: method is never used: `pop`
+  --> src/grid/storage.rs:50:5
+   |
+50 |     pub fn pop(&mut self) -> Option<T> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: #[warn(dead_code)] on by default
+
+warning: method is never used: `swap`
+  --> src/grid/storage.rs:69:5
+   |
+69 |     pub fn swap(&mut self, a: usize, b: usize) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Finished dev [unoptimized + debuginfo] target(s) in 9.82 secs
+     Running `target/debug/alacritty`
+thread 'main' panicked at 'attempt to subtract with overflow', src/index.rs:414:17
+stack backtrace:
+   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
+             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
+   1: std::sys_common::backtrace::_print
+             at libstd/sys_common/backtrace.rs:71
+   2: std::panicking::default_hook::{{closure}}
+             at libstd/sys_common/backtrace.rs:59
+             at libstd/panicking.rs:207
+   3: std::panicking::default_hook
+             at libstd/panicking.rs:223
+   4: std::panicking::rust_panic_with_hook
+             at libstd/panicking.rs:402
+   5: std::panicking::begin_panic_fmt
+             at libstd/panicking.rs:349
+   6: rust_begin_unwind
+             at libstd/panicking.rs:325
+   7: core::panicking::panic_fmt
+             at libcore/panicking.rs:72
+   8: core::panicking::panic
+             at libcore/panicking.rs:51
+   9: <alacritty::index::Column as core::ops::arith::SubAssign<usize>>::sub_assign
+             at src/index.rs:414
+  10: alacritty::selection::Selection::span_simple
+             at src/selection.rs:283
+  11: alacritty::selection::Selection::to_span
+             at src/selection.rs:167
+  12: alacritty::term::Term::renderable_cells::{{closure}}
+             at src/term/mod.rs:1058
+  13: <core::option::Option<T>>::and_then
+             at /checkout/src/libcore/option.rs:612
+  14: alacritty::term::Term::renderable_cells
+             at src/term/mod.rs:1057
+  15: alacritty::display::Display::draw::{{closure}}
+             at src/display.rs:368
+  16: alacritty::renderer::QuadRenderer::with_api
+             at src/renderer/mod.rs:658
+  17: alacritty::display::Display::draw
+             at src/display.rs:360
+  18: alacritty::run
+             at src/main.rs:203
+  19: alacritty::main
+             at src/main.rs:62
+  20: std::rt::lang_start::{{closure}}
+             at /checkout/src/libstd/rt.rs:74
+  21: std::panicking::try::do_call
+             at libstd/rt.rs:59
+             at libstd/panicking.rs:306
+  22: __rust_maybe_catch_panic
+             at libpanic_unwind/lib.rs:102
+  23: std::rt::lang_start_internal
+             at libstd/panicking.rs:285
+             at libstd/panic.rs:361
+             at libstd/rt.rs:58
+  24: std::rt::lang_start
+             at /checkout/src/libstd/rt.rs:74
+  25: main
+  26: __libc_start_main
+  27: _start

--- a/src/event.rs
+++ b/src/event.rs
@@ -154,8 +154,8 @@ pub enum ClickState {
 
 /// State of the mouse
 pub struct Mouse {
-    pub x: u32,
-    pub y: u32,
+    pub x: usize,
+    pub y: usize,
     pub left_button_state: ElementState,
     pub last_click_timestamp: Instant,
     pub click_state: ClickState,
@@ -309,13 +309,11 @@ impl<N: Notify> Processor<N> {
                         processor.ctx.terminal.dirty = true;
                     },
                     CursorMoved { position: (x, y), modifiers, .. } => {
-                        let x = x as i32;
-                        let y = y as i32;
-                        let x = limit(x, 0, processor.ctx.size_info.width as i32);
-                        let y = limit(y, 0, processor.ctx.size_info.height as i32);
+                        let x = limit(x as i32, 0, processor.ctx.size_info.width as i32);
+                        let y = limit(y as i32, 0, processor.ctx.size_info.height as i32);
 
                         *hide_cursor = false;
-                        processor.mouse_moved(x as u32, y as u32, modifiers);
+                        processor.mouse_moved(x as usize, y as usize, modifiers);
                     },
                     MouseWheel { delta, phase, modifiers, .. } => {
                         *hide_cursor = false;

--- a/src/input.rs
+++ b/src/input.rs
@@ -275,7 +275,10 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             let cell_x = (x as usize - size_info.padding_x as usize) % size_info.cell_width as usize;
             let half_cell_width = (size_info.cell_width / 2.0) as usize;
 
-            let cell_side = if cell_x > half_cell_width {
+            let cell_side = if cell_x > half_cell_width
+                // Edge case when mouse leaves the window
+                || x as f32 >= size_info.width - size_info.padding_x
+            {
                 Side::Right
             } else {
                 Side::Left

--- a/src/input.rs
+++ b/src/input.rs
@@ -263,44 +263,43 @@ impl From<&'static str> for Action {
 
 impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     #[inline]
-    pub fn mouse_moved(&mut self, x: u32, y: u32, modifiers: ModifiersState) {
+    pub fn mouse_moved(&mut self, x: usize, y: usize, modifiers: ModifiersState) {
         self.ctx.mouse_mut().x = x;
         self.ctx.mouse_mut().y = y;
 
         let size_info = self.ctx.size_info();
-        if let Some(point) = size_info.pixels_to_coords(x as usize, y as usize) {
-            let prev_line = mem::replace(&mut self.ctx.mouse_mut().line, point.line);
-            let prev_col = mem::replace(&mut self.ctx.mouse_mut().column, point.col);
+        let point = size_info.pixels_to_coords(x, y);
 
-            let cell_x = (x as usize - size_info.padding_x as usize) % size_info.cell_width as usize;
-            let half_cell_width = (size_info.cell_width / 2.0) as usize;
+        let prev_line = mem::replace(&mut self.ctx.mouse_mut().line, point.line);
+        let prev_col = mem::replace(&mut self.ctx.mouse_mut().column, point.col);
 
-            let cell_side = if cell_x > half_cell_width
-                // Edge case when mouse leaves the window
-                || x as f32 >= size_info.width - size_info.padding_x
+        let cell_x = x.saturating_sub(size_info.padding_x as usize) % size_info.cell_width as usize;
+        let half_cell_width = (size_info.cell_width / 2.0) as usize;
+
+        let cell_side = if cell_x > half_cell_width
+            // Edge case when mouse leaves the window
+            || x as f32 >= size_info.width - size_info.padding_x
+        {
+            Side::Right
+        } else {
+            Side::Left
+        };
+        self.ctx.mouse_mut().cell_side = cell_side;
+
+        if self.ctx.mouse_mut().left_button_state == ElementState::Pressed {
+            let report_mode = mode::TermMode::MOUSE_REPORT_CLICK | mode::TermMode::MOUSE_MOTION;
+            if modifiers.shift || !self.ctx.terminal_mode().intersects(report_mode) {
+                self.ctx.update_selection(Point {
+                    line: point.line,
+                    col: point.col
+                }, cell_side);
+            } else if self.ctx.terminal_mode().contains(mode::TermMode::MOUSE_MOTION)
+                // Only report motion when changing cells
+                && (prev_line != self.ctx.mouse_mut().line
+                    || prev_col != self.ctx.mouse_mut().column)
+                && size_info.contains_point(x, y)
             {
-                Side::Right
-            } else {
-                Side::Left
-            };
-            self.ctx.mouse_mut().cell_side = cell_side;
-
-            if self.ctx.mouse_mut().left_button_state == ElementState::Pressed {
-                let report_mode = mode::TermMode::MOUSE_REPORT_CLICK | mode::TermMode::MOUSE_MOTION;
-                if modifiers.shift || !self.ctx.terminal_mode().intersects(report_mode) {
-                    self.ctx.update_selection(Point {
-                        line: point.line,
-                        col: point.col
-                    }, cell_side);
-                } else if self.ctx.terminal_mode().contains(mode::TermMode::MOUSE_MOTION)
-                        // Only report motion when changing cells
-                        && (
-                            prev_line != self.ctx.mouse_mut().line
-                            || prev_col != self.ctx.mouse_mut().column
-                        )
-                {
-                    self.mouse_report(32, ElementState::Pressed);
-                }
+                self.mouse_report(32, ElementState::Pressed);
             }
         }
     }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -253,8 +253,31 @@ impl Selection {
 
         // Handle some edge cases
         if start.line > end.line {
-            start.col += 1;
-            end.col -= 1;
+            if end.col > Column(0) {
+                start.col += 1;
+                end.col -= 1;
+            }
+            // Special case for when a multi-line selection to the
+            // bottom ends on a new line with just one cell selected
+            // and the first cell should not be selected
+            else {
+                if start_side == Side::Right {
+                    start.col += 1;
+                }
+
+                // Remove the single selected cell if mouse left window
+                if end_side == Side::Left {
+                    end.line += 1;
+                    end.col = cols - 1;
+                }
+
+                return Some(Span {
+                    cols,
+                    front: end,
+                    tail: start,
+                    ty: SpanType::Inclusive,
+                });
+            }
         } else if start.line < end.line {
             start.col -= 1;
             end.col += 1;

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -279,8 +279,31 @@ impl Selection {
                 });
             }
         } else if start.line < end.line {
-            start.col -= 1;
             end.col += 1;
+            if start.col > Column(0) {
+                start.col -= 1;
+            }
+            // Special case for when a selection is started
+            // in the first cell of a line
+            else {
+                let ty = match end_side {
+                    Side::Left => SpanType::ExcludeTail,
+                    Side::Right => SpanType::Inclusive,
+                };
+
+                // Switch start cell to last cell of previous line
+                if start_side == Side::Left {
+                    start.line += 1;
+                    start.col = cols - 1;
+                }
+
+                return Some(Span {
+                    ty,
+                    cols,
+                    front: start,
+                    tail: end,
+                });
+            }
         }
 
         let (front, tail, front_side, tail_side) = if start > end {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -191,8 +191,6 @@ impl Selection {
             (region.end, region.start)
         };
 
-        println!("BEFORE front={:?}, start={:?}, tail={:?}, end={:?}", front, start, tail, end);
-
         if front < tail && front.line == tail.line {
             start = grid.semantic_search_left(front);
             end = grid.semantic_search_right(tail);
@@ -200,8 +198,6 @@ impl Selection {
             start = grid.semantic_search_right(front);
             end = grid.semantic_search_left(tail);
         }
-
-        println!("AFTER  front={:?}, start={:?}, tail={:?}, end={:?}", front, start, tail, end);
 
         if start > end {
             ::std::mem::swap(&mut start, &mut end);
@@ -249,11 +245,20 @@ impl Selection {
     }
 
     fn span_simple<G: Dimensions>(grid: &G, region: &Range<Anchor>) -> Option<Span> {
-        let start = region.start.point;
+        let mut start = region.start.point;
         let start_side = region.start.side;
-        let end = region.end.point;
+        let mut end = region.end.point;
         let end_side = region.end.side;
         let cols = grid.dimensions().col;
+
+        // Handle some edge cases
+        if start.line > end.line {
+            start.col += 1;
+            end.col -= 1;
+        } else if start.line < end.line {
+            start.col -= 1;
+            end.col += 1;
+        }
 
         let (front, tail, front_side, tail_side) = if start > end {
             // Selected upward; start/end are swapped

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -134,7 +134,7 @@ impl<'a> RenderableCellsIter<'a> {
                     Some((start_line, loc.start.col, end_line, loc.end.col))
                 },
                 (Some(start_line), None) => {
-                    Some((start_line, loc.start.col, Line(0), grid.num_cols()))
+                    Some((start_line, loc.start.col, Line(0), Column(0)))
                 },
                 (None, Some(end_line)) => {
                     Some((grid.num_lines(), Column(0), end_line, loc.end.col))

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1057,7 +1057,6 @@ impl Term {
         let selection = self.grid.selection.as_ref()
             .and_then(|s| s.to_span(self))
             .map(|span| {
-                // println!("span={:?}, locations={:?}", span, span.to_locations());
                 span.to_locations()
             });
         let cursor = if window_focused {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -790,25 +790,21 @@ impl SizeInfo {
         Column(((self.width - 2. * self.padding_x) / self.cell_width) as usize)
     }
 
-    fn contains_point(&self, x: usize, y:usize) -> bool {
+    pub fn contains_point(&self, x: usize, y:usize) -> bool {
         x <= (self.width - self.padding_x) as usize &&
             x >= self.padding_x as usize &&
             y <= (self.height - self.padding_y) as usize &&
             y >= self.padding_y as usize
     }
 
-    pub fn pixels_to_coords(&self, x: usize, y: usize) -> Option<Point> {
-        if !self.contains_point(x, y) {
-            return None;
-        }
+    pub fn pixels_to_coords(&self, x: usize, y: usize) -> Point {
+        let col = Column(x.saturating_sub(self.padding_x as usize) / (self.cell_width as usize));
+        let line = Line(y.saturating_sub(self.padding_y as usize) / (self.cell_height as usize));
 
-        let col = Column((x - self.padding_x as usize) / (self.cell_width as usize));
-        let line = Line((y - self.padding_y as usize) / (self.cell_height as usize));
-
-        Some(Point {
+        Point {
             line: min(line, self.lines() - 1),
             col: min(col, self.cols() - 1)
-        })
+        }
     }
 }
 
@@ -1033,7 +1029,11 @@ impl Term {
     ///
     /// Returns None if the coordinates are outside the screen
     pub fn pixels_to_coords(&self, x: usize, y: usize) -> Option<Point> {
-        self.size_info().pixels_to_coords(x, y)
+        if self.size_info.contains_point(x, y) {
+            Some(self.size_info.pixels_to_coords(x, y))
+        } else {
+            None
+        }
     }
 
     /// Access to the raw grid data structure


### PR DESCRIPTION
There were a few issues with selection in scrollback that were mainly
off-by-one errors. This aims at fixing these issues.

This also fixes a bug that currently exists in master where the last
cell is not selected when the mouse leaves the window to the right.

This fixes #1159 and fixes #1182.