### PR TITLE
Fix cursor not showing in first column

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -744,25 +744,28 @@ impl<'a, T: Copy + 'a> Iterator for DisplayIter<'a, T> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        // Make sure indices are valid. Return None if we've reached the end.
+        // Check if the end of the line was reached
         let next_line = self.col == self.grid.num_cols();
         if next_line {
+            // Return `None` if we've reached the end of the last line
             if self.offset == self.limit {
                 return None;
             }
 
+            // Switch to the next line
             self.col = Column(0);
             self.offset -= 1;
             self.line = Line(*self.grid.lines - 1 - (self.offset - self.limit));
         }
 
-        // Return the next item.
+        // Return the next item
         let item = Some(Indexed {
             inner: self.grid.raw[self.offset][self.col],
             line: self.line,
             column: self.col
         });
 
+        // Only increment column if the line hasn't changed
         if !next_line {
             self.col += 1;
         }

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -745,13 +745,13 @@ impl<'a, T: Copy + 'a> Iterator for DisplayIter<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         // Make sure indices are valid. Return None if we've reached the end.
-        if self.col == self.grid.num_cols() {
+        let next_line = self.col == self.grid.num_cols();
+        if next_line {
             if self.offset == self.limit {
                 return None;
             }
 
             self.col = Column(0);
-
             self.offset -= 1;
             self.line = Line(*self.grid.lines - 1 - (self.offset - self.limit));
         }
@@ -763,7 +763,9 @@ impl<'a, T: Copy + 'a> Iterator for DisplayIter<'a, T> {
             column: self.col
         });
 
-        self.col += 1;
+        if !next_line {
+            self.col += 1;
+        }
         item
     }
 }


### PR DESCRIPTION
There was a bug in the display iterator where the first column was never
reached after the top line because it was instantly incremented to 1
after it was reset when iterator column reached the end of the terminal
width.

This has been fixed by making sure that the column is never incremented
when the column is reset due to a change in terminal line.

This fixes #1198.