### PR TITLE
Fix scrollback accessing indices out of bounds

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -357,7 +357,10 @@ impl<T: Copy + Clone> Grid<T> {
         if region.start == Line(0) {
             // Update display offset when not pinned to active area
             if self.display_offset != 0 {
-                self.display_offset += *positions;
+                self.display_offset = min(
+                    self.display_offset + *positions,
+                    self.len() - self.num_lines().0,
+                );
             }
 
             self.increase_scroll_limit(*positions);

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -100,12 +100,6 @@ pub struct GridIterator<'a, T: 'a> {
 
     /// Current position of the iterator within the grid.
     pub cur: Point<usize>,
-
-    /// Bottom of screen (buffer)
-    bot: usize,
-
-    /// Top of screen (buffer)
-    top: usize,
 }
 
 pub enum Scroll {
@@ -436,8 +430,6 @@ impl<T> Grid<T> {
         GridIterator {
             grid: self,
             cur: point,
-            bot: self.display_offset,
-            top: self.display_offset + *self.num_lines() - 1,
         }
     }
 
@@ -462,7 +454,7 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         let last_col = self.grid.num_cols() - Column(1);
         match self.cur {
-            Point { line, col } if (line == self.bot) && (col == last_col) => None,
+            Point { line, col } if line == 0 && col == last_col => None,
             Point { col, .. } if
                 (col == last_col) => {
                 self.cur.line -= 1;
@@ -482,7 +474,7 @@ impl<'a, T> BidirectionalIterator for GridIterator<'a, T> {
         let num_cols = self.grid.num_cols();
 
         match self.cur {
-            Point { line, col: Column(0) } if line == self.top => None,
+            Point { line, col: Column(0) } if line == self.grid.len() - 1 => None,
             Point { col: Column(0), .. } => {
                 self.cur.line += 1;
                 self.cur.col = num_cols - Column(1);

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -198,7 +198,7 @@ impl<T> Storage<T> {
 
     /// Compute actual index in underlying storage given the requested index.
     fn compute_index(&self, requested: usize) -> usize {
-        debug_assert!(requested < self.inner.len());
+        debug_assert!(requested < self.len);
         let zeroed = requested + self.zero;
 
         // This part is critical for performance,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -38,6 +38,11 @@ use self::cell::LineLength;
 
 impl selection::SemanticSearch for Term {
     fn semantic_search_left(&self, mut point: Point<usize>) -> Point<usize> {
+        // Limit the starting point to the last line in the history
+        if point.line >= self.grid.len() {
+            point.line = self.grid.len() - 1;
+        }
+
         let mut iter = self.grid.iter_from(point);
         let last_col = self.grid.num_cols() - Column(1);
 
@@ -57,6 +62,11 @@ impl selection::SemanticSearch for Term {
     }
 
     fn semantic_search_right(&self, mut point: Point<usize>) -> Point<usize> {
+        // Limit the starting point to the last line in the history
+        if point.line >= self.grid.len() {
+            point.line = self.grid.len() - 1;
+        }
+
         let mut iter = self.grid.iter_from(point);
         let last_col = self.grid.num_cols() - Column(1);
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -39,9 +39,7 @@ use self::cell::LineLength;
 impl selection::SemanticSearch for Term {
     fn semantic_search_left(&self, mut point: Point<usize>) -> Point<usize> {
         // Limit the starting point to the last line in the history
-        if point.line >= self.grid.len() {
-            point.line = self.grid.len() - 1;
-        }
+        point.line = min(point.line, self.grid.len() - 1);
 
         let mut iter = self.grid.iter_from(point);
         let last_col = self.grid.num_cols() - Column(1);
@@ -63,9 +61,7 @@ impl selection::SemanticSearch for Term {
 
     fn semantic_search_right(&self, mut point: Point<usize>) -> Point<usize> {
         // Limit the starting point to the last line in the history
-        if point.line >= self.grid.len() {
-            point.line = self.grid.len() - 1;
-        }
+        point.line = min(point.line, self.grid.len() - 1);
 
         let mut iter = self.grid.iter_from(point);
         let last_col = self.grid.num_cols() - Column(1);
@@ -1027,7 +1023,7 @@ impl Term {
                 }
 
                 // Starting line
-                res.append(&self.grid, start.line, Column(0)..(start.col + 1));
+                res.append(&self.grid, start.line, Column(0)..start.col);
 
             }
         }


### PR DESCRIPTION
There have been two instances of the scrollback trying to access indices
which were moved out of bounds due to new lines (`yes` command). These
have both been fixed.

The first instance was during semantic selection, since the logic of
limiting the selection start point was moved outside of `compute_index`,
it was necessary to add this to semantic selection too. Now semantic
selection, line selection and normal selection should all work without
crashing when new lines are shoving the selection out of bounds.

The other error was with the viewport being outside of the scrollback
history. Since the default is to keep the scrollback buffer at its
current position when new lines are added, it is possible that the
position the scrollback buffer is at is suddenly shoved out of the
visible area. To fix this the `display_offset` is now limited to always
be an allowed value.
If a single line of the viewport is moved out of the history now, the
viewport should move down a single line now, so only valid content is
displayed, with multiple lines this process is repeated.

This fixes #1400 and also fixes #1406.