### PR TITLE
Don't paste selection when in mouse mode

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -191,12 +191,16 @@ impl Action {
                     });
             },
             Action::PasteSelection => {
-                Clipboard::new()
-                    .and_then(|clipboard| clipboard.load_selection() )
-                    .map(|contents| { self.paste(ctx, contents) })
-                    .unwrap_or_else(|err| {
-                        warn!("Error loading data from clipboard. {}", Red(err));
-                    });
+                // Only paste if mouse events are not captured by an application
+                let mouse_modes = TermMode::MOUSE_REPORT_CLICK | TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION;
+                if !ctx.terminal_mode().intersects(mouse_modes) {
+                    Clipboard::new()
+                        .and_then(|clipboard| clipboard.load_selection() )
+                        .map(|contents| { self.paste(ctx, contents) })
+                        .unwrap_or_else(|err| {
+                            warn!("Error loading data from clipboard. {}", Red(err));
+                        });
+                }
             },
             Action::Command(ref program, ref args) => {
                 trace!("running command: {} {:?}", program, args);


### PR DESCRIPTION
When the mouse mode is set using either 1000h, 1002h or 1003h, the
selection should not be pasted when hitting the middle mouse button,
because it is job of the application to handle this when mouse mode is
enabled.

This has been solved by checking for the current mouse modes whenever
the `PasteSelection` binding is invoked.

This fixes #1215.