### PR TITLE
Add scrollback hotkeys

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -281,7 +281,18 @@ live_config_reload: true
 # around them.
 #
 # Either an `action`, `chars`, or `command` field must be present.
-#   `action` must be one of `Paste`, `PasteSelection`, `Copy`, or `Quit`.
+#   `action` must be one of the following:
+#       - `Paste`
+#       - `PasteSelection`
+#       - `Copy`
+#       - `IncreaseFontSize`
+#       - `DecreaseFontSize`
+#       - `ResetFontSize`
+#       - `ScrollPageUp`
+#       - `ScrollPageDown`
+#       - `ScrollToTop`
+#       - `ScrollToBottom`
+#       - `Quit`
 #   `chars` writes the specified string every time that binding is activated.
 #     These should generally be escape sequences, but they can be configured to
 #     send arbitrary strings of bytes.

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -262,7 +262,18 @@ live_config_reload: true
 # around them.
 #
 # Either an `action`, `chars`, or `command` field must be present.
-#   `action` must be one of `Paste`, `PasteSelection`, `Copy`, or `Quit`.
+#   `action` must be one of the following:
+#       - `Paste`
+#       - `PasteSelection`
+#       - `Copy`
+#       - `IncreaseFontSize`
+#       - `DecreaseFontSize`
+#       - `ResetFontSize`
+#       - `ScrollPageUp`
+#       - `ScrollPageDown`
+#       - `ScrollToTop`
+#       - `ScrollToBottom`
+#       - `Quit`
 #   `chars` writes the specified string every time that binding is activated.
 #     These should generally be escape sequences, but they can be configured to
 #     send arbitrary strings of bytes.

--- a/src/config.rs
+++ b/src/config.rs
@@ -588,7 +588,8 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
             type Value = ActionWrapper;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, ResetFontSize, or Quit")
+                f.write_str("Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, \
+                            ResetFontSize, ScrollPageUp, ScrollPageDown, ScrollToTop, ScrollToBottom or Quit")
             }
 
             fn visit_str<E>(self, value: &str) -> ::std::result::Result<ActionWrapper, E>
@@ -601,6 +602,10 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
                     "IncreaseFontSize" => Action::IncreaseFontSize,
                     "DecreaseFontSize" => Action::DecreaseFontSize,
                     "ResetFontSize" => Action::ResetFontSize,
+                    "ScrollPageUp" => Action::ScrollPageUp,
+                    "ScrollPageDown" => Action::ScrollPageDown,
+                    "ScrollToTop" => Action::ScrollToTop,
+                    "ScrollToBottom" => Action::ScrollToBottom,
                     "Quit" => Action::Quit,
                     _ => return Err(E::invalid_value(Unexpected::Str(value), &self)),
                 }))

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,6 +10,7 @@ use parking_lot::MutexGuard;
 use glutin::{self, ModifiersState, Event, ElementState};
 use copypasta::{Clipboard, Load, Store};
 
+use grid::Scroll;
 use config::{self, Config};
 use cli::Options;
 use display::OnResize;
@@ -53,24 +54,8 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         *self.size_info
     }
 
