### PR TITLE
Optimize indexing of the grid's raw buffer

### DIFF
--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -186,7 +186,8 @@ impl<T> Storage<T> {
         split.truncate(split_len - (shrinkage - shrinkage_start));
 
         // Merge buffers again and reset zero
-        self.inner.append(&mut split);
+        split.append(&mut self.inner);
+        self.inner = split;
         self.zero = 0;
     }
 
@@ -561,8 +562,8 @@ fn truncate_invisible_lines_beginning() {
 
     // Make sure the result is correct
     let expected = Storage {
-        inner: vec![Row::new(Column(1), &'1'), Row::new(Column(1), &'0')],
-        zero: 1,
+        inner: vec![Row::new(Column(1), &'0'), Row::new(Column(1), &'1')],
+        zero: 0,
         visible_lines: Line(1),
         len: 2,
     };

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -197,10 +197,8 @@ impl<T> Storage<T> {
     }
 
     /// Compute actual index in underlying storage given the requested index.
-    fn compute_index(&self, mut requested: usize) -> usize {
-        // If line outside the buffer is requested, return the last line in the buffer
-        // This is used for copying a selection that has left the screen
-        requested = ::std::cmp::min(requested, self.inner.len());
+    fn compute_index(&self, requested: usize) -> usize {
+        debug_assert!(requested < self.inner.len());
         let zeroed = requested + self.zero;
 
         // This part is critical for performance,

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -201,7 +201,16 @@ impl<T> Storage<T> {
 
     /// Compute actual index in underlying storage given the requested index.
     fn compute_index(&self, requested: usize) -> usize {
-        (requested + self.zero) % self.inner.len()
+        let zeroed = requested + self.zero;
+        let len = self.inner.len();
+
+        // This is performance-critical, since `zeroed` is smaller than `len` most of the time,
+        // it makes sense to check before doing an expensive modulo operation
+        if zeroed >= len {
+            zeroed % len
+        } else {
+            zeroed
+        }
     }
 
     pub fn swap_lines(&mut self, a: Line, b: Line) {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -945,9 +945,12 @@ impl Term {
             fn append(
                 &mut self,
                 grid: &Grid<Cell>,
-                line: usize,
+                mut line: usize,
                 cols: Range<Column>
             ) -> Option<Range<Column>> {
+                // Select until last line still within the buffer
+                line = min(line, grid.len() - 1);
+
                 let grid_line = &grid[line];
                 let line_length = grid_line.line_length();
                 let line_end = min(line_length, cols.end + 1);


### PR DESCRIPTION
The `compute_index` method in the `Storage` struct used to normalize
indices was responsible for a significant amount of the CPU time spent
while running the `alt-screen-random-write` benchmark (~50%).

The issue with this relatively simple method was that due to how often
the method is executed, the modulo operation was too expensive. However
since most of the time when a majority of the buffer changes (high
througput), it's in the alternate screen, the modulo operation can be
skipped with a simple branch. There might be some more optimization to
be done here, however this resolved all measurable issues in the
`alt-sceen-random-write` benchmark.

The whole `vtebench` suite hasn't been tested, however unless there were
some regressions, this fixes #1316. I will benchmark this a bit more in
the near future.