### PR TITLE
Allow changing scrollback history size at runtime 

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -155,6 +155,13 @@ impl<T: Copy + Clone> Grid<T> {
         self.line_to_offset(line) + self.display_offset
     }
 
+    /// Update the size of the scrollback history
+    pub fn update_history(&mut self, history_size: usize, template: &T)
+    {
+        self.raw.update_history(history_size, Row::new(self.cols, &template));
+        self.scroll_limit = min(self.scroll_limit, history_size);
+    }
+
     pub fn scroll_display(&mut self, scroll: Scroll) {
         match scroll {
             Scroll::Lines(count) => {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -907,6 +907,8 @@ impl Term {
         self.default_cursor_style = config.cursor_style();
         self.dynamic_title = config.dynamic_title();
         self.auto_scroll = config.scrolling().auto_scroll;
+        self.grid
+            .update_history(config.scrolling().history as usize, &self.cursor.template);
     }
 
     #[inline]
@@ -2012,17 +2014,17 @@ mod tests {
         mem::swap(&mut term.semantic_escape_chars, &mut escape_chars);
 
         {
-            *term.selection_mut() = Some(Selection::semantic(Point { line: 2, col: Column(1) }, &term));
+            *term.selection_mut() = Some(Selection::semantic(Point { line: 2, col: Column(1) }));
             assert_eq!(term.selection_to_string(), Some(String::from("aa")));
         }
 
         {
-            *term.selection_mut() = Some(Selection::semantic(Point { line: 2, col: Column(4) }, &term));
+            *term.selection_mut() = Some(Selection::semantic(Point { line: 2, col: Column(4) }));
             assert_eq!(term.selection_to_string(), Some(String::from("aaa")));
         }
 
         {
-            *term.selection_mut() = Some(Selection::semantic(Point { line: 1, col: Column(1) }, &term));
+            *term.selection_mut() = Some(Selection::semantic(Point { line: 1, col: Column(1) }));
             assert_eq!(term.selection_to_string(), Some(String::from("aaa")));
         }
     }


### PR DESCRIPTION
***This PR is based on #1284 and should not be merged before it.***

Making use of the changes that have been introduced in #1234 and #1284,
this allows changing the size of the scrollback buffer at runtime.

This simply changes the size of the raw inner buffer making use of the
optimized mutation algorithms introduced in #1284. As a result,
shrinking the scrollback history size at runtime should be basically
free and growing will only introduce a performance cost when there are
no more buffered lines. However, as a result there will not be any
memory freed when shrinking the scrollback history size at runtime.

As discussed in #1234 a potential solution for this could be to truncate
the raw buffer whenever more than X lines are deleted, however this
issue should not be very significant PR and if a solution is desired a
separate issue/PR should be opened.

This fixes #1235.