### PR TITLE
Disable scroll buffer for "alt" Grid

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -849,13 +849,13 @@ impl Term {
 
         let history_size = config.scrolling().history as usize;
         let grid = Grid::new(num_lines, num_cols, history_size, Cell::default());
+        let alt = Grid::new(num_lines, num_cols, 0 /* scroll history */, Cell::default());
 
         let tabspaces = config.tabspaces();
         let tabs = IndexRange::from(Column(0)..grid.num_cols())
             .map(|i| (*i as usize) % tabspaces == 0)
             .collect::<Vec<bool>>();
 
-        let alt = grid.clone();
         let scroll_region = Line(0)..grid.num_lines();
 
         Term {


### PR DESCRIPTION
The scroll history size for the alternative grid (used by fullscreen
apps such as vim and tmux) is now forced to zero. There are two
motivations for this change:

1. According to the literature, the alt screen should not have scroll
   history.
2. Reduce memory consumption by only allocating the single scroll
   history.

In the future, it may be desirable to support a configuration option to
enable a scroll buffer for the alt screen. By launching without this
feature, we can delay a decision about whether to officially support
this or not.