-    fn scroll(&mut self, count: isize) {
-        self.terminal.scroll_display(count);
-    }
-
-    fn reset_scroll(&mut self) {
-        self.terminal.reset_scroll();
-    }
-
-    fn scroll_to_top(&mut self) {
-        self.terminal.scroll_to_top();
-    }
-
-    fn scroll_page_up(&mut self) {
-        self.terminal.scroll_page_up();
-    }
-
-    fn scroll_page_down(&mut self) {
-        self.terminal.scroll_page_down();
+    fn scroll(&mut self, scroll: Scroll) {
+        self.terminal.scroll_display(scroll);
     }
 
     fn copy_selection(&self, buffer: ::copypasta::Buffer) {

--- a/src/event.rs
+++ b/src/event.rs
@@ -61,6 +61,18 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         self.terminal.reset_scroll();
     }
 
+    fn scroll_to_top(&mut self) {
+        self.terminal.scroll_to_top();
+    }
+
+    fn scroll_page_up(&mut self) {
+        self.terminal.scroll_page_up();
+    }
+
+    fn scroll_page_down(&mut self) {
+        self.terminal.scroll_page_down();
+    }
+
     fn copy_selection(&self, buffer: ::copypasta::Buffer) {
         self.terminal
             .selection_to_string()

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -176,6 +176,26 @@ impl<T: Copy + Clone> Grid<T> {
         self.display_offset = 0;
     }
 
+    pub fn scroll_to_top(&mut self) {
+        self.display_offset = self.scroll_limit;
+    }
+
+    pub fn scroll_page_up(&mut self) {
+        if self.display_offset + self.lines.0 >= self.scroll_limit {
+            self.display_offset = self.scroll_limit;
+        } else {
+            self.display_offset += self.lines.0;
+        }
+    }
+
+    pub fn scroll_page_down(&mut self) {
+        if self.display_offset <= self.lines.0 {
+            self.display_offset = 0;
+        } else {
+            self.display_offset -= self.lines.0;
+        }
+    }
+
     pub fn resize(&mut self, lines: index::Line, cols: index::Column) {
         // Check that there's actually work to do and return early if not
         if lines == self.lines && cols == self.cols {

--- a/src/input.rs
+++ b/src/input.rs
@@ -28,6 +28,7 @@ use copypasta::{Clipboard, Load, Buffer};
 use glutin::{ElementState, VirtualKeyCode, MouseButton, TouchPhase, MouseScrollDelta, ModifiersState};
 
 use config;
+use grid::Scroll;
 use event::{ClickState, Mouse};
 use index::{Line, Column, Side, Point};
 use term::SizeInfo;
@@ -65,11 +66,7 @@ pub trait ActionContext {
     fn last_modifiers(&mut self) -> &mut ModifiersState;
     fn change_font_size(&mut self, delta: i8);
     fn reset_font_size(&mut self);
-    fn scroll(&mut self, count: isize);
-    fn reset_scroll(&mut self);
-    fn scroll_to_top(&mut self);
-    fn scroll_page_up(&mut self);
-    fn scroll_page_down(&mut self);
+    fn scroll(&mut self, scroll: Scroll);
 }
 
 /// Describes a state and action to take in that state
@@ -250,16 +247,16 @@ impl Action {
                ctx.reset_font_size();
             },
             Action::ScrollPageUp => {
-                ctx.scroll_page_up();
+                ctx.scroll(Scroll::PageUp);
             },
             Action::ScrollPageDown => {
-                ctx.scroll_page_down();
+                ctx.scroll(Scroll::PageDown);
             },
             Action::ScrollToTop => {
-                ctx.scroll_to_top();
+                ctx.scroll(Scroll::Top);
             },
             Action::ScrollToBottom => {
-                ctx.reset_scroll();
+                ctx.scroll(Scroll::Bottom);
             },
         }
     }
@@ -486,7 +483,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             self.ctx.write_to_pty(content);
         } else {
             for _ in 0..scroll_multiplier {
-                self.ctx.scroll(-((code as isize) * 2 - 129));
+                self.ctx.scroll(Scroll::Lines(-((code as isize) * 2 - 129)));
             }
         }
     }
