### PR TITLE
Fix crash when selection leaves viewport

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -148,13 +148,17 @@ impl<T: Copy + Clone> Grid<T> {
 
     pub fn buffer_to_visible(&self, point: Point<usize>) -> Point {
         Point {
-            line: self.buffer_line_to_visible(point.line),
+            line: self.buffer_line_to_visible(point.line).expect("Line not visible"),
             col: point.col
         }
     }
 
-    pub fn buffer_line_to_visible(&self, line: usize) -> Line {
-        self.offset_to_line(line - self.display_offset)
+    pub fn buffer_line_to_visible(&self, line: usize) -> Option<Line> {
+        if line >= self.display_offset {
+            self.offset_to_line(line - self.display_offset)
+        } else {
+            None
+        }
     }
 
     pub fn visible_line_to_buffer(&self, line: Line) -> usize {
@@ -267,10 +271,12 @@ impl<T: Copy + Clone> Grid<T> {
         *(self.num_lines() - line - 1)
     }
 
-    pub fn offset_to_line(&self, offset: usize) -> Line {
-        assert!(offset < *self.num_lines());
-
-        self.lines - offset - 1
+    pub fn offset_to_line(&self, offset: usize) -> Option<Line> {
+        if offset < *self.num_lines() {
+            Some(self.lines - offset - 1)
+        } else {
+            None
+        }
     }
 
     #[inline]


### PR DESCRIPTION
There was an issue where alacritty tries to convert the lines in a
selection to the on-screen lines even when the selection is not on the
screen. This results in a crash.

To prevent this from happening the selection now is not shown if it is
off the screen.

There currently still is a bug that when the selection is at the top of
the screen but still half visible, it will not show the top line as
selected but start in the second line.
This bug should be resolved with
https://github.com/jwilm/alacritty/pull/1171.

This fixes #1148.