### PR TITLE
Improve smart select to include :// by default

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -218,6 +218,7 @@ mouse:
 
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
+  semantic_detect_scheme: true
 
 dynamic_title: true
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -199,6 +199,7 @@ mouse:
 
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
+  semantic_detect_scheme: true
 
 dynamic_title: true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,12 +37,14 @@ fn true_bool() -> bool {
 #[derive(Clone, Debug, Deserialize)]
 pub struct Selection {
     pub semantic_escape_chars: String,
+    pub semantic_detect_scheme: bool,
 }
 
 impl Default for Selection {
     fn default() -> Selection {
         Selection {
-            semantic_escape_chars: String::new()
+            semantic_escape_chars: String::new(),
+            semantic_detect_scheme: true,
         }
     }
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -40,8 +40,14 @@ impl selection::SemanticSearch for Term {
     fn semantic_search_left(&self, mut point: Point) -> Point {
         let mut iter = self.grid.iter_from(point);
         let last_col = self.grid.num_cols() - Column(1);
+        let mut prev_point = point;
 
         while let Some(cell) = iter.prev() {
+            if self.semantic_detect_scheme && ":".contains(cell.c) && "/".contains(self.grid[prev_point.line][prev_point.col].c) {
+                // Bypass things that look like schemes (:/)
+                continue
+            }
+
             if self.semantic_escape_chars.contains(cell.c) {
                 break;
             }
@@ -50,6 +56,7 @@ impl selection::SemanticSearch for Term {
                 break; // cut off if on new line or hit escape char
             }
 
+            prev_point = point;
             point = iter.cur;
         }
 
@@ -61,6 +68,7 @@ impl selection::SemanticSearch for Term {
         let last_col = self.grid.num_cols() - Column(1);
 
         while let Some(cell) = iter.next() {
+            // TODO: Implement semantic_detect_scheme
             if self.semantic_escape_chars.contains(cell.c) {
                 break;
             }
@@ -705,6 +713,7 @@ pub struct Term {
     cursor_save_alt: Cursor,
 
     semantic_escape_chars: String,
+    semantic_detect_scheme: bool,
 
     /// Colors used for rendering
     colors: color::List,
@@ -834,6 +843,7 @@ impl Term {
             color_modified: [false; color::COUNT],
             original_colors: color::List::from(config.colors()),
             semantic_escape_chars: config.selection().semantic_escape_chars.clone(),
+            semantic_detect_scheme: true,
             cursor_style: None,
             default_cursor_style: config.cursor_style(),
             dynamic_title: config.dynamic_title(),

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1993,21 +1993,27 @@ mod tests {
             padding_y: 0.0,
         };
         let mut term = Term::new(&Default::default(), size);
-        let mut grid: Grid<Cell> = Grid::new(Line(3), Column(5), &Cell::default());
+        let mut grid: Grid<Cell> = Grid::new(Line(4), Column(5), &Cell::default());
         for i in 0..5 {
-            for j in 0..2 {
+            for j in 0..4 {
                 grid[Line(j)][Column(i)].c = 'a';
             }
         }
-        grid[Line(0)][Column(0)].c = '"';
-        grid[Line(0)][Column(3)].c = '"';
-        grid[Line(1)][Column(2)].c = '"';
+        grid[Line(0)][Column(0)].c = ':';
+        grid[Line(0)][Column(3)].c = ':';
+        grid[Line(1)][Column(2)].c = ':';
         grid[Line(0)][Column(4)].flags.insert(cell::Flags::WRAPLINE);
 
-        let mut escape_chars = String::from("\"");
+        grid[Line(2)][Column(1)].c = ':';
+        grid[Line(2)][Column(2)].c = '/';
+        grid[Line(2)][Column(3)].c = '/';
+
+        let mut escape_chars = String::from(":");
+        let mut detect_scheme = true;
 
         mem::swap(&mut term.grid, &mut grid);
         mem::swap(&mut term.semantic_escape_chars, &mut escape_chars);
+        mem::swap(&mut term.semantic_detect_scheme, &mut detect_scheme);
 
         {
             let selection = Selection::semantic(Point { line: Line(0), col: Column(1) }, &term);
@@ -2022,6 +2028,16 @@ mod tests {
         {
             let selection = Selection::semantic(Point { line: Line(1), col: Column(1) }, &term);
             assert_eq!(term.string_from_selection(&selection.to_span(&term).unwrap()), "aaa");
+        }
+
+        {
+            let selection = Selection::semantic(Point { line: Line(3), col: Column(3) }, &term);
+            assert_eq!(term.string_from_selection(&selection.to_span(&term).unwrap()), "aaaaa\n");
+        }
+
+        {
+            let selection = Selection::semantic(Point { line: Line(2), col: Column(0) }, &term);
+            assert_eq!(term.string_from_selection(&selection.to_span(&term).unwrap()), "a://a\n");
         }
     }
 


### PR DESCRIPTION
Hiya, I'm trying to improve on #368 by fixing part of #1210 and let double-click select include things that look like URLs by default (ie. include `://`). Otherwise, the `:` character breaks the selection by default which is frustrating.

I'm also very new to Rust, so please be gentle with the review. I'm happy to iterate on it.

I believe there is still room for improvement (see #1210 for a more complete outline) but I'm using this patch locally which has been a very convenient improvement and a good first step.