### PR TITLE
Allow disabling DPI scaling

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -93,6 +93,12 @@ font:
     x: 0
     y: 0
 
+  # Scale the font size based on the monitor's DPI. This will lead to bigger text on HiDPI
+  # screens and make reading text a little easier.
+  # On X11 it is possible to change the DPI for each instance of alacritty by using
+  # `WINIT_HIDPI_FACTOR=1.0 alacritty` to scale the font.
+  scale_with_dpi: true
+
   # OS X only: use thin stroke font rendering. Thin strokes are suitable
   # for retina displays, but for non-retina you probably want this set to
   # false.

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -73,6 +73,10 @@ font:
     x: 0
     y: 0
 
+  # Scale the font size based on the monitor's DPI. This will lead to bigger text on HiDPI
+  # screens and make reading text a little easier.
+  scale_with_dpi: true
+
   # OS X only: use thin stroke font rendering. Thin strokes are suitable
   # for retina displays, but for non-retina you probably want this set to
   # false.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1541,7 +1541,10 @@ pub struct Font {
     glyph_offset: Delta<i8>,
 
     #[serde(default="true_bool", deserialize_with = "default_true_bool")]
-    use_thin_strokes: bool
+    use_thin_strokes: bool,
+
+    #[serde(default="true_bool", deserialize_with = "default_true_bool")]
+    scale_with_dpi: bool,
 }
 
 fn default_bold_desc() -> FontDescription {
@@ -1594,6 +1597,11 @@ impl Font {
             .. self
         }
     }
+
+    /// Check whether dpi should be applied
+    pub fn scale_with_dpi(&self) -> bool {
+        self.scale_with_dpi
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -1605,8 +1613,9 @@ impl Default for Font {
             italic: FontDescription::new_with_family("Menlo"),
             size: Size::new(11.0),
             use_thin_strokes: true,
+            scale_with_dpi: true,
+            glyph_offset: Default::default(),
             offset: Default::default(),
-            glyph_offset: Default::default()
         }
     }
 }
@@ -1620,8 +1629,9 @@ impl Default for Font {
             italic: FontDescription::new_with_family("monospace"),
             size: Size::new(11.0),
             use_thin_strokes: false,
+            scale_with_dpi: true,
+            glyph_offset: Default::default(),
             offset: Default::default(),
-            glyph_offset: Default::default()
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -142,15 +142,20 @@ impl Display {
         // get window properties for initializing the other subsystems
         let mut viewport_size = window.inner_size_pixels()
             .expect("glutin returns window size");
-        let dpr = window.hidpi_factor();
+        let dpr = if config.font().scale_with_dpi() {
+            window.hidpi_factor()
+        } else {
+            1.0
+        };
 
         info!("device_pixel_ratio: {}", dpr);
+        println!("DPR: {}", dpr);
 
         // Create renderer
         let mut renderer = QuadRenderer::new(config, viewport_size)?;
 
         let (glyph_cache, cell_width, cell_height) =
-            Self::new_glyph_cache(&window, &mut renderer, config)?;
+            Self::new_glyph_cache(dpr, &mut renderer, config)?;
 
 
         let dimensions = options.dimensions()
@@ -211,11 +216,10 @@ impl Display {
         })
     }
 
-    fn new_glyph_cache(window : &Window, renderer : &mut QuadRenderer, config: &Config)
+    fn new_glyph_cache(dpr: f32, renderer: &mut QuadRenderer, config: &Config)
         -> Result<(GlyphCache, f32, f32), Error>
     {
         let font = config.font().clone();
-        let dpr = window.hidpi_factor();
         let rasterizer = font::Rasterizer::new(dpr, config.use_thin_strokes())?;
 
         // Initialize glyph cache

--- a/src/display.rs
+++ b/src/display.rs
@@ -149,7 +149,6 @@ impl Display {
         };
 
         info!("device_pixel_ratio: {}", dpr);
-        println!("DPR: {}", dpr);
 
         // Create renderer
         let mut renderer = QuadRenderer::new(config, viewport_size)?;


### PR DESCRIPTION
This makes it possible to disable DPI scaling completely, instead the
the display pixel ration will always be fixed to 1.0.

By default nothing has changed and DPI is still enabled, this just seems
like a better way than running `WINIT_HIDPI_FACTOR=1.0 alacritty` every
time the user wants to start alacritty.

It would be possible to allow specifying any DPR, however I've decided
against this since I'd assume it's a very rare usecase. It's also still
possible to make use of `WINIT_HIDPI_FACTOR` to do this on X11.

Currently this is not updated at runtime using the live config update,
there is not really much of a technical limitation why this woudn't be
possible, however a solution for that issue should be first added in
jwilm/alacritty#1346, once a system is established for changing DPI at
runtime, porting that functionality to this PR should be simple.