### PR TITLE
Fixes typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Alacritty
 
 Alacritty is the fastest terminal emulator in existence. Using the GPU for
 rendering enables optimizations that simply aren't possible in other emulators.
-Alacritty currently supports FreeBSD, Linux and macOS. Windows support is planned
+Alacritty currently supports FreeBSD, Linux, and macOS. Windows support is planned
 before the 1.0 release.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Alacritty
 
 Alacritty is the fastest terminal emulator in existence. Using the GPU for
 rendering enables optimizations that simply aren't possible in other emulators.
-Alacritty currently supports freeBSD, macOS and Linux. Windows support is planned
+Alacritty currently supports FreeBSD, Linux and macOS. Windows support is planned
 before the 1.0 release.
 
 <p align="center">


### PR DESCRIPTION
Fixes a typo in the name of FreeBSD, and reorders the OS support list alphabetically.