### PR TITLE
Fix incorrect cell side in selection

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -304,9 +304,11 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         let cell_x = x.saturating_sub(size_info.padding_x as usize) % size_info.cell_width as usize;
         let half_cell_width = (size_info.cell_width / 2.0) as usize;
 
+        let additional_padding = (size_info.width - size_info.padding_x * 2.) % size_info.cell_width;
+        let end_of_grid = size_info.width - size_info.padding_x - additional_padding;
         let cell_side = if cell_x > half_cell_width
             // Edge case when mouse leaves the window
-            || x as f32 >= size_info.width - size_info.padding_x
+            || x as f32 >= end_of_grid
         {
             Side::Right
         } else {


### PR DESCRIPTION
Previously the cell side of a selection with the mouse outside of the
grid has been calculated by setting the `Side` to `Right` whenever the
`X` of the mouse is bigger or equal to `window_width - padding_x`.
However since the grid doesn't perfectly fit the window in most cases,
there was an additional few pixels where the `Side` would be `Left`,
resulting in the selection jumping around.

To fix this the additional padding due to not perfectly fitting window
size has been included in the calculation. The `X` position is now
checked to be bigger or equal to `width - padding_x - extra_padding_x`.

An important note is that this will need changing when the grid is
centered inside the window, so extra padding is split up evenly. Once
that change is merged the calculation required will be
`width - padding_x - extra_padding_x / 2.`.

This fixes #1412.

I've created this PR separate from the block selection one because
this is a fix for an already existing bug. This way it will be easier
to merge this PR without having to first get a finished version of
#1398 up and running.