### PR TITLE
--title should override the dynamic_title config.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,11 +15,9 @@ extern crate log;
 use clap::{Arg, App};
 use index::{Line, Column};
 use config::{Dimensions, Shell};
+use window::{DEFAULT_TITLE, DEFAULT_CLASS};
 use std::path::{Path, PathBuf};
 use std::borrow::Cow;
-
-const DEFAULT_TITLE: &str = "Alacritty";
-const DEFAULT_CLASS: &str = "Alacritty";
 
 /// Options specified on the command line
 pub struct Options {
@@ -27,8 +25,8 @@ pub struct Options {
     pub print_events: bool,
     pub ref_test: bool,
     pub dimensions: Option<Dimensions>,
-    pub title: String,
-    pub class: String,
+    pub title: Option<String>,
+    pub class: Option<String>,
     pub log_level: log::LevelFilter,
     pub command: Option<Shell<'static>>,
     pub working_dir: Option<PathBuf>,
@@ -42,8 +40,8 @@ impl Default for Options {
             print_events: false,
             ref_test: false,
             dimensions: None,
-            title: DEFAULT_TITLE.to_owned(),
-            class: DEFAULT_CLASS.to_owned(),
+            title: None,
+            class: None,
             log_level: log::LevelFilter::Warn,
             command: None,
             working_dir: None,
@@ -139,12 +137,16 @@ impl Options {
             }
         }
 
-        if let Some(title) = matches.value_of("title") {
-            options.title = title.to_owned();
+        if matches.occurrences_of("title") > 0 {
+            if let Some(title) = matches.value_of("title") {
+                options.title = Some(title.to_owned());
+            }
         }
 
-        if let Some(class) = matches.value_of("class") {
-            options.class = class.to_owned();
+        if matches.occurrences_of("class") > 0 {
+            if let Some(class) = matches.value_of("class") {
+                options.class = Some(class.to_owned());
+            }
         }
 
         match matches.occurrences_of("q") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1373,6 +1373,11 @@ impl Config {
         self.dynamic_title
     }
 
+    #[inline]
+    pub fn dynamic_title_mut(&mut self) -> bool {
+        self.dynamic_title
+    }
+
     pub fn load_from<P: Into<PathBuf>>(path: P) -> Result<Config> {
         let path = path.into();
         let raw = Config::read_file(path.as_path())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,13 @@ use alacritty::util::fmt::Red;
 fn main() {
     // Load command line options and config
     let options = cli::Options::load();
-    let config = load_config(&options);
+    let mut config = load_config(&options);
+
+    // Override configurations based on CLI options.
+    if options.title.is_some() {
+        let mut dynamic_title = config.dynamic_title_mut();
+        dynamic_title = false;
+    }
 
     // Switch to home directory
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
This PR makes it so that the `--title` flag is respected regardless of your `dynamic_title` configuration, which is the intended behavior.