### PR TITLE
 Implement config options for term colors 16..256 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `transparent` - This makes the title bar transparent and allows the
         viewport to extend to the top of the window.
     - `buttonless` - Similar to transparent but also removed the buttons.
+- Add support for changing the colors from 16 to 256 in the `indexed_colors` config section
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -196,6 +196,14 @@ colors:
     cyan:    '0x66cccc'
     white:   '0xdddddd'
 
+  # Indexed Colors
+  #
+  # The indexed colors include all colors from 16 to 256.
+  # When these are not set, they're filled with sensible defaults.
+  #
+  #indexed_colors:
+  #  - { index: 16, color: '0x000000' }
+
 # Visual Bell
 #
 # Any time the BEL code is received, Alacritty "rings" the visual bell. Once

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -194,6 +194,14 @@ colors:
     cyan:    '0x66cccc'
     white:   '0xdddddd'
 
+  # Indexed Colors
+  #
+  # The indexed colors include all colors from 16 to 256.
+  # When these are not set, they're filled with sensible defaults.
+  #
+  #indexed_colors:
+  #  - { index: 16, color: '0x000000' }
+
 # Visual Bell
 #
 # Any time the BEL code is received, Alacritty "rings" the visual bell. Once

--- a/src/config.rs
+++ b/src/config.rs
@@ -1100,16 +1100,42 @@ pub struct Colors {
     pub bright: AnsiColors,
     #[serde(default, deserialize_with = "failure_default")]
     pub dim: Option<AnsiColors>,
+    #[serde(default, deserialize_with = "failure_default_vec")]
+    pub indexed_colors: Vec<IndexedColor>,
 }
 
-fn deserialize_cursor_colors<'a, D>(deserializer: D) -> ::std::result::Result<CursorColors, D::Error>
+#[derive(Debug, Deserialize)]
+pub struct IndexedColor {
+    #[serde(deserialize_with = "deserialize_color_index")]
+    pub index: u8,
+    #[serde(deserialize_with = "rgb_from_hex")]
+    pub color: Rgb,
+}
+
+fn deserialize_color_index<'a, D>(deserializer: D) -> ::std::result::Result<u8, D::Error>
     where D: de::Deserializer<'a>
 {
-    match CursorOrPrimaryColors::deserialize(deserializer) {
-        Ok(either) => Ok(either.into_cursor_colors()),
+    match u8::deserialize(deserializer) {
+        Ok(index) => {
+            if index < 16 {
+                eprintln!(
+                    "problem with config: indexed_color's index is '{}', \
+                     but a value bigger than 15 was expected; \
+                     Ignoring setting",
+                    index
+                );
+
+                // Return value out of range to ignore this color
+                Ok(0)
+            } else {
+                Ok(index)
+            }
+        },
         Err(err) => {
-            eprintln!("problem with config: {}; Using default value", err);
-            Ok(CursorColors::default())
+            eprintln!("problem with config: {}; Ignoring setting", err);
+
+            // Return value out of range to ignore this color
+            Ok(0)
         },
     }
 }
@@ -1166,6 +1192,18 @@ impl Default for CursorColors {
             text: Rgb { r: 0, g: 0, b: 0 },
             cursor: Rgb { r: 0xff, g: 0xff, b: 0xff },
         }
+    }
+}
+
+fn deserialize_cursor_colors<'a, D>(deserializer: D) -> ::std::result::Result<CursorColors, D::Error>
+    where D: de::Deserializer<'a>
+{
+    match CursorOrPrimaryColors::deserialize(deserializer) {
+        Ok(either) => Ok(either.into_cursor_colors()),
+        Err(err) => {
+            eprintln!("problem with config: {}; Using default value", err);
+            Ok(CursorColors::default())
+        },
     }
 }
 
@@ -1234,6 +1272,7 @@ impl Default for Colors {
                 white: Rgb {r: 0xff, g: 0xff, b: 0xff},
             },
             dim: None,
