### PR TITLE
Reduce debug level for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,4 @@ gl_generator = "0.9"
 
 [profile.release]
 lto = true
-debug = true
+debug = 1


### PR DESCRIPTION
Backtraces are useful, but line-level debuginfo bloats the binary, and has impact on compile times notably. This reduces it to function-level debuginfo which is a good compromise point.