### PR TITLE
font: manually impl PartialEq for GlyphKey

### DIFF
--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -146,7 +146,7 @@ impl FontKey {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Eq)]
 pub struct GlyphKey {
     pub c: char,
     pub font_key: FontKey,
@@ -162,6 +162,14 @@ impl Hash for GlyphKey {
             // - Result is being used for hashing and has no fields (it's a u64)
             ::std::mem::transmute::<GlyphKey, u64>(*self)
         }.hash(state);
+    }
+}
+
+impl PartialEq for GlyphKey {
+    fn eq(&self, other: &GlyphKey) -> bool {
+        self.c == other.c &&
+        self.font_key == other.font_key &&
+        self.size == other.size
     }
 }
 


### PR DESCRIPTION
This silences #[deny(derive_hash_xor_eq)] clippy failure:
````
error: you are implementing `Hash` explicitly but have derived `PartialEq`
   --> font/src/lib.rs:156:1
    |
156 | / impl Hash for GlyphKey {
157 | |     fn hash<H: Hasher>(&self, state: &mut H) {
158 | |         unsafe {
159 | |             // This transmute is fine:
...   |
165 | |     }
166 | | }
    | |_^
    |
    = note: #[deny(derive_hash_xor_eq)] on by default
note: `PartialEq` implemented here
   --> font/src/lib.rs:149:30
    |
149 | #[derive(Debug, Copy, Clone, PartialEq, Eq)]
    |                              ^^^^^^^^^
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#derive_hash_xor_eq
````