### PR TITLE
enable clippy in font/copypasta crates

### DIFF
--- a/copypasta/src/lib.rs
+++ b/copypasta/src/lib.rs
@@ -1,5 +1,7 @@
 //! A cross-platform clipboard library
 
+#![cfg_attr(feature = "cargo-clippy", deny(clippy, if_not_else, enum_glob_use, wrong_pub_self_convention))]
+
 // This has to be here due to macro_use
 #[cfg(target_os = "macos")]
 #[macro_use] extern crate objc;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -232,15 +232,15 @@ impl FreeTypeRasterizer {
             let ft_face = self.library.new_face(&path, index)?;
 
             // Get available pixel sizes if font isn't scalable.
-            let non_scalable = if !pattern.scalable().next().unwrap_or(true) {
+            let non_scalable = if pattern.scalable().next().unwrap_or(true) {
+                None
+            } else {
                 let mut pixelsize = pattern.pixelsize();
                 debug!("pixelsizes: {:?}", pixelsize);
 
                 Some(FixedSize {
                     pixelsize: pixelsize.next().expect("has 1+ pixelsize"),
                 })
-            } else {
-                None
             };
 
             let face = Face {

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -17,6 +17,9 @@
 //! CoreText is used on Mac OS.
 //! FreeType is used on everything that's not Mac OS.
 //! Eventually, ClearType support will be available for windows
+
+#![cfg_attr(feature = "cargo-clippy", deny(clippy, if_not_else, enum_glob_use, wrong_pub_self_convention))]
+
 #[cfg(not(target_os = "macos"))]
 extern crate fontconfig;
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
turned out regular "cargo clippy" would ignore these previously.