### PR TITLE
Allow mouse pasting in mouse mode with shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved `cursor_style` to `cursor.style`
 - Moved `unfocused_hollow_cursor` to `cursor.unfocused_hollow`
 - Moved `hide_cursor_when_typing` to `mouse.hide_when_typing`
+- Mouse bindings now ignore additional modifiers
 
 ### Removed
 
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed rendering cursors other than rectangular with the RustType backend
 - Selection memory leak and glitches in the alternate screen buffer
 - Invalid default configuration on macOS and Linux
+- Middle mouse pasting if mouse mode is enabled
 
 ## Version 0.2.1
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,17 +106,6 @@ pub struct Url {
     pub modifiers: ModifiersState,
 }
 
-impl Url {
-    // Make sure that modifiers in the config are always present,
-    // but ignore surplus modifiers.
-    pub fn mods_match_relaxed(&self, mods: ModifiersState) -> bool {
-        !((self.modifiers.shift && !mods.shift)
-            || (self.modifiers.ctrl && !mods.ctrl)
-            || (self.modifiers.alt && !mods.alt)
-            || (self.modifiers.logo && !mods.logo))
-    }
-}
-
 fn deserialize_modifiers<'a, D>(deserializer: D) -> ::std::result::Result<ModifiersState, D::Error>
     where D: de::Deserializer<'a>
 {


### PR DESCRIPTION
It is now possible to paste in mouse mode again by making use of the
`shift` key while pressing the mouse button reserved for PasteSelection.

This fixes #1298.