### PR TITLE
Replace debug asserts with static_assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vte 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -967,6 +968,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "static_assertions"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1367,7 @@ dependencies = [
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum smithay-client-toolkit 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "84c45607482d31161951f4ea11ba2673e3999e1cc6ca2d50a72eaee7eae3cbf1"
 "checksum stable_deref_trait 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffbc596e092fe5f598b12ef46cc03754085ac2f4d8c739ad61c4ae266cc3b3fa"
+"checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
 "checksum tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "47776f63b85777d984a50ce49d6b9e58826b6a3766a449fc95bc66cd5663c15b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ arraydeque = "0.4"
 glutin = "0.16"
 env_logger = "0.5"
 base64 = "0.9.0"
+static_assertions = "0.2.5"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
 x11-dl = "2"

--- a/src/input.rs
+++ b/src/input.rs
@@ -137,7 +137,7 @@ impl<T> Binding<T> {
     /// Optimized to use single check instead of four (one per modifier)
     #[inline]
     fn mods_match(&self, mods: ModifiersState) -> bool {
-        debug_assert!(4 == mem::size_of::<ModifiersState>());
+        assert_eq_size!(ModifiersState, u32);
         unsafe {
             mem::transmute_copy::<_, u32>(&self.mods) == mem::transmute_copy::<_, u32>(&mods)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 #[macro_use] extern crate clap;
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
+#[macro_use] extern crate static_assertions;
 
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))]
 extern crate x11_dl;


### PR DESCRIPTION
To check that transmutes will work correctly without having to rely on
error-prone runtime checking, the `static_assertions` crate has been
introduced. This allows comparing the size of types at runtime,
preventing potential silent breakage.

@jwilm do you think there are any other places where this could be introduced?
This is the only place where `mem::size_of` is used inside an assertion.
There also is no other instance of `transmute` that is unchecked outside of tests.

This fixes #1417.