### PR TITLE
Update Cargo.toml debug value from integer to bool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,4 +55,4 @@ gl_generator = "0.9"
 
 [profile.release]
 lto = true
-debug = 1
+debug = true


### PR DESCRIPTION
Encounter following error on MacOS:
```shell
make app
cargo build --release
error: failed to parse manifest at `/Users/work/rust_workspace/alacritty/Cargo.toml`

Caused by:
  expected a value of type `bool`, but found a value of type `integer` for the key `profile.release.debug`
make: *** [alacritty] Error 101
```