### PR TITLE
Explicitly call log::set_max_level (Closes: #1201)

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -31,6 +31,7 @@ impl<T: Send + io::Write> Logger<T> {
     // False positive, see: https://github.com/rust-lang-nursery/rust-clippy/issues/734
     #[cfg_attr(feature = "clippy", allow(new_ret_no_self))]
     pub fn new(output: T, level: log::LevelFilter) -> Logger<io::LineWriter<T>> {
+        log::set_max_level(level);
         Logger {
             level,
             output: sync::Mutex::new(io::LineWriter::new(output))


### PR DESCRIPTION
For some reason, log 0.4 requires that we explicitly set the log level
with log::set_max_level or it defaults to Off.  The documentation
isn't clear but suggests we must do this in addition to doing the
filtration ourselves in the Log impl.