### PR TITLE
Try to create window with different SRGB config when failed (solve #921, #1178)

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -183,6 +183,17 @@ impl From<glutin::ContextError> for Error {
     }
 }
 
+fn create_gl_window(
+    window: WindowBuilder,
+    event_loop: &EventsLoop,
+    srgb: bool,
+) -> ::std::result::Result<glutin::GlWindow, glutin::CreationError> {
+    let context = ContextBuilder::new()
+        .with_srgb(srgb)
+        .with_vsync(true);
+    ::glutin::GlWindow::new(window, context, event_loop)
+}
+
 impl Window {
     /// Create a new window
     ///
@@ -199,10 +210,8 @@ impl Window {
             .with_visibility(false)
             .with_transparency(true)
             .with_decorations(window_config.decorations());
-        let context = ContextBuilder::new()
-            .with_srgb(true)
-            .with_vsync(true);
-        let window = ::glutin::GlWindow::new(window, context, &event_loop)?;
+        let window = create_gl_window(window.clone(), &event_loop, false)
+            .or_else(|_| create_gl_window(window, &event_loop, true))?;
         window.show();
 
         // Text cursor


### PR DESCRIPTION
By this patch, alacritty will try to create window with SRGB enabled at first,
but when creation failed, retry with SRGB disabled.

This may truly solve #921, and issue caused by #1178: <https://github.com/jwilm/alacritty/issues/921#issuecomment-372619121>.