### PR TITLE
remove remaining clippy lint annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ matrix:
     - rust: nightly
 
 script:
-  - if [ -n "$CLIPPY" ]; then cargo clippy; fi
+  - if [ -n "$CLIPPY" ]; then cargo clippy --all-features --all-targets; fi
   - if [ -z "$CLIPPY" ]; then cargo test; fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,9 +110,6 @@ impl Mul<f32> for Rgb {
 }
 
 
-#[cfg_attr(feature = "clippy", allow(too_many_arguments))]
-#[cfg_attr(feature = "clippy", allow(doc_markdown))]
-#[cfg_attr(feature = "clippy", allow(unreadable_literal))]
 #[allow(unused_mut)]
 pub mod gl {
     #![allow(non_upper_case_globals)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,7 +15,6 @@ use std::cmp;
 
 #[cfg(not(feature = "nightly"))]
 #[inline(always)]
-#[cfg_attr(feature = "clippy", allow(inline_always))]
 pub unsafe fn unlikely(x: bool) -> bool {
     x
 }


### PR DESCRIPTION
We moved to "cargo clippy" in 5ba34d4f9766a55a06ed5e3e44cc384af1b09f65 and
removing them did not seem to cause additional warnings.