@@ -553,7 +550,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     /// Process a received character
     pub fn received_char(&mut self, c: char) {
         if !*self.ctx.suppress_chars() {
-            self.ctx.reset_scroll();
+            self.ctx.scroll(Scroll::Bottom);
             self.ctx.clear_selection();
 
             let utf8_len = c.len_utf8();

--- a/src/input.rs
+++ b/src/input.rs
@@ -65,8 +65,11 @@ pub trait ActionContext {
     fn last_modifiers(&mut self) -> &mut ModifiersState;
     fn change_font_size(&mut self, delta: i8);
     fn reset_font_size(&mut self);
-    fn scroll(&mut self, count: isize) {}
-    fn reset_scroll(&mut self) {}
+    fn scroll(&mut self, count: isize);
+    fn reset_scroll(&mut self);
+    fn scroll_to_top(&mut self);
+    fn scroll_page_up(&mut self);
+    fn scroll_page_down(&mut self);
 }
 
 /// Describes a state and action to take in that state
@@ -168,6 +171,18 @@ pub enum Action {
     /// Reset font size to the config value
     ResetFontSize,
 
+    /// Scroll exactly one page up
+    ScrollPageUp,
+
+    /// Scroll exactly one page down
+    ScrollPageDown,
+
+    /// Scroll all the way to the top
+    ScrollToTop,
+
+    /// Scroll all the way to the bottom
+    ScrollToBottom,
+
     /// Run given command
     Command(String, Vec<String>),
 
@@ -233,7 +248,19 @@ impl Action {
             }
             Action::ResetFontSize => {
                ctx.reset_font_size();
-            }
+            },
+            Action::ScrollPageUp => {
+                ctx.scroll_page_up();
+            },
+            Action::ScrollPageDown => {
+                ctx.scroll_page_down();
+            },
+            Action::ScrollToTop => {
+                ctx.scroll_to_top();
+            },
+            Action::ScrollToBottom => {
+                ctx.reset_scroll();
+            },
         }
     }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -24,7 +24,7 @@ use unicode_width::UnicodeWidthChar;
 
 use font::{self, Size};
 use ansi::{self, Color, NamedColor, Attr, Handler, CharsetIndex, StandardCharset, CursorStyle};
-use grid::{BidirectionalIterator, Grid, Indexed, IndexRegion, DisplayIter};
+use grid::{BidirectionalIterator, Grid, Indexed, IndexRegion, DisplayIter, Scroll};
 use index::{self, Point, Column, Line, IndexRange, Contains, RangeInclusive, Linear};
 use selection::{self, Selection, Locations};
 use config::{Config, VisualBellAnimation};
@@ -823,28 +823,8 @@ impl Term {
         self.next_title.take()
     }
 
-    pub fn scroll_display(&mut self, count: isize) {
-        self.grid.scroll_display(count);
-        self.dirty = true;
-    }
-
-    pub fn reset_scroll(&mut self) {
-        self.grid.reset_scroll_display();
-        self.dirty = true;
-    }
-
-    pub fn scroll_to_top(&mut self) {
-        self.grid.scroll_to_top();
-        self.dirty = true;
-    }
-
-    pub fn scroll_page_up(&mut self) {
-        self.grid.scroll_page_up();
-        self.dirty = true;
-    }
-
-    pub fn scroll_page_down(&mut self) {
-        self.grid.scroll_page_down();
+    pub fn scroll_display(&mut self, scroll: Scroll) {
+        self.grid.scroll_display(scroll);
         self.dirty = true;
     }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -830,6 +830,22 @@ impl Term {
 
     pub fn reset_scroll(&mut self) {
         self.grid.reset_scroll_display();
+        self.dirty = true;
+    }
+
+    pub fn scroll_to_top(&mut self) {
+        self.grid.scroll_to_top();
+        self.dirty = true;
+    }
+
+    pub fn scroll_page_up(&mut self) {
+        self.grid.scroll_page_up();
+        self.dirty = true;
+    }
+
+    pub fn scroll_page_down(&mut self) {
+        self.grid.scroll_page_down();
+        self.dirty = true;
     }
 
     #[inline]


### PR DESCRIPTION
This offers a few additional hotkeys that can be used in combination
with scrollback. None of these are used by default yet.

This implements the following bindings:
 - ScrollPageUp: Scroll exactly one screen height up
 - ScrollPageDown: Scroll exactly one screen height down
 - ScrollToTop: Scroll as far up as possible
 - ScrollToBottom: Scroll as far down as possible

This fixes #1151.