### PR TITLE
Enable SRGB (fix #921)

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -200,6 +200,7 @@ impl Window {
             .with_transparency(true)
             .with_decorations(window_config.decorations());
         let context = ContextBuilder::new()
+            .with_srgb(true)
             .with_vsync(true);
         let window = ::glutin::GlWindow::new(window, context, &event_loop)?;
         window.show();


### PR DESCRIPTION
This fixes #921, the error `Error creating GL context; Couldn't find any pixel format that matches the criterias.`.

I'm not sure whether this is right and ideal solution, but [this change actually fix the issue for some people](https://github.com/jwilm/alacritty/issues/921#issuecomment-372295759) including me.