### PR TITLE
Make compilation of binary a phony target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(DMG_NAME): $(APP_NAME)
 install: $(DMG_NAME) ## Mount disk image
 	@open $(DMG_DIR)/$(DMG_NAME)
 
-.PHONY: app binary clean dmg install
+.PHONY: app binary clean dmg install $(TARGET)
 
 clean: ## Remove all artifacts
 	-rm -rf $(APP_DIR)


### PR DESCRIPTION
`binary` is already a phony target, but its dependency (alacritty) is not.
This caused an issue whereby `make binary` would not compile the latest binary
after updating the repository.

To reproduce this issue:

1. `cd <alacritty>`
1. Go back a few revisions: `git checkout HEAD^^^`
1. `make binary` (or `make app`)
1. Update the repository: `git checkout master && git pull`
1. `make binary` (or `make app`)
1. The new binary has not been buil, the old version is still present in `target`.