### PR TITLE
Disable live-config-reload for opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The `background_opacity` config option has been moved to `window.background_opacity`
+- Live config reload has been disabled for window opacity
+
 ## Version 0.2.4
 
 ### Added

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -42,6 +42,12 @@ window:
   # When true, alacritty starts maximized.
   start_maximized: false
 
+  # Background opacity (changes require restart)
+  #
+  # Window opacity as a floating point number from `0.0` to `1.0`.
+  # The value `0.0` is completely transparent and `1.0` is opaque.
+  background_opacity: 1.0
+
 scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.
@@ -223,12 +229,6 @@ colors:
 visual_bell:
   animation: EaseOutExpo
   duration: 0
-
-# Background opacity
-#
-# Window opacity as a floating point number from `0.0` to `1.0`.
-# The value `0.0` is completely transparent and `1.0` is opaque.
-background_opacity: 1.0
 
 # Mouse bindings
 #

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -53,6 +53,12 @@ window:
   # When true, alacritty starts maximized.
   start_maximized: false
 
+  # Background opacity (changes require restart)
+  #
+  # Window opacity as a floating point number from `0.0` to `1.0`.
+  # The value `0.0` is completely transparent and `1.0` is opaque.
+  background_opacity: 1.0
+
 scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.
@@ -234,12 +240,6 @@ colors:
 visual_bell:
   animation: EaseOutExpo
   duration: 0
-
-# Background opacity
-#
-# Window opacity as a floating point number from `0.0` to `1.0`.
-# The value `0.0` is completely transparent and `1.0` is opaque.
-background_opacity: 1.0
 
 # Mouse bindings
 #

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -42,6 +42,12 @@ window:
   # When true, alacritty starts maximized.
   start_maximized: false
 
+  # Background opacity (changes require restart)
+  #
+  # Window opacity as a floating point number from `0.0` to `1.0`.
+  # The value `0.0` is completely transparent and `1.0` is opaque.
+  background_opacity: 1.0
+
 scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.
@@ -204,12 +210,6 @@ colors:
 visual_bell:
   animation: EaseOutExpo
   duration: 0
-
-# Background opacity
-#
-# Window opacity as a floating point number from `0.0` to `1.0`.
-# The value `0.0` is completely transparent and `1.0` is opaque.
-background_opacity: 1.0
 
 # Mouse bindings
 #

--- a/src/config.rs
+++ b/src/config.rs
@@ -384,6 +384,10 @@ pub struct WindowConfig {
     /// Start maximized
     #[serde(default, deserialize_with = "failure_default")]
     start_maximized: bool,
+
+    /// Window opacity from 0.0 to 1.0
+    #[serde(default, deserialize_with = "failure_default")]
+    background_opacity: Alpha,
 }
 
 fn default_padding() -> Delta<u8> {
@@ -414,6 +418,10 @@ impl WindowConfig {
     pub fn start_maximized(&self) -> bool {
         self.start_maximized
     }
+
+    pub fn background_opacity(&self) -> Alpha {
+        self.background_opacity
+    }
 }
 
 impl Default for WindowConfig {
@@ -424,6 +432,7 @@ impl Default for WindowConfig {
             decorations: Default::default(),
             dynamic_padding: false,
             start_maximized: false,
+            background_opacity: Default::default(),
         }
     }
 }