+            indexed_colors: Vec::new(),
         }
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -282,7 +282,7 @@ impl GlyphCache {
         self.cache
             .entry(glyph_key)
             .or_insert_with(|| {
-                let mut rasterized = rasterizer.get_glyph(glyph_key)
+                let mut rasterized = rasterizer.get_glyph(&glyph_key)
                     .unwrap_or_else(|_| Default::default());
 
                 rasterized.left += i32::from(glyph_offset.x);

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -282,7 +282,7 @@ impl GlyphCache {
         self.cache
             .entry(glyph_key)
             .or_insert_with(|| {
-                let mut rasterized = rasterizer.get_glyph(&glyph_key)
+                let mut rasterized = rasterizer.get_glyph(glyph_key)
                     .unwrap_or_else(|_| Default::default());
 
                 rasterized.left += i32::from(glyph_offset.x);

--- a/src/term/color.rs
+++ b/src/term/color.rs
@@ -23,8 +23,8 @@ impl<'a> From<&'a Colors> for List {
         let mut list: List = unsafe { ::std::mem::uninitialized() };
 
         list.fill_named(colors);
-        list.fill_cube();
-        list.fill_gray_ramp();
+        list.fill_cube(colors);
+        list.fill_gray_ramp(colors);
 
         list
     }
@@ -95,12 +95,26 @@ impl List {
         }
     }
 
-    fn fill_cube(&mut self) {
+    pub fn fill_cube(&mut self, colors: &Colors) {
         let mut index: usize = 16;
         // Build colors
         for r in 0..6 {
             for g in 0..6 {
                 for b in 0..6 {
+                    // Index of the color is number of named colors + rgb
+                    let color_index = 16 + r + g + b;
+
+                    // Override colors 16..232 with the config (if present)
+                    if let Some(indexed_color) = colors
+                        .indexed_colors
+                        .iter()
+                        .find(|ic| ic.index == color_index)
+                    {
+                        self[index] = indexed_color.color;
+                        index += 1;
+                        continue;
+                    }
+
                     self[index] = Rgb { r: if r == 0 { 0 } else { r * 40 + 55 },
                         b: if b == 0 { 0 } else { b * 40 + 55 },
                         g: if g == 0 { 0 } else { g * 40 + 55 },
@@ -113,10 +127,24 @@ impl List {
         debug_assert!(index == 232);
     }
 
-    fn fill_gray_ramp(&mut self) {
+    pub fn fill_gray_ramp(&mut self, colors: &Colors) {
         let mut index: usize = 232;
 
         for i in 0..24 {
+            // Index of the color is number of named colors + number of cube colors + i
+            let color_index = 16 + 216 + i;
+
+            // Override colors 232..256 with the config (if present)
+            if let Some(indexed_color) = colors
+                .indexed_colors
+                .iter()
+                .find(|ic| ic.index == color_index)
+            {
+                self[index] = indexed_color.color;
+                index += 1;
+                continue;
+            }
+
             let value = i * 10 + 8;
             self[index] = Rgb {
                 r: value,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -900,6 +900,8 @@ impl Term {
     pub fn update_config(&mut self, config: &Config) {
         self.semantic_escape_chars = config.selection().semantic_escape_chars.clone();
         self.original_colors.fill_named(config.colors());
+        self.original_colors.fill_cube(config.colors());
+        self.original_colors.fill_gray_ramp(config.colors());
         for i in 0..color::COUNT {
             if !self.color_modified[i] {
                 self.colors[i] = self.original_colors[i];


### PR DESCRIPTION
This adds a config option which allows setting terminal colors above the
0..16 range, this is often not used so it has been added to the config
option commented out by default.

Live config reload already works for this, so it is possible to change
these colors the same way it works with the normal colors.

If a color below 16 is specified, the configuration will throw an error,
so the normal colors can't be overridden. This is just to prevent
possible complications with the settings that already exist.

I've also fixed existing clippy issues in this PR, I've chosen to do
so in a different commit to make reviews easier. All changes related
to the term colors are outside of the `Fix existing clippy issues` commit.