### PR TITLE
Hide Window

### DIFF
--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -273,6 +273,7 @@ key_bindings:
   - { key: C,        mods: Command, action: Copy                         }
   - { key: Paste,                   action: Paste                        }
   - { key: Copy,                    action: Copy                         }
+  - { key: H,        mods: Command, action: Hide                         }
   - { key: Q,        mods: Command, action: Quit                         }
   - { key: W,        mods: Command, action: Quit                         }
   - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }

--- a/src/config.rs
+++ b/src/config.rs
@@ -549,7 +549,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
             type Value = ActionWrapper;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, ResetFontSize, or Quit")
+                f.write_str("Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, ResetFontSize, Hide, or Quit")
             }
 
             fn visit_str<E>(self, value: &str) -> ::std::result::Result<ActionWrapper, E>
@@ -562,6 +562,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
                     "IncreaseFontSize" => Action::IncreaseFontSize,
                     "DecreaseFontSize" => Action::DecreaseFontSize,
                     "ResetFontSize" => Action::ResetFontSize,
+                    "Hide" => Action::Hide,
                     "Quit" => Action::Quit,
                     _ => return Err(E::invalid_value(Unexpected::Str(value), &self)),
                 }))

--- a/src/input.rs
+++ b/src/input.rs
@@ -66,6 +66,7 @@ pub trait ActionContext {
     fn last_modifiers(&mut self) -> &mut ModifiersState;
     fn change_font_size(&mut self, delta: f32);
     fn reset_font_size(&mut self);
+    fn hide_window(&mut self);
 }
 
 /// Describes a state and action to take in that state
@@ -170,6 +171,9 @@ pub enum Action {
     /// Run given command
     Command(String, Vec<String>),
 
+    /// Hides the Alacritty window
+    Hide,
+
     /// Quits Alacritty.
     Quit,
 }
@@ -223,6 +227,9 @@ impl Action {
                         warn!("couldn't run command: {}", err);
                     },
                 }
+            },
+            Action::Hide => {
+                ctx.hide_window();
             },
             Action::Quit => {
                 // FIXME should do a more graceful shutdown
@@ -626,7 +633,7 @@ mod tests {
     use glutin::{VirtualKeyCode, Event, WindowEvent, ElementState, MouseButton, ModifiersState};
 
     use term::{SizeInfo, Term, TermMode};
-    use event::{Mouse, ClickState};
+    use event::{Mouse, ClickState, WindowChanges};
     use config::{self, Config, ClickHandler};
     use index::{Point, Side};
     use selection::Selection;
@@ -651,6 +658,7 @@ mod tests {
         pub received_count: usize,
         pub suppress_chars: bool,
         pub last_modifiers: ModifiersState,
+        pub window_changes: &'a mut WindowChanges,
     }
 
     impl <'a>super::ActionContext for ActionContext<'a> {
@@ -704,6 +712,8 @@ mod tests {
         }
         fn reset_font_size(&mut self) {
         }
+        fn hide_window(&mut self) {
+        }
     }
 
     macro_rules! test_clickstate {
@@ -742,6 +752,7 @@ mod tests {
                     received_count: 0,
                     suppress_chars: false,
                     last_modifiers: ModifiersState::default(),
+                    window_changes: &mut WindowChanges::default(),
                 };
 
                 let mut processor = Processor {

--- a/src/window.rs
+++ b/src/window.rs
@@ -379,6 +379,11 @@ impl Window {
     pub fn get_window_id(&self) -> Option<usize> {
         None
     }
+
+    /// Hide the window
+    pub fn hide(&self) {
+        self.window.hide();
+    }
 }
 
 pub trait OsExtensions {


### PR DESCRIPTION
This fixes #542 

This PR is based on the changed provided by @sorccu and @algesten in #542 in that the Alacritty window is hidden when handling `Action::Hide`. Additionally, I've updated the macos config to bind `Command+H` to emit `Action::Hide`.

Currently though, when the window is hidden, focus is maintained on Alacritty. I couldn't see a way to unfocus the window with glutin so I'm thinking it might be an upstream issue but I'll keep investigating. 

Tested on macOS