### PR TITLE
Fix scrollback history size 0 bug

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -240,15 +240,8 @@ impl<T: Copy + Clone> Grid<T> {
         let lines_added = new_line_count - self.lines;
 
         // Need to "resize" before updating buffer
-        self.raw.set_visible_lines(new_line_count);
+        self.raw.grow_visible_lines(new_line_count, Row::new(self.cols, template));
         self.lines = new_line_count;
-
-        // Fill up the history with empty lines
-        if self.raw.len() < self.raw.capacity() {
-            for _ in self.raw.len()..self.raw.capacity() {
-                self.raw.push(Row::new(self.cols, &template));
-            }
-        }
 
         // Add new lines to bottom
         self.scroll_up(&(Line(0)..new_line_count), lines_added, template);
@@ -277,7 +270,7 @@ impl<T: Copy + Clone> Grid<T> {
 
         self.selection = None;
         self.raw.rotate(*prev as isize - *target as isize);
-        self.raw.set_visible_lines(target);
+        self.raw.shrink_visible_lines(target);
         self.lines = target;
     }
 

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -48,6 +48,17 @@ impl<T> Storage<T> {
     }
 
     pub fn set_visible_lines(&mut self, next: Line) {
+        // Change capacity to fit scrollback + screen size
+        if next > self.visible_lines + 1 {
+            self.inner.reserve_exact((next - (self.visible_lines + 1)).0);
+        } else if next < self.visible_lines + 1 {
+            let shrinkage = (self.visible_lines + 1 - next).0;
+            let new_size = self.inner.capacity() - shrinkage;
+            self.inner.truncate(new_size);
+            self.inner.shrink_to_fit();
+        }
+
+        // Update visible lines
         self.visible_lines = next - 1;
     }
 

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -76,7 +76,7 @@ impl<T> Storage<T> {
 
         // Generate range of lines that have to be deleted before the zero line
         let start = offset.saturating_sub(shrinkage - 1);
-        let shrink_before = start..=offset;
+        let shrink_before = start..(offset + 1);
 
         // Generate range of lines that have to be deleted after the zero line
         let shrink_after = (self.inner.len() + offset + 1 - shrinkage)..self.inner.len();


### PR DESCRIPTION
There was an issue where alacritty would panic whenever the scrollback
history size is set to 0, this fixes that issue.

The panic was caused by a substraction with unsigned integers which was
underflowing, this has been fixed to use `saturating_sub`.

After that was fixed there was still a bug where scrollback would not
behave correctly because the number of lines in the grid was decided at
startup.
This has been adapted so whenever the size of the terminal changes, the
scrollback history and grid adapts to make sure the number of lines in
the terminal is always the number of visible lines plus the amount of
scrollback lines configured in the config file.

This fixes #1150.