### PR TITLE
Fix bright characters in first column

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -747,16 +747,15 @@ impl<'a, T: Copy + 'a> Iterator for DisplayIter<'a, T> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        // Check if the end of the line was reached
-        let next_line = self.col == self.grid.num_cols();
-        if next_line {
-            // Return `None` if we've reached the end of the last line
+        // Make sure indices are valid. Return None if we've reached the end.
+        if self.col == self.grid.num_cols() {
             if self.offset == self.limit {
                 return None;
             }
 
             // Switch to the next line
             self.col = Column(0);
+
             self.offset -= 1;
             self.line = Line(*self.grid.lines - 1 - (self.offset - self.limit));
         }
@@ -768,10 +767,7 @@ impl<'a, T: Copy + 'a> Iterator for DisplayIter<'a, T> {
             column: self.col
         });
 
-        // Only increment column if the line hasn't changed
-        if !next_line {
-            self.col += 1;
-        }
+        self.col += 1;
         item
     }
 }

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -747,27 +747,29 @@ impl<'a, T: Copy + 'a> Iterator for DisplayIter<'a, T> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        // Make sure indices are valid. Return None if we've reached the end.
-        if self.col == self.grid.num_cols() {
-            if self.offset == self.limit {
-                return None;
-            }
-
-            // Switch to the next line
-            self.col = Column(0);
-
-            self.offset -= 1;
-            self.line = Line(*self.grid.lines - 1 - (self.offset - self.limit));
+        // Return None if we've reached the end.
+        if self.offset == self.limit && self.grid.num_cols() == self.col {
+            return None;
         }
 
-        // Return the next item
+        // Get the next item.
         let item = Some(Indexed {
             inner: self.grid.raw[self.offset][self.col],
             line: self.line,
             column: self.col
         });
 
+        // Update line/col to point to next item
         self.col += 1;
+        if self.col == self.grid.num_cols() {
+            if self.offset != self.limit {
+                self.offset -= 1;
+
+                self.col = Column(0);
+                self.line = Line(*self.grid.lines - 1 - (self.offset - self.limit));
+            }
+        }
+
         item
     }
 }


### PR DESCRIPTION
This bug was introduced by the commit which fixed the invisible cursor
in the first column (54b21b6). To resolve this the alternative implementation by @jwilm has been applied which seems to work out.

This fixes #1259.