### PR TITLE
Reset grid when running `reset`

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -73,10 +73,6 @@ pub struct Grid<T> {
     /// Invariant: lines is equivalent to raw.len()
     lines: index::Line,
 
-    /// Maximum number of lines in the scrollback history
-    #[serde(default)]
-    history_size: usize,
-
     /// Offset of displayed area
     ///
     /// If the displayed region isn't at the bottom of the screen, it stays
@@ -136,7 +132,6 @@ impl<T: Copy + Clone> Grid<T> {
             display_offset: 0,
             scroll_limit: 0,
             selection: None,
-            history_size: scrollback,
         }
     }
 
@@ -408,9 +403,8 @@ impl<T> Grid<T> {
         self.cols
     }
 
-    #[inline]
-    pub fn history_size(&self) -> usize {
-        self.history_size
+    pub fn reset(&mut self) {
+        self.scroll_limit = 0;
     }
 
     pub fn iter_from(&self, point: Point<usize>) -> GridIterator<T> {

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -73,6 +73,10 @@ pub struct Grid<T> {
     /// Invariant: lines is equivalent to raw.len()
     lines: index::Line,
 
+    /// Maximum number of lines in the scrollback history
+    #[serde(default)]
+    history_size: usize,
+
     /// Offset of displayed area
     ///
     /// If the displayed region isn't at the bottom of the screen, it stays
@@ -132,6 +136,7 @@ impl<T: Copy + Clone> Grid<T> {
             display_offset: 0,
             scroll_limit: 0,
             selection: None,
+            history_size: scrollback,
         }
     }
 
@@ -401,6 +406,11 @@ impl<T> Grid<T> {
     #[inline]
     pub fn num_cols(&self) -> index::Column {
         self.cols
+    }
+
+    #[inline]
+    pub fn history_size(&self) -> usize {
+        self.history_size
     }
 
     pub fn iter_from(&self, point: Point<usize>) -> GridIterator<T> {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1816,12 +1816,7 @@ impl ansi::Handler for Term {
         self.colors = self.original_colors;
         self.color_modified = [false; color::COUNT];
         self.cursor_style = None;
-        self.grid = Grid::new(
-            self.grid.num_lines(),
-            self.grid.num_cols(),
-            self.grid.history_size(),
-            Cell::default(),
-        );
+        self.grid.reset();
     }
 
     #[inline]

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -837,13 +837,11 @@ impl Term {
     }
 
     pub fn new(config: &Config, size: SizeInfo) -> Term {
-        let template = Cell::default();
-
         let num_cols = size.cols();
         let num_lines = size.lines();
 
         let history_size = config.scrolling().history as usize;
-        let grid = Grid::new(num_lines, num_cols, history_size, template);
+        let grid = Grid::new(num_lines, num_cols, history_size, Cell::default());
 
         let tabspaces = config.tabspaces();
         let tabs = IndexRange::from(Column(0)..grid.num_cols())
@@ -1818,6 +1816,12 @@ impl ansi::Handler for Term {
         self.colors = self.original_colors;
         self.color_modified = [false; color::COUNT];
         self.cursor_style = None;
+        self.grid = Grid::new(
+            self.grid.num_lines(),
+            self.grid.num_cols(),
+            self.grid.history_size(),
+            Cell::default(),
+        );
     }
 
     #[inline]

--- a/tests/ref.rs
+++ b/tests/ref.rs
@@ -47,7 +47,6 @@ ref_tests! {
     vttest_scroll
     vttest_tab_clear_set
     zsh_tab_completion
-    grid_reset
 }
 
 fn read_u8<P>(path: P) -> Vec<u8>

--- a/tests/ref.rs
+++ b/tests/ref.rs
@@ -47,6 +47,7 @@ ref_tests! {
     vttest_scroll
     vttest_tab_clear_set
     zsh_tab_completion
+    grid_reset
 }
 
 fn read_u8<P>(path: P) -> Vec<u8>


### PR DESCRIPTION
In the current scrollback PR the `reset` command does not affect the
scrollback history. To make sure the terminal is properly reset, it
should clear the scrollback history.

This commit fixes this by creating a new and empty grid whenever `reset`
is executed. It takes the current dimensions and history size from the
old grid.

Right now there's an empty ref-test called `grid_reset` without any
content, this should be implemented once #1244 is resolved.

This fixes #1242.