### PR TITLE
Update the manpage to document all CLI options

### DIFF
--- a/alacritty.man
+++ b/alacritty.man
@@ -36,6 +36,9 @@ Increases the level of verbosity (the max level is \fB\-vvv\fR)
 Prints version information
 .SH "OPTIONS"
 .TP
+\fB\-\-class\fR <class>
+Defines the window class on X11 [default: Alacritty]
+.TP
 \fB\-e\fR, \fB\-\-command\fR <command>...
 Command and args to execute (must be last argument)
 .HP

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ extern crate log;
 use clap::{Arg, App};
 use index::{Line, Column};
 use config::{Dimensions, Shell};
+use window::{DEFAULT_TITLE, DEFAULT_CLASS};
 use std::path::{Path, PathBuf};
 use std::borrow::Cow;
 
@@ -80,11 +81,11 @@ impl Options {
                 .long("title")
                 .short("t")
                 .takes_value(true)
-                .help("Defines the window title"))
+                .help(&format!("Defines the window title [default: {}]", DEFAULT_TITLE)))
             .arg(Arg::with_name("class")
                  .long("class")
                  .takes_value(true)
-                 .help("Defines window class on X11"))
+                 .help(&format!("Defines window class on X11 [default: {}]", DEFAULT_CLASS)))
             .arg(Arg::with_name("q")
                 .short("q")
                 .multiple(true)


### PR DESCRIPTION
The introduction of `--class` has added a flag to the CLI without adding
it to the manpage. This has been fixed by updating the manpage.

This also adds the default values of `--class` and `--title` to the CLI
options.