@@ -457,10 +466,6 @@ pub struct Config {
 
     #[serde(default, deserialize_with = "failure_default")]
     colors: Colors,
-
-    /// Background opacity from 0.0 to 1.0
-    #[serde(default, deserialize_with = "failure_default")]
-    background_opacity: Alpha,
 
     /// Window configuration
     #[serde(default, deserialize_with = "failure_default")]
@@ -531,6 +536,10 @@ pub struct Config {
     // TODO: DEPRECATED
     #[serde(default, deserialize_with = "failure_default")]
     unfocused_hollow_cursor: Option<bool>,
+
+    // TODO: DEPRECATED
+    #[serde(default, deserialize_with = "failure_default")]
+    background_opacity: Option<Alpha>,
 }
 
 fn failure_default_vec<'a, D, T>(deserializer: D) -> ::std::result::Result<Vec<T>, D::Error>
@@ -1549,11 +1558,6 @@ impl Config {
         &self.colors
     }
 
-    #[inline]
-    pub fn background_opacity(&self) -> Alpha {
-        self.background_opacity
-    }
-
     pub fn key_bindings(&self) -> &[KeyBinding] {
         &self.key_bindings[..]
     }
@@ -1756,6 +1760,12 @@ impl Config {
         if self.unfocused_hollow_cursor.is_some() {
             warn!("{}", "Config `unfocused_hollow_cursor` is deprecated. \
                   Please use `cursor.unfocused_hollow` instead.");
+        }
+
+        if let Some(alpha) = self.background_opacity {
+            warn!("{}", "Config `background_opacity` is deprecated. \
+                  Please use `window.background_opacity` instead.");
+            self.window.background_opacity = alpha;
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -150,7 +150,8 @@ impl Display {
             .expect("glutin returns window size").to_physical(dpr);
 
         // Create renderer
-        let mut renderer = QuadRenderer::new(viewport_size)?;
+        let alpha = config.window().background_opacity().get();
+        let mut renderer = QuadRenderer::new(viewport_size, alpha)?;
 
         let (glyph_cache, cell_width, cell_height) =
             Self::new_glyph_cache(dpr, &mut renderer, config)?;
@@ -209,7 +210,6 @@ impl Display {
         // Clear screen
         let background_color = config.colors().primary.background;
         renderer.with_api(
-            config,
             &size_info,
             0., /* visual bell intensity */
             |api| {
@@ -405,7 +405,7 @@ impl Display {
         // handling and rendering.
         drop(terminal);
 
-        self.renderer.with_api(config, &size_info, visual_bell_intensity, |api| {
+        self.renderer.with_api(&size_info, visual_bell_intensity, |api| {
             api.clear(background_color);
         });
 
@@ -416,7 +416,7 @@ impl Display {
             {
                 let _sampler = self.meter.sampler();
 
-                self.renderer.with_api(config, &size_info, visual_bell_intensity, |mut api| {
+                self.renderer.with_api(&size_info, visual_bell_intensity, |mut api| {
                     // Draw the grid
                     api.render_cells(grid_cells.iter(), glyph_cache);
                 });
@@ -430,7 +430,7 @@ impl Display {
                     g: 0x4e,
                     b: 0x53,
                 };
-                self.renderer.with_api(config, &size_info, visual_bell_intensity, |mut api| {
+                self.renderer.with_api(&size_info, visual_bell_intensity, |mut api| {
                     api.render_string(&timing[..], size_info.lines() - 2, glyph_cache, color);
                 });
             }
@@ -446,7 +446,7 @@ impl Display {
                     g: 0x00,
                     b: 0x00,
                 };
-                self.renderer.with_api(config, &size_info, visual_bell_intensity, |mut api| {
+                self.renderer.with_api(&size_info, visual_bell_intensity, |mut api| {
                     api.render_string(&msg, size_info.lines() - 1, glyph_cache, color);
                 });
             } else if self.logger_proxy.warnings() {
@@ -459,7 +459,7 @@ impl Display {
                     g: 0xff,
                     b: 0x00,
                 };
-                self.renderer.with_api(config, &size_info, visual_bell_intensity, |mut api| {
+                self.renderer.with_api(&size_info, visual_bell_intensity, |mut api| {
                     api.render_string(&msg, size_info.lines() - 1, glyph_cache, color);
                 });
             }

--- a/src/window.rs
+++ b/src/window.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use std::convert::From;
 use std::fmt::Display;
+use std::f32::EPSILON;
 
 use crate::gl;
 use glutin::GlContext;
@@ -296,10 +297,11 @@ impl Window {
             _ => true,
         };
 
+        let transparent = (window_config.background_opacity().get() - 1.0).abs() > EPSILON;
         WindowBuilder::new()
             .with_title(title)
             .with_visibility(false)
-            .with_transparency(true)
+            .with_transparency(transparent)
             .with_maximized(window_config.start_maximized())
             .with_decorations(decorations)
     }
@@ -313,11 +315,12 @@ impl Window {
             _ => true,
         };
 
+        let transparent = (window_config.background_opacity().get() - 1.0).abs() > EPSILON;
         WindowBuilder::new()
             .with_title(title)
             .with_visibility(cfg!(windows))
             .with_decorations(decorations)
-            .with_transparency(true)
+            .with_transparency(transparent)
             .with_maximized(window_config.start_maximized())
             .with_window_icon(Some(icon))
     }
@@ -326,10 +329,11 @@ impl Window {
     pub fn get_platform_window(title: &str, window_config: &WindowConfig) -> WindowBuilder {
         use glutin::os::macos::WindowBuilderExt;
 
+        let transparent = (window_config.background_opacity().get() - 1.0).abs() > EPSILON;
         let window = WindowBuilder::new()
             .with_title(title)
             .with_visibility(false)
-            .with_transparency(true)
+            .with_transparency(transparent)
             .with_maximized(window_config.start_maximized());
 
         match window_config.decorations() {


### PR DESCRIPTION
It is now not possible anymore to update the background opacity of
alacritty while it is running.

This is not just the removal of a feature though, there have been a lot
of issues with the `with_transparency(true)` call in the `window.rs`
module. Some of these issues are flickering on resize and alacritty
crashing on startup.

To fix these issues the transparency of alacritty is now set at startup,
if alacritty is started with opacity `1.0` the window is crated
with `.with_transparency(false)`. If the opacity is anything other than
`1.0` alacritty will function as usual, so it is possible to start
alacritty with transparency `0.99` and then change it to `0.5` at
runtime.

Even though this definitely is not a great solution, I think this should
be beneficial for most users and solve a lot of annoyances that have
been mentioned in the past.

This fixes #1268 and fixes #969.