### PR TITLE
Fix semantic_escape_chars to match links

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -217,7 +217,7 @@ mouse:
   faux_scrollback_lines: 1
 
 selection:
-  semantic_escape_chars: ",│`|:\"' ()[]{}<>"
+  semantic_escape_chars: ",│`|\"' ()[]{}<>"
 
 dynamic_title: true
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -198,7 +198,7 @@ mouse:
   faux_scrollback_lines: 1
 
 selection:
-  semantic_escape_chars: ",│`|:\"' ()[]{}<>"
+  semantic_escape_chars: ",│`|\"' ()[]{}<>"
 
 dynamic_title: true
 


### PR DESCRIPTION
The default config has problems selecting links using double-clicks because the `:` is not considered for the semantic select. When doubleclicking on `https://example.com/index.html` alacritty is only selecting `//example.com/index.html`, so I either have to fix the link manually or select the whole link manually.