### PR TITLE
alacritty: add support for OpenBSD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Alacritty
 
 Alacritty is the fastest terminal emulator in existence. Using the GPU for
 rendering enables optimizations that simply aren't possible in other emulators.
-Alacritty currently supports FreeBSD, Linux, and macOS. Windows support is planned
-before the 1.0 release.
+Alacritty currently supports FreeBSD, Linux, macOS, and OpenBSD. Windows
+support is planned before the 1.0 release.
 
 <p align="center">
   <img width="600" alt="Alacritty running vim inside tmux" src="https://cloud.githubusercontent.com/assets/4285147/21585004/2ebd0288-d06c-11e6-95d3-4a2889dbbd6f.png">
@@ -156,6 +156,16 @@ missing, please open an issue.
 
 ```sh
 pkg install cmake freetype2 fontconfig xclip pkgconf
+```
+
+#### OpenBSD
+
+Alacritty builds on OpenBSD 6.3 almost out-of-the-box if Rust and
+[Xenocara](https://xenocara.org) are installed.  If something is still found to
+be missing, please open an issue.
+
+```sh
+pkg_add rust
 ```
 
 #### Solus

--- a/copypasta/src/lib.rs
+++ b/copypasta/src/lib.rs
@@ -63,9 +63,9 @@ pub trait Store : Load {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 mod x11;
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
 pub use x11::{Clipboard, Error};
 
 #[cfg(target_os = "macos")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1611,7 +1611,7 @@ impl Default for Font {
     }
 }
 
-#[cfg(any(target_os = "linux",target_os = "freebsd"))]
+#[cfg(any(target_os = "linux",target_os = "freebsd",target_os = "openbsd"))]
 impl Default for Font {
     fn default() -> Font {
         Font {

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -87,7 +87,7 @@ fn openpty(rows: u8, cols: u8) -> (c_int, c_int) {
     (master, slave)
 }
 
-#[cfg(any(target_os = "macos",target_os = "freebsd"))]
+#[cfg(any(target_os = "macos",target_os = "freebsd",target_os = "openbsd"))]
 fn openpty(rows: u8, cols: u8) -> (c_int, c_int) {
     let mut master: c_int = 0;
     let mut slave: c_int = 0;


### PR DESCRIPTION
This commit expands the conditional compilation directives to support
building Alacritty for OpenBSD.  The build succeeds, and Alacritty runs
without issue once https://github.com/rust-lang/libc/pull/957 has been
merged and added to a versioned release.

This has been tested on the recently-released OpenBSD 6.3 on amd64 with
rustc 1.24.0 from its standard ports tree.

Oligatory screenshot: https://twitter.com/khanreaper/status/981073170580017153