### PR TITLE
Allow to use alternative font on small font size

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -124,6 +124,26 @@ font:
   # `WINIT_HIDPI_FACTOR=1.0 alacritty` to scale the font.
   scale_with_dpi: true
 
+#
+# An optional small font fallback for smaller requested sizes can be used in
+# the case where a bitmap font would look better. Alacritty will switch between
+# the two fonts upon font resize requests by the user. The upper bound for
+# controlling the use of the fallback is specified using 'upper_bound' field.
+#
+# For example:
+#
+#   small_font:
+#     upper_bound: 11.0
+#     font:
+#         normal:
+#           family: Terminus
+#         bold:
+#           family: Terminus
+#         italic:
+#           family: Terminus
+#         size: 16.0
+#
+
 # Display the time it takes to redraw each frame.
 render_timer: false
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -123,6 +123,25 @@ font:
   # it is recommended to set `use_thin_strokes` to `false`
   use_thin_strokes: true
 
+#
+# An optional small font fallback for smaller requested sizes can be used in
+# the case where a bitmap font would look better. Alacritty will switch between
+# the two fonts upon font resize requests by the user. The upper bound for
+# controlling the use of the fallback is specified using 'upper_bound' field.
+#
+# For example:
+#  
+#   small_font:
+#     upper_bound: 11.0
+#     font:
+#         normal:
+#           family: Terminus
+#         bold:
+#           family: Terminus
+#         italic:
+#           family: Terminus
+#         size: 16.0
+
 # Display the time it takes to redraw each frame.
 render_timer: false
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -363,6 +363,27 @@ impl<'de> Deserialize<'de> for Decorations {
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct SmallFontConfig {
+    /// Font configuration
+    #[serde(default)]
+    font: Font,
+
+    // Font size in points
+    #[serde(deserialize_with="DeserializeSize::deserialize")]
+    pub upper_bound: Size,
+}
+
+impl SmallFontConfig {
+    pub fn check_bound(&self, size: Size) -> Option<&Font> {
+        if size <= self.upper_bound {
+            Some(&self.font)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Deserialize)]
 pub struct WindowConfig {
     /// Initial dimensions
@@ -428,6 +449,10 @@ pub struct Config {
     /// Font configuration
     #[serde(default, deserialize_with = "failure_default")]
     font: Font,
+
+    /// Small font configuration
+    #[serde(default)]
+    small_font: Option<SmallFontConfig>,
 
     /// Should show render timer
     #[serde(default, deserialize_with = "failure_default")]
@@ -1565,6 +1590,12 @@ impl Config {
     #[inline]
     pub fn font(&self) -> &Font {
         &self.font
+    }
+
+    /// Get font config
+    #[inline]
+    pub fn small_font(&self) -> &Option<SmallFontConfig> {
+        &self.small_font
     }
 
     /// Get window dimensions


### PR DESCRIPTION
On smaller font size, it is sometimes better to switch to a bitmap font
automatically.

This change allows two fonts to be configured - one for larger sizes and
another for smaller sizes. An optional 'small_font' configuration is
possible, with an 'upper_bound' on the size which determines when to use
that font, based on currently used size.

For example, I with this commit I use Hack, a TTF antialised font for
large sizes, and Terminus, a bitmap font, for small sizes:

```
font:
  normal:
    family: Hack
  bold:
    family: Hack
  italic:
    family: Hack
  size: 13.0

small_font:
  upper_bound: 11.0
  font:
      normal:
        family: Terminus
      bold:
        family: Terminus
      italic:
        family: Terminus
      size: 16.0
```