### PR TITLE
Add Copy/Cut/Paste keys

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -286,6 +286,8 @@ live_config_reload: true
 key_bindings:
   - { key: V,        mods: Control|Shift,    action: Paste               }
   - { key: C,        mods: Control|Shift,    action: Copy                }
+  - { key: Paste,                   action: Paste                        }
+  - { key: Copy,                    action: Copy                         }
   - { key: Q,        mods: Command, action: Quit                         }
   - { key: W,        mods: Command, action: Quit                         }
   - { key: Insert,   mods: Shift,   action: PasteSelection               }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -263,6 +263,8 @@ live_config_reload: true
 key_bindings:
   - { key: V,        mods: Command, action: Paste                        }
   - { key: C,        mods: Command, action: Copy                         }
+  - { key: Paste,                   action: Paste                        }
+  - { key: Copy,                    action: Copy                         }
   - { key: Q,        mods: Command, action: Quit                         }
   - { key: W,        mods: Command, action: Quit                         }
   - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1879,6 +1879,9 @@ enum Key {
     WebStop,
     Yen,
     Caret,
+    Copy,
+    Paste,
+    Cut,
 }
 
 impl Key {
@@ -2037,6 +2040,9 @@ impl Key {
             Key::WebStop => WebStop,
             Key::Yen => Yen,
             Key::Caret => Caret,
+            Key::Copy => Copy,
+            Key::Paste => Paste,
+            Key::Cut => Cut,
         }
     }
 }


### PR DESCRIPTION
This just adds support for the Copy/Cut/Paste keys and sets up
Copy/Paste as alternative defaults for Ctrl+Shift+C/V.

I'm not sure if this should be part of the default key bindings, but I
find this useful and don't really see anything wrong with having this
functionality work by default.