### PR TITLE
Scrollback cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ matrix:
     - rust: nightly
 
 script:
-  - if [ -n "$CLIPPY" ]; then cargo clippy; fi
+  - if [ -n "$CLIPPY" ]; then cargo clippy --all-features --all-targets; fi
   - if [ -z "$CLIPPY" ]; then cargo test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,22 @@ rust:
   - nightly
 
 env:
-  - FEATURES="clippy"
-  - FEATURES=""
+  - CLIPPY="true"
+  - CLIPPY=""
+
+install:
+  - if [ -n "$CLIPPY" ]; then cargo install -f clippy; fi
 
 matrix:
   fast_finish: true
   exclude:
     - rust: stable
-      env: FEATURES="clippy"
+      env: CLIPPY="true"
     - rust: nightly
-      env: FEATURES=""
+      env: CLIPPY=""
   allow_failures:
     - rust: nightly
 
 script:
-  - cargo test --no-default-features --features "$FEATURES"
+  - if [ -n "$CLIPPY" ]; then cargo clippy; fi
+  - if [ -z "$CLIPPY" ]; then cargo test; fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,11 +11,10 @@ name = "alacritty"
 version = "0.1.0"
 dependencies = [
  "arraydeque 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.205 (registry+https://github.com/rust-lang/crates.io-index)",
  "copypasta 0.0.1",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -23,20 +22,20 @@ dependencies = [
  "font 0.1.0",
  "gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-more 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vte 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11-dl 2.17.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -50,7 +49,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -68,36 +67,14 @@ name = "atty"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace-sys 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "base64"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -121,11 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -145,20 +117,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cargo_metadata"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cc"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -172,7 +132,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gleam 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,44 +160,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "clippy"
-version = "0.0.205"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.205 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "clippy_lints"
-version = "0.0.205"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -248,7 +175,7 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -267,7 +194,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -276,7 +203,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -284,7 +211,7 @@ name = "core-foundation-sys"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -300,7 +227,7 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -311,7 +238,7 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -322,7 +249,7 @@ dependencies = [
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -344,18 +271,13 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "either"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "env_logger"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -366,16 +288,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -401,8 +315,8 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -421,8 +335,8 @@ dependencies = [
  "euclid 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-fontconfig 0.4.0 (git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8)",
 ]
 
@@ -446,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -454,7 +368,7 @@ name = "freetype-sys"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -466,7 +380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -474,7 +388,7 @@ name = "fsevent-sys"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -492,17 +406,12 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "getopts"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "gl_generator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -525,15 +434,15 @@ dependencies = [
  "core-foundation 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11-dl 2.17.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -545,26 +454,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "if_chain"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "inotify"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -572,16 +466,8 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -605,7 +491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -620,7 +506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.41"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -628,8 +514,8 @@ name = "libloading"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -637,8 +523,8 @@ name = "libz-sys"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -653,12 +539,12 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -669,20 +555,15 @@ name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -690,8 +571,8 @@ name = "memmap"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -700,7 +581,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -720,8 +601,8 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -767,8 +648,8 @@ version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -777,7 +658,19 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -791,7 +684,7 @@ dependencies = [
  "fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,7 +742,7 @@ name = "owning_ref"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -866,10 +759,10 @@ name = "parking_lot_core"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -884,19 +777,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -905,16 +789,11 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "quine-mc_cluskey"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "quote"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -923,13 +802,13 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -937,7 +816,7 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -947,14 +826,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -965,20 +844,7 @@ name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -991,56 +857,42 @@ name = "same-file"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.62"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.62"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1049,7 +901,7 @@ name = "servo-fontconfig"
 version = "0.4.0"
 source = "git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8#be2b94de833ec69cf767186262a5fb8360fa5b45"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-fontconfig-sys 4.0.3 (git+https://github.com/jwilm/libfontconfig?branch=updated-2017-10-8)",
 ]
 
@@ -1068,8 +920,8 @@ name = "shared_library"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1094,23 +946,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-protocols 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-protocols 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1120,11 +973,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1133,11 +986,11 @@ name = "tempfile"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1153,8 +1006,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1171,7 +1024,7 @@ name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1180,35 +1033,14 @@ name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "toml"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ucd-util"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1227,16 +1059,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "url"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1278,45 +1100,45 @@ version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-commons"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1324,11 +1146,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1338,7 +1160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1365,27 +1187,27 @@ name = "wincolor"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winit"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smithay-client-toolkit 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11-dl 2.17.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1399,11 +1221,11 @@ dependencies = [
 
 [[package]]
 name = "x11-dl"
-version = "2.17.5"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1435,25 +1257,19 @@ dependencies = [
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arraydeque 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc059aa8598b9f4fb1dd532a061edc8e4efe0ccc55ba05358aba2a80b7b01f11"
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
-"checksum backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbdd17cd962b570302f5297aea8648d5923e22e555c2ed2d8b2e34eca646bf6d"
-"checksum backtrace-sys 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5fd343a2466c4603f76f38de264bc0526cffc7fa38ba52fb9f13237eccc1ced2"
-"checksum base64 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9263aa6a38da271eec5c91a83ce1e800f093c8535788d403d626d8d5c3f8f007"
+"checksum base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
-"checksum cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ebd6272a2ca4fd39dbabbd6611eb03df45c2259b3b80b39a9ff8fbdcf42a4b3"
-"checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
+"checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum cgl 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "80f05e25f9631fdee56693110feda284a49308ca1e768857a0ad3906cfc1502a"
 "checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
-"checksum clippy 0.0.205 (registry+https://github.com/rust-lang/crates.io-index)" = "bef3132dda284aba0f5630374566e98095c306d9ae49c4f7ede99347c4343fbe"
-"checksum clippy_lints 0.0.205 (registry+https://github.com/rust-lang/crates.io-index)" = "1dcb837d7510bf9e4e3b6f470c450c6d25e61116db5503a6f565bb6283860622"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
 "checksum cocoa 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b44bd25bd275e9d74a5dff8ca55f2fb66c9ad5e12170d58697701df21a56e0e"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
@@ -1466,10 +1282,8 @@ dependencies = [
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0e6e40ebb0e66918a37b38c7acab4e10d299e0463fe2af5d29b9cc86710cfd2a"
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum euclid 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c95fd0d455f114291a3109286bd387bd423770058474a2d3f38b712cd661df60"
 "checksum expat-sys 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c470ccb972f2088549b023db8029ed9da9426f5affbf9b62efff7009ab8ed5b1"
 "checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
@@ -1482,30 +1296,25 @@ dependencies = [
 "checksum fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a772d36c338d07a032d5375a36f15f9a7043bf0cb8ce7cee658e037c6032874"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12b793fcf40a23dd372f184c228ab3eb96f88c50bb4fba8319c483aa025a4e45"
 "checksum glutin 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "42fb2de780307bd2bedbe013bc585659a683e7c6307d0baa878aec3da9250fc1"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
-"checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
-"checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum inotify 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887fcc180136e77a85e6a6128579a719027b1bab9b1c38ea4444244fe262c20c"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "037ab472c33f67b5fbd3e9163a2645319e5356fcd355efa6d4eb7fff4bbcb554"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
-"checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
+"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+"checksum log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6fddaa003a65722a7fb9e26b0ce95921fe4ba590542ced664d8ce2fa26f9f3ac"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-"checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
@@ -1514,6 +1323,7 @@ dependencies = [
 "checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
+"checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5c3812da3098f210a0bb440f9c008471a031aa4c1de07a264fdd75456c95a4eb"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
@@ -1527,27 +1337,21 @@ dependencies = [
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
-"checksum proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a45f2f0ae0b5757f6fe9e68745ba25f5246aea3598984ed81d013865873c1f84"
-"checksum pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdf85cda6cadfae5428a54661d431330b312bc767ddbc57adbedc24da66e32"
+"checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
-"checksum quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e53eeda07ddbd8b057dde66d9beded11d0dfda13f0db0769e6b71d6bcf2074e"
+"checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "0a12d51a5b5fd700e6c757f15877685bfa04fd7eb60c108f01d045cafa0073c2"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
-"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
+"checksum regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05b06a75f5217880fc5e905952a42750bf44787e56a6c6d6852ed0992f5e1d54"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
-"checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
-"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)" = "44d9552562673a8ea8757f5b77ccd794b54dd6841d2def71e9936f293ee81c72"
-"checksum serde_derive 1.0.62 (registry+https://github.com/rust-lang/crates.io-index)" = "9503e0851dc4398d7f7ee1da227f9c9b9cf82718eb239ab10847b1de6e2a5777"
-"checksum serde_json 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "ee382a792fabc5d720630aeafe1a4c69abe3d32aaaa5dbba6762fd8246d1bbe3"
-"checksum serde_yaml 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "107bb818146aaf922e7bbcf6a940f1db2f0dcf381779b451e400331b2c6f86db"
+"checksum serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "e9a2d9a9ac5120e0f768801ca2b58ad6eec929dc9d1d616c162f208869c2ce95"
+"checksum serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "0a90213fa7e0f5eac3f7afe2d5ff6b088af515052cc7303bd68c7e3b91a3fb79"
+"checksum serde_json 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "fc97cccc2959f39984524026d760c08ef0dd5f0f5948c8d31797dbfae458c875"
+"checksum serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051"
 "checksum servo-fontconfig 0.4.0 (git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8)" = "<none>"
 "checksum servo-fontconfig-sys 4.0.3 (git+https://github.com/jwilm/libfontconfig?branch=updated-2017-10-8)" = "<none>"
 "checksum shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8254bf098ce4d8d7cc7cc6de438c5488adc5297e5b7ffef88816c0a91bd289c1"
@@ -1555,24 +1359,20 @@ dependencies = [
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
-"checksum smithay-client-toolkit 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "92dd41b4a4a0679e5873f8e58b8191554d4dc0104d32a22ff09b678059327bd2"
-"checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
+"checksum smithay-client-toolkit 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "84c45607482d31161951f4ea11ba2673e3999e1cc6ca2d50a72eaee7eae3cbf1"
+"checksum stable_deref_trait 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffbc596e092fe5f598b12ef46cc03754085ac2f4d8c739ad61c4ae266cc3b3fa"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99d991a9e7c33123925e511baab68f7ec25c3795962fe326a2395e5a42a614f0"
+"checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
 "checksum tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "47776f63b85777d984a50ce49d6b9e58826b6a3766a449fc95bc66cd5663c15b"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
-"checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
-"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum utf8parse 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a15ea87f3194a3a454c78d79082b4f5e85f6956ddb6cb86bbfbe4892aa3c0323"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
@@ -1580,20 +1380,20 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum vte 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a01634c75db59478405de08d8567c40c578bba80c565217ee709934b551720d8"
 "checksum walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369"
-"checksum wayland-client 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7de22033af9c568a9c91230c9c46358bc832308c76bf04884dab2f89dd75489c"
-"checksum wayland-commons 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d3faac04ae4d5f42b86ed0b32cbedd3b212bd12b064258c2b8a10a43ec81a353"
-"checksum wayland-protocols 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7a2dfff48d5f7d0be1de525db808e3dae429cbd0517b89244ee07ce0238612b2"
-"checksum wayland-scanner 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0fb79019ceee53288e51e3657eec52d1ddda70f0a11e74ad7ad83789a3bdecf1"
-"checksum wayland-sys 0.20.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e47d1f8971491be2431996a326e81d78e56563d581d856c95195fff5bb738059"
+"checksum wayland-client 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0f3ed65542a0be13ea0fdcc55c9a011fcc44c3882e6e1a9b4dfddb25182897dd"
+"checksum wayland-commons 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4ac5c79f1d050f4047a82ddce77acda026c142c0023e7b7e20eea5ad76fb7dbf"
+"checksum wayland-protocols 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)" = "be56e3d80559177a70bc78f9396fbe1705b7baed4951ae6e34d28bb59681b1a8"
+"checksum wayland-scanner 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)" = "93cf4ef48caedf3fc1a9b2bf0df64e6d425bd628b85830a08432dd25b61de17c"
+"checksum wayland-sys 0.20.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d2dbe7b51c16b8a8153806aaa21f346333074482bb57bc5cb059cc828f8c6842"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
-"checksum winit 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "452e3331a6fb5b9d660efae533bf9ae022c528d36eb1e6278b37fc9319d58eff"
+"checksum winit 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bb6ea35de8bd722201914b28a33d503ee45b09fcf85fc4bbf574845e41f79e2"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum x11-dl 2.17.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3235540540fde1ae074c8df49054166c0e070407f1c6e1ee17b8c87c2c7bcc7d"
+"checksum x11-dl 2.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "931d8584b49771143af0c422f372d8aef4280afd5920dad39b0a95a8e51df1e9"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vte 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -967,6 +968,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "static_assertions"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1367,7 @@ dependencies = [
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum smithay-client-toolkit 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "84c45607482d31161951f4ea11ba2673e3999e1cc6ca2d50a72eaee7eae3cbf1"
 "checksum stable_deref_trait 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffbc596e092fe5f598b12ef46cc03754085ac2f4d8c739ad61c4ae266cc3b3fa"
+"checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
 "checksum tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "47776f63b85777d984a50ce49d6b9e58826b6a3766a449fc95bc66cd5663c15b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ arraydeque = "0.4"
 glutin = "0.16"
 env_logger = "0.5"
 base64 = "0.9.0"
+static_assertions = "0.2.5"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
 x11-dl = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ fnv = "1"
 unicode-width = "0.1"
 arraydeque = "0.4"
 glutin = "0.16"
-clippy = { version = "*", optional = true }
 env_logger = "0.5"
 base64 = "0.9.0"
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(DMG_NAME): $(APP_NAME)
 install: $(DMG_NAME) ## Mount disk image
 	@open $(DMG_DIR)/$(DMG_NAME)
 
-.PHONY: app binary clean dmg install
+.PHONY: app binary clean dmg install $(TARGET)
 
 clean: ## Remove all artifacts
 	-rm -rf $(APP_DIR)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ built from source.
 
 Instructions are provided for macOS and many Linux variants to compile Alacritty
 from source. With the exception of Arch (which has a package in the AUR), Void Linux (in main repository) and
-[NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/alacritty/default.nix)
-(at the moment in unstable, will be part of 17.09), please first read the
+[NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/alacritty/default.nix), please first read the
 [prerequisites](#prerequisites) section, then find the section for your OS, and
 finally go to [building](#building) and [configuration](#configuration).
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ cd alacritty-git
 makepkg -isr
 ```
 
+### openSUSE Tumbleweed Linux
+
+```sh
+zypper in alacritty
+```
+
 ### Void Linux
 
 ```sh

--- a/alacritty.man
+++ b/alacritty.man
@@ -36,6 +36,9 @@ Increases the level of verbosity (the max level is \fB\-vvv\fR)
 Prints version information
 .SH "OPTIONS"
 .TP
+\fB\-\-class\fR <class>
+Defines the window class on X11 [default: Alacritty]
+.TP
 \fB\-e\fR, \fB\-\-command\fR <command>...
 Command and args to execute (must be last argument)
 .HP

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -116,6 +116,12 @@ font:
     x: 0
     y: 0
 
+  # Scale the font size based on the monitor's DPI. This will lead to bigger text on HiDPI
+  # screens and make reading text a little easier.
+  # On X11 it is possible to change the DPI for each instance of alacritty by using
+  # `WINIT_HIDPI_FACTOR=1.0 alacritty` to scale the font.
+  scale_with_dpi: true
+
   # OS X only: use thin stroke font rendering. Thin strokes are suitable
   # for retina displays, but for non-retina you probably want this set to
   # false.

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -316,6 +316,8 @@ live_config_reload: true
 key_bindings:
   - { key: V,        mods: Control|Shift,    action: Paste               }
   - { key: C,        mods: Control|Shift,    action: Copy                }
+  - { key: Paste,                   action: Paste                        }
+  - { key: Copy,                    action: Copy                         }
   - { key: Q,        mods: Command, action: Quit                         }
   - { key: W,        mods: Command, action: Quit                         }
   - { key: Insert,   mods: Shift,   action: PasteSelection               }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -291,6 +291,8 @@ live_config_reload: true
 key_bindings:
   - { key: V,        mods: Command, action: Paste                        }
   - { key: C,        mods: Command, action: Copy                         }
+  - { key: Paste,                   action: Paste                        }
+  - { key: Copy,                    action: Copy                         }
   - { key: Q,        mods: Command, action: Quit                         }
   - { key: W,        mods: Command, action: Quit                         }
   - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -96,6 +96,10 @@ font:
     x: 0
     y: 0
 
+  # Scale the font size based on the monitor's DPI. This will lead to bigger text on HiDPI
+  # screens and make reading text a little easier.
+  scale_with_dpi: true
+
   # OS X only: use thin stroke font rendering. Thin strokes are suitable
   # for retina displays, but for non-retina you probably want this set to
   # false.

--- a/copypasta/src/lib.rs
+++ b/copypasta/src/lib.rs
@@ -1,5 +1,7 @@
 //! A cross-platform clipboard library
 
+#![cfg_attr(feature = "cargo-clippy", deny(clippy, if_not_else, enum_glob_use, wrong_pub_self_convention))]
+
 // This has to be here due to macro_use
 #[cfg(target_os = "macos")]
 #[macro_use] extern crate objc;

--- a/font/Cargo.lock
+++ b/font/Cargo.lock
@@ -1,0 +1,224 @@
+[[package]]
+name = "bitflags"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cmake"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-text"
+version = "9.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "euclid"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "expat-sys"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "font"
+version = "0.1.0"
+dependencies = [
+ "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 9.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-fontconfig 0.4.0 (git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8)",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "freetype-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libz-sys"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "servo-fontconfig"
+version = "0.4.0"
+source = "git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8#be2b94de833ec69cf767186262a5fb8360fa5b45"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-fontconfig-sys 4.0.3 (git+https://github.com/jwilm/libfontconfig?branch=updated-2017-10-8)",
+]
+
+[[package]]
+name = "servo-fontconfig-sys"
+version = "4.0.3"
+source = "git+https://github.com/jwilm/libfontconfig?branch=updated-2017-10-8#5c1845e1bffa11cf4d3e6fb27f456bf5c814ce1b"
+dependencies = [
+ "expat-sys 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
+"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
+"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
+"checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
+"checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
+"checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
+"checksum core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb0ed45fdc32f9ab426238fba9407dfead7bacd7900c9b4dd3f396f46eafdae3"
+"checksum core-text 9.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd581c37283d0c23311d179aefbb891f2324ee0405da58a26e8594ab76e5748"
+"checksum euclid 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c95fd0d455f114291a3109286bd387bd423770058474a2d3f38b712cd661df60"
+"checksum expat-sys 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c470ccb972f2088549b023db8029ed9da9426f5affbf9b62efff7009ab8ed5b1"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1418e2a055fec8efe18c1a90a54b2cf5e649e583830dd4c71226c4e3bc920c6"
+"checksum freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccfb6d96cac99921f0c2142a91765f6c219868a2c45bdfe7d65a08775f18127"
+"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
+"checksum log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6fddaa003a65722a7fb9e26b0ce95921fe4ba590542ced664d8ce2fa26f9f3ac"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+"checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
+"checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
+"checksum servo-fontconfig 0.4.0 (git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8)" = "<none>"
+"checksum servo-fontconfig-sys 4.0.3 (git+https://github.com/jwilm/libfontconfig?branch=updated-2017-10-8)" = "<none>"
+"checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"

--- a/font/src/darwin/byte_order.rs
+++ b/font/src/darwin/byte_order.rs
@@ -24,7 +24,7 @@ pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Little;
 pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Big;
 
 #[cfg(target_endian = "little")]
-pub fn extract_rgb(bytes: Vec<u8>) -> Vec<u8> {
+pub fn extract_rgb(bytes: &[u8]) -> Vec<u8> {
     let pixels = bytes.len() / 4;
     let mut rgb = Vec::with_capacity(pixels * 3);
 
@@ -32,7 +32,7 @@ pub fn extract_rgb(bytes: Vec<u8>) -> Vec<u8> {
         let offset = i * 4;
         rgb.push(bytes[offset + 2]);
         rgb.push(bytes[offset + 1]);
-        rgb.push(bytes[offset + 0]);
+        rgb.push(bytes[offset]);
     }
 
     rgb

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -162,7 +162,7 @@ impl ::Rasterize for Rasterizer {
     }
 
     /// Get rasterized glyph for given glyph key
-    fn get_glyph(&mut self, glyph: &GlyphKey) -> Result<RasterizedGlyph, Error> {
+    fn get_glyph(&mut self, glyph: GlyphKey) -> Result<RasterizedGlyph, Error> {
 
         // get loaded font
         let font = self.fonts
@@ -246,7 +246,7 @@ impl Rasterizer {
     // Helper to try and get a glyph for a given font. Used for font fallback.
     fn maybe_get_glyph(
         &self,
-        glyph: &GlyphKey,
+        glyph: GlyphKey,
         font: &Font,
     ) -> Option<Result<RasterizedGlyph, Error>> {
         let scaled_size = self.device_pixel_ratio * glyph.size.as_f32_pts();
@@ -356,7 +356,7 @@ impl Descriptor {
                     let menlo = ct_new_from_descriptor(&descriptor.ct_descriptor, size);
 
                     // TODO fixme, hardcoded en for english
-                    let mut fallbacks = cascade_list_for_languages(&menlo, &vec!["en".to_owned()])
+                    let mut fallbacks = cascade_list_for_languages(&menlo, &["en".to_owned()])
                         .into_iter()
                         .filter(|desc| desc.font_path != "")
                         .map(|desc| desc.to_font(size, false))

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -132,8 +132,8 @@ impl ::Rasterize for Rasterizer {
         Ok(Rasterizer {
             fonts: HashMap::new(),
             keys: HashMap::new(),
-            device_pixel_ratio: device_pixel_ratio,
-            use_thin_strokes: use_thin_strokes,
+            device_pixel_ratio,
+            use_thin_strokes,
         })
     }
 
@@ -196,7 +196,7 @@ impl Rasterizer {
         for descriptor in descriptors {
             if descriptor.style_name == style {
                 // Found the font we want
-                let scaled_size = size.as_f32_pts() as f64 * self.device_pixel_ratio as f64;
+                let scaled_size = f64::from(size.as_f32_pts()) * f64::from(self.device_pixel_ratio);
                 let font = descriptor.to_font(scaled_size, true);
                 return Ok(font);
             }
@@ -220,7 +220,7 @@ impl Rasterizer {
             Slant::Normal => false,
             _ => true,
         };
-        let scaled_size = size.as_f32_pts() as f64 * self.device_pixel_ratio as f64;
+        let scaled_size = f64::from(size.as_f32_pts()) * f64::from(self.device_pixel_ratio);
 
         let descriptors = descriptors_for_family(&desc.name[..]);
         for descriptor in descriptors {
@@ -250,7 +250,7 @@ impl Rasterizer {
         font: &Font,
     ) -> Option<Result<RasterizedGlyph, Error>> {
         let scaled_size = self.device_pixel_ratio * glyph.size.as_f32_pts();
-        font.get_glyph(glyph.c, scaled_size as _, self.use_thin_strokes)
+        font.get_glyph(glyph.c, f64::from(scaled_size), self.use_thin_strokes)
             .map(|r| Some(Ok(r)))
             .unwrap_or_else(|e| match e {
                 Error::MissingGlyph(_) => None,
@@ -301,7 +301,7 @@ pub fn get_family_names() -> Vec<String> {
 /// Return fallback descriptors for font/language list
 fn cascade_list_for_languages(
     ct_font: &CTFont,
-    languages: &Vec<String>
+    languages: &[String]
 ) -> Vec<Descriptor> {
 
     // convert language type &Vec<String> -> CFArray
@@ -368,12 +368,11 @@ impl Descriptor {
                     // many chars. We add the symbols back in.
                     // Investigate if we can actually use the .-prefixed
                     // fallbacks somehow.
-                    descriptors_for_family("Apple Symbols")
-                        .into_iter()
-                        .next() // should only have one element; use it
-                        .map(|descriptor| {
-                            fallbacks.push(descriptor.to_font(size, false))
-                        });
+                    if let Some(descriptor) =
+                        descriptors_for_family("Apple Symbols").into_iter().next()
+                    {
+                        fallbacks.push(descriptor.to_font(size, false))
+                    };
 
                     // Include Menlo in the fallback list as well
                     fallbacks.insert(0, Font {
@@ -390,9 +389,9 @@ impl Descriptor {
         };
 
         Font {
-            ct_font: ct_font,
-            cg_font: cg_font,
-            fallbacks: fallbacks,
+            ct_font,
+            cg_font,
+            fallbacks,
         }
     }
 }
@@ -424,8 +423,8 @@ impl Font {
         let line_height = (ascent + descent + leading + 0.5).floor();
 
         Metrics {
-            average_advance: average_advance,
-            line_height: line_height,
+            average_advance,
+            line_height,
             descent: -(self.ct_font.descent() as f32),
         }
     }
@@ -482,13 +481,13 @@ impl Font {
         }
 
         let glyph_index = self.glyph_index(character)
-            .ok_or(Error::MissingGlyph(character))?;
+            .ok_or_else(|| Error::MissingGlyph(character))?;
 
         let bounds = self.bounding_rect_for_glyph(Default::default(), glyph_index);
 
         let rasterized_left = bounds.origin.x.floor() as i32;
         let rasterized_width =
-            (bounds.origin.x - (rasterized_left as f64) + bounds.size.width).ceil() as u32;
+            (bounds.origin.x - f64::from(rasterized_left) + bounds.size.width).ceil() as u32;
         let rasterized_descent = (-bounds.origin.y).ceil() as i32;
         let rasterized_ascent = (bounds.size.height + bounds.origin.y).ceil() as i32;
         let rasterized_height = (rasterized_descent + rasterized_ascent) as u32;
@@ -519,8 +518,8 @@ impl Font {
         let context_rect = CGRect::new(
             &CGPoint::new(0.0, 0.0),
             &CGSize::new(
-                rasterized_width as f64,
-                rasterized_height as f64
+                f64::from(rasterized_width),
+                f64::from(rasterized_height)
             )
         );
 
@@ -542,8 +541,8 @@ impl Font {
         // Set fill color to white for drawing the glyph
         cg_context.set_rgb_fill_color(1.0, 1.0, 1.0, 1.0);
         let rasterization_origin = CGPoint {
-            x: -rasterized_left as f64,
-            y: rasterized_descent as f64,
+            x: f64::from(-rasterized_left),
+            y: f64::from(rasterized_descent),
         };
 
         self.ct_font.draw_glyphs(&[glyph_index as CGGlyph],
@@ -552,7 +551,7 @@ impl Font {
 
         let rasterized_pixels = cg_context.data().to_vec();
 
-        let buf = extract_rgb(rasterized_pixels);
+        let buf = extract_rgb(&rasterized_pixels);
 
         Ok(RasterizedGlyph {
             c: character,
@@ -560,7 +559,7 @@ impl Font {
             top: (bounds.size.height + bounds.origin.y).ceil() as i32,
             width: rasterized_width as i32,
             height: rasterized_height as i32,
-            buf: buf,
+            buf,
         })
     }
 
@@ -585,7 +584,7 @@ impl Font {
         );
 
         if res {
-            Some(glyphs[0] as u32)
+            Some(u32::from(glyphs[0]))
         } else {
             None
         }

--- a/font/src/ft/fc/char_set.rs
+++ b/font/src/ft/fc/char_set.rs
@@ -24,7 +24,13 @@ foreign_type! {
 }
 
 impl CharSet {
-    pub fn new() -> CharSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for CharSet {
+    fn default() -> Self {
         CharSet(unsafe { FcCharSetCreate() })
     }
 }

--- a/font/src/ft/fc/config.rs
+++ b/font/src/ft/fc/config.rs
@@ -38,7 +38,7 @@ impl Config {
 impl ConfigRef {
     /// Returns one of the two sets of fonts from the configuration as
     /// specified by `set`.
-    pub fn get_fonts<'a>(&'a self, set: SetName) -> &'a FontSetRef {
+    pub fn get_fonts(&self, set: SetName) -> &FontSetRef {
         unsafe {
             let ptr = FcConfigGetFonts(self.as_ptr(), set as u32);
             FontSetRef::from_ptr(ptr)

--- a/font/src/ft/fc/mod.rs
+++ b/font/src/ft/fc/mod.rs
@@ -180,9 +180,9 @@ pub enum Width {
 }
 
 impl Width {
-    fn to_isize(&self) -> isize {
+    fn to_isize(self) -> isize {
         use self::Width::*;
-        match *self {
+        match self {
             Ultracondensed => 50,
             Extracondensed => 63,
             Condensed => 75,

--- a/font/src/ft/fc/object_set.rs
+++ b/font/src/ft/fc/object_set.rs
@@ -24,8 +24,13 @@ foreign_type! {
 }
 
 impl ObjectSet {
-    #[allow(dead_code)]
-    pub fn new() -> ObjectSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for ObjectSet {
+    fn default() -> Self {
         ObjectSet(unsafe {
             FcObjectSetCreate()
         })

--- a/font/src/ft/fc/pattern.rs
+++ b/font/src/ft/fc/pattern.rs
@@ -39,8 +39,8 @@ pub struct StringPropertyIter<'a> {
 impl<'a> StringPropertyIter<'a> {
     fn new<'b>(pattern: &'b PatternRef, object: &'b [u8]) -> StringPropertyIter<'b> {
         StringPropertyIter {
-            pattern: pattern,
-            object: object,
+            pattern,
+            object,
             index: 0
         }
     }
@@ -82,8 +82,8 @@ pub struct BooleanPropertyIter<'a> {
 impl<'a> BooleanPropertyIter<'a> {
     fn new<'b>(pattern: &'b PatternRef, object: &'b [u8]) -> BooleanPropertyIter<'b> {
         BooleanPropertyIter {
-            pattern: pattern,
-            object: object,
+            pattern,
+            object,
             index: 0
         }
     }
@@ -101,7 +101,7 @@ impl<'a> BooleanPropertyIter<'a> {
         };
 
         if result == FcResultMatch {
-            Some(!(value == 0))
+            Some(value != 0)
         } else {
             None
         }
@@ -118,8 +118,8 @@ pub struct IntPropertyIter<'a> {
 impl<'a> IntPropertyIter<'a> {
     fn new<'b>(pattern: &'b PatternRef, object: &'b [u8]) -> IntPropertyIter<'b> {
         IntPropertyIter {
-            pattern: pattern,
-            object: object,
+            pattern,
+            object,
             index: 0
         }
     }
@@ -171,7 +171,7 @@ pub struct HintStylePropertyIter<'a> {
 }
 
 impl<'a> HintStylePropertyIter<'a> {
-    fn new<'b>(pattern: &'b PatternRef) -> HintStylePropertyIter<'b> {
+    fn new(pattern: &PatternRef) -> HintStylePropertyIter {
         HintStylePropertyIter {
             inner: IntPropertyIter::new(pattern, b"hintstyle\0")
         }
@@ -201,7 +201,7 @@ pub struct LcdFilterPropertyIter<'a> {
 }
 
 impl<'a> LcdFilterPropertyIter<'a> {
-    fn new<'b>(pattern: &'b PatternRef) -> LcdFilterPropertyIter<'b> {
+    fn new(pattern: &PatternRef) -> LcdFilterPropertyIter {
         LcdFilterPropertyIter {
             inner: IntPropertyIter::new(pattern, b"lcdfilter\0")
         }
@@ -236,14 +236,14 @@ pub struct DoublePropertyIter<'a> {
 impl<'a> DoublePropertyIter<'a> {
     fn new<'b>(pattern: &'b PatternRef, object: &'b [u8]) -> DoublePropertyIter<'b> {
         DoublePropertyIter {
-            pattern: pattern,
-            object: object,
+            pattern,
+            object,
             index: 0
         }
     }
 
     fn get_value(&self, index: usize) -> Option<f64> {
-        let mut value = 0 as c_double;
+        let mut value = f64::from(0);
 
         let result = unsafe {
             FcPatternGetDouble(
@@ -379,7 +379,13 @@ macro_rules! string_accessor {
 }
 
 impl Pattern {
-    pub fn new() -> Pattern {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Pattern {
+    fn default() -> Self {
         Pattern(unsafe { FcPatternCreate() })
     }
 }
@@ -483,11 +489,11 @@ impl PatternRef {
         BooleanPropertyIter::new(self, object)
     }
 
-    pub fn hintstyle<'a>(&'a self) -> HintStylePropertyIter<'a> {
+    pub fn hintstyle(&self) -> HintStylePropertyIter {
         HintStylePropertyIter::new(self)
     }
 
-    pub fn lcdfilter<'a>(&'a self) -> LcdFilterPropertyIter<'a> {
+    pub fn lcdfilter(&self) -> LcdFilterPropertyIter {
         LcdFilterPropertyIter::new(self)
     }
 
@@ -565,7 +571,7 @@ impl PatternRef {
         RgbaPropertyIter::new(self, b"rgba\0")
     }
 
-    pub fn set_rgba(&self, rgba: Rgba) -> bool {
+    pub fn set_rgba(&self, rgba: &Rgba) -> bool {
         unsafe {
             self.add_integer(b"rgba\0", rgba.to_isize())
         }

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -102,7 +102,7 @@ impl ::Rasterize for FreeTypeRasterizer {
         self.get_face(desc, size)
     }
 
-    fn get_glyph(&mut self, glyph_key: &GlyphKey) -> Result<RasterizedGlyph, Error> {
+    fn get_glyph(&mut self, glyph_key: GlyphKey) -> Result<RasterizedGlyph, Error> {
         self.get_rendered_glyph(glyph_key)
     }
 
@@ -264,7 +264,7 @@ impl FreeTypeRasterizer {
         }
     }
 
-    fn face_for_glyph(&mut self, glyph_key: &GlyphKey, have_recursed: bool) -> Result<FontKey, Error> {
+    fn face_for_glyph(&mut self, glyph_key: GlyphKey, have_recursed: bool) -> Result<FontKey, Error> {
         let c = glyph_key.c;
 
         let use_initial_face = if self.faces.contains_key(&glyph_key.font_key) {
@@ -285,7 +285,7 @@ impl FreeTypeRasterizer {
         }
     }
 
-    fn get_rendered_glyph(&mut self, glyph_key: &GlyphKey)
+    fn get_rendered_glyph(&mut self, glyph_key: GlyphKey)
                           -> Result<RasterizedGlyph, Error> {
         // Render a custom symbol for the underline and beam cursor
         match glyph_key.c {

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -80,8 +80,8 @@ impl ::Rasterize for FreeTypeRasterizer {
         Ok(FreeTypeRasterizer {
             faces: HashMap::new(),
             keys: HashMap::new(),
-            library: library,
-            device_pixel_ratio: device_pixel_ratio,
+            library,
+            device_pixel_ratio,
         })
     }
 
@@ -94,7 +94,7 @@ impl ::Rasterize for FreeTypeRasterizer {
         Ok(Metrics {
             average_advance: full.cell_width,
             line_height: height,
-            descent: descent,
+            descent,
         })
     }
 
@@ -172,7 +172,7 @@ impl FreeTypeRasterizer {
         } as f64;
 
         Ok(FullMetrics {
-            size_metrics: size_metrics,
+            size_metrics,
             cell_width: width
         })
     }
@@ -188,7 +188,7 @@ impl FreeTypeRasterizer {
         pattern.add_family(&desc.name);
         pattern.set_weight(weight.into_fontconfig_type());
         pattern.set_slant(slant.into_fontconfig_type());
-        pattern.add_pixelsize(size.as_f32_pts() as _);
+        pattern.add_pixelsize(f64::from(size.as_f32_pts()));
 
         let font = fc::font_match(fc::Config::get_current(), &mut pattern)
             .ok_or_else(|| Error::MissingFont(desc.to_owned()))?;
@@ -210,7 +210,7 @@ impl FreeTypeRasterizer {
         let mut pattern = fc::Pattern::new();
         pattern.add_family(&desc.name);
         pattern.add_style(style);
-        pattern.add_pixelsize(size.as_f32_pts() as _);
+        pattern.add_pixelsize(f64::from(size.as_f32_pts()));
 
         let font = fc::font_match(fc::Config::get_current(), &mut pattern)
             .ok_or_else(|| Error::MissingFont(desc.to_owned()))?;
@@ -244,12 +244,12 @@ impl FreeTypeRasterizer {
             };
 
             let face = Face {
-                ft_face: ft_face,
+                ft_face,
                 key: FontKey::next(),
                 load_flags: Self::ft_load_flags(pattern),
                 render_mode: Self::ft_render_mode(pattern),
                 lcd_filter: Self::ft_lcd_filter(pattern),
-                non_scalable: non_scalable,
+                non_scalable,
             };
 
             debug!("Loaded Face {:?}", face);
@@ -269,14 +269,10 @@ impl FreeTypeRasterizer {
 
         let use_initial_face = if self.faces.contains_key(&glyph_key.font_key) {
             // Get face and unwrap since we just checked for presence.
-            let face = self.faces.get(&glyph_key.font_key).unwrap();
+            let face = &self.faces[&glyph_key.font_key];
             let index = face.ft_face.get_char_index(c as usize);
 
-            if index != 0 || have_recursed {
-                true
-            } else {
-                false
-            }
+            index != 0 || have_recursed
         } else {
             false
         };
@@ -334,7 +330,7 @@ impl FreeTypeRasterizer {
 
         // Render a normal character if it's not a cursor
         let font_key = self.face_for_glyph(glyph_key, false)?;
-        let face = self.faces.get(&font_key).unwrap();
+        let face = &self.faces[&font_key];
         let index = face.ft_face.get_char_index(glyph_key.c as usize);
 
         let size = face.non_scalable.as_ref()
@@ -360,7 +356,7 @@ impl FreeTypeRasterizer {
             left: glyph.bitmap_left(),
             width: pixel_width,
             height: glyph.bitmap().rows(),
-            buf: buf,
+            buf,
         })
     }
 
@@ -490,7 +486,7 @@ impl FreeTypeRasterizer {
                 }
                 Ok((bitmap.width(), packed))
             },
-            mode @ _ => panic!("unhandled pixel mode: {:?}", mode)
+            mode => panic!("unhandled pixel mode: {:?}", mode)
         }
     }
 

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -232,15 +232,15 @@ impl FreeTypeRasterizer {
             let ft_face = self.library.new_face(&path, index)?;
 
             // Get available pixel sizes if font isn't scalable.
-            let non_scalable = if !pattern.scalable().next().unwrap_or(true) {
+            let non_scalable = if pattern.scalable().next().unwrap_or(true) {
+                None
+            } else {
                 let mut pixelsize = pattern.pixelsize();
                 debug!("pixelsizes: {:?}", pixelsize);
 
                 Some(FixedSize {
                     pixelsize: pixelsize.next().expect("has 1+ pixelsize"),
                 })
-            } else {
-                None
             };
 
             let face = Face {

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -17,6 +17,9 @@
 //! CoreText is used on Mac OS.
 //! FreeType is used on everything that's not Mac OS.
 //! Eventually, ClearType support will be available for windows
+
+#![cfg_attr(feature = "cargo-clippy", deny(clippy, if_not_else, enum_glob_use, wrong_pub_self_convention))]
+
 #[cfg(not(target_os = "macos"))]
 extern crate fontconfig;
 #[cfg(not(target_os = "macos"))]

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -116,7 +116,7 @@ impl FontDesc {
     {
         FontDesc {
             name: name.into(),
-            style: style
+            style,
         }
     }
 }
@@ -146,7 +146,7 @@ impl FontKey {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Eq)]
 pub struct GlyphKey {
     pub c: char,
     pub font_key: FontKey,
@@ -162,6 +162,19 @@ impl Hash for GlyphKey {
             // - Result is being used for hashing and has no fields (it's a u64)
             ::std::mem::transmute::<GlyphKey, u64>(*self)
         }.hash(state);
+    }
+}
+
+impl PartialEq for GlyphKey {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe {
+            // This transmute is fine:
+            //
+            // - If GlyphKey ever becomes a different size, this will fail to compile
+            // - Result is being used for equality checking and has no fields (it's a u64)
+            let other = ::std::mem::transmute::<GlyphKey, u64>(*other);
+            ::std::mem::transmute::<GlyphKey, u64>(*self).eq(&other)
+        }
     }
 }
 
@@ -183,7 +196,7 @@ impl Size {
 
     /// Get the f32 size in points
     pub fn as_f32_pts(self) -> f32 {
-        self.0 as f32 / Size::factor()
+        f32::from(self.0) / Size::factor()
     }
 }
 
@@ -224,14 +237,14 @@ pub fn get_underline_cursor_glyph(descent: i32, width: i32) -> Result<Rasterized
     let buf = vec![255u8; (width * height * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
-    return Ok(RasterizedGlyph {
+    Ok(RasterizedGlyph {
         c: UNDERLINE_CURSOR_CHAR,
         top: descent + height,
         left: 0,
         height,
         width,
-        buf: buf,
-    });
+        buf,
+    })
 }
 
 // Returns a custom beam cursor character
@@ -245,14 +258,14 @@ pub fn get_beam_cursor_glyph(
     let buf = vec![255u8; (beam_width * height * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
-    return Ok(RasterizedGlyph {
+    Ok(RasterizedGlyph {
         c: BEAM_CURSOR_CHAR,
         top: ascent,
         left: 0,
         height,
         width: beam_width,
-        buf: buf,
-    });
+        buf,
+    })
 }
 
 // Returns a custom box cursor character
@@ -276,14 +289,14 @@ pub fn get_box_cursor_glyph(
     }
 
     // Create a custom glyph with the rectangle data attached to it
-    return Ok(RasterizedGlyph {
+    Ok(RasterizedGlyph {
         c: BOX_CURSOR_CHAR,
         top: ascent,
         left: 0,
         height,
         width,
-        buf: buf,
-    });
+        buf,
+    })
 }
 
 struct BufDebugger<'a>(&'a [u8]);

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -344,5 +344,5 @@ pub trait Rasterize {
     fn load_font(&mut self, &FontDesc, Size) -> Result<FontKey, Self::Err>;
 
     /// Rasterize the glyph described by `GlyphKey`.
-    fn get_glyph(&mut self, &GlyphKey) -> Result<RasterizedGlyph, Self::Err>;
+    fn get_glyph(&mut self, GlyphKey) -> Result<RasterizedGlyph, Self::Err>;
 }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -561,8 +561,8 @@ pub enum NamedColor {
 }
 
 impl NamedColor {
-    pub fn to_bright(&self) -> Self {
-        match *self {
+    pub fn to_bright(self) -> Self {
+        match self {
             NamedColor::Black => NamedColor::BrightBlack,
             NamedColor::Red => NamedColor::BrightRed,
             NamedColor::Green => NamedColor::BrightGreen,
@@ -583,8 +583,8 @@ impl NamedColor {
         }
     }
 
-    pub fn to_dim(&self) -> Self {
-        match *self {
+    pub fn to_dim(self) -> Self {
+        match self {
             NamedColor::Black => NamedColor::DimBlack,
             NamedColor::Red => NamedColor::DimRed,
             NamedColor::Green => NamedColor::DimGreen,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ extern crate log;
 use clap::{Arg, App};
 use index::{Line, Column};
 use config::{Dimensions, Shell};
+use window::{DEFAULT_TITLE, DEFAULT_CLASS};
 use std::path::{Path, PathBuf};
 use std::borrow::Cow;
 
@@ -80,11 +81,11 @@ impl Options {
                 .long("title")
                 .short("t")
                 .takes_value(true)
-                .help("Defines the window title"))
+                .help(&format!("Defines the window title [default: {}]", DEFAULT_TITLE)))
             .arg(Arg::with_name("class")
                  .long("class")
                  .takes_value(true)
-                 .help("Defines window class on X11"))
+                 .help(&format!("Defines window class on X11 [default: {}]", DEFAULT_CLASS)))
             .arg(Arg::with_name("q")
                 .short("q")
                 .multiple(true)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::borrow::Cow;
 
 const DEFAULT_TITLE: &str = "Alacritty";
+const DEFAULT_CLASS: &str = "Alacritty";
 
 /// Options specified on the command line
 pub struct Options {
@@ -27,6 +28,7 @@ pub struct Options {
     pub ref_test: bool,
     pub dimensions: Option<Dimensions>,
     pub title: String,
+    pub class: String,
     pub log_level: log::LevelFilter,
     pub command: Option<Shell<'static>>,
     pub working_dir: Option<PathBuf>,
@@ -41,6 +43,7 @@ impl Default for Options {
             ref_test: false,
             dimensions: None,
             title: DEFAULT_TITLE.to_owned(),
+            class: DEFAULT_CLASS.to_owned(),
             log_level: log::LevelFilter::Warn,
             command: None,
             working_dir: None,
@@ -81,6 +84,10 @@ impl Options {
                 .short("t")
                 .default_value(DEFAULT_TITLE)
                 .help("Defines the window title"))
+            .arg(Arg::with_name("class")
+                 .long("class")
+                 .default_value(DEFAULT_CLASS)
+                 .help("Defines window class on X11"))
             .arg(Arg::with_name("q")
                 .short("q")
                 .multiple(true)
@@ -134,6 +141,10 @@ impl Options {
 
         if let Some(title) = matches.value_of("title") {
             options.title = title.to_owned();
+        }
+
+        if let Some(class) = matches.value_of("class") {
+            options.class = class.to_owned();
         }
 
         match matches.occurrences_of("q") {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,17 +18,14 @@ use config::{Dimensions, Shell};
 use std::path::{Path, PathBuf};
 use std::borrow::Cow;
 
-const DEFAULT_TITLE: &str = "Alacritty";
-const DEFAULT_CLASS: &str = "Alacritty";
-
 /// Options specified on the command line
 pub struct Options {
     pub live_config_reload: Option<bool>,
     pub print_events: bool,
     pub ref_test: bool,
     pub dimensions: Option<Dimensions>,
-    pub title: String,
-    pub class: String,
+    pub title: Option<String>,
+    pub class: Option<String>,
     pub log_level: log::LevelFilter,
     pub command: Option<Shell<'static>>,
     pub working_dir: Option<PathBuf>,
@@ -42,8 +39,8 @@ impl Default for Options {
             print_events: false,
             ref_test: false,
             dimensions: None,
-            title: DEFAULT_TITLE.to_owned(),
-            class: DEFAULT_CLASS.to_owned(),
+            title: None,
+            class: None,
             log_level: log::LevelFilter::Warn,
             command: None,
             working_dir: None,
@@ -82,11 +79,11 @@ impl Options {
             .arg(Arg::with_name("title")
                 .long("title")
                 .short("t")
-                .default_value(DEFAULT_TITLE)
+                .takes_value(true)
                 .help("Defines the window title"))
             .arg(Arg::with_name("class")
                  .long("class")
-                 .default_value(DEFAULT_CLASS)
+                 .takes_value(true)
                  .help("Defines window class on X11"))
             .arg(Arg::with_name("q")
                 .short("q")
@@ -139,13 +136,8 @@ impl Options {
             }
         }
 
-        if let Some(title) = matches.value_of("title") {
-            options.title = title.to_owned();
-        }
-
-        if let Some(class) = matches.value_of("class") {
-            options.class = class.to_owned();
-        }
+        options.class = matches.value_of("class").map(|c| c.to_owned());
+        options.title = matches.value_of("title").map(|t| t.to_owned());
 
         match matches.occurrences_of("q") {
             0 => {},

--- a/src/config.rs
+++ b/src/config.rs
@@ -1609,7 +1609,10 @@ pub struct Font {
     glyph_offset: Delta<i8>,
 
     #[serde(default="true_bool", deserialize_with = "default_true_bool")]
-    use_thin_strokes: bool
+    use_thin_strokes: bool,
+
+    #[serde(default="true_bool", deserialize_with = "default_true_bool")]
+    scale_with_dpi: bool,
 }
 
 fn default_bold_desc() -> FontDescription {
@@ -1662,6 +1665,11 @@ impl Font {
             .. self
         }
     }
+
+    /// Check whether dpi should be applied
+    pub fn scale_with_dpi(&self) -> bool {
+        self.scale_with_dpi
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -1673,8 +1681,9 @@ impl Default for Font {
             italic: FontDescription::new_with_family("Menlo"),
             size: Size::new(11.0),
             use_thin_strokes: true,
+            scale_with_dpi: true,
+            glyph_offset: Default::default(),
             offset: Default::default(),
-            glyph_offset: Default::default()
         }
     }
 }
@@ -1688,8 +1697,9 @@ impl Default for Font {
             italic: FontDescription::new_with_family("monospace"),
             size: Size::new(11.0),
             use_thin_strokes: false,
+            scale_with_dpi: true,
+            glyph_offset: Default::default(),
             offset: Default::default(),
-            glyph_offset: Default::default()
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,7 +225,7 @@ impl Alpha {
     }
 
     #[inline]
-    pub fn get(&self) -> f32 {
+    pub fn get(self) -> f32 {
         self.0
     }
 
@@ -1993,10 +1993,10 @@ enum Key {
 }
 
 impl Key {
-    fn to_glutin_key(&self) -> ::glutin::VirtualKeyCode {
+    fn to_glutin_key(self) -> ::glutin::VirtualKeyCode {
         use ::glutin::VirtualKeyCode::*;
         // Thank you, vim macros!
-        match *self {
+        match self {
             Key::Key1 => Key1,
             Key::Key2 => Key2,
             Key::Key3 => Key3,

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ use notify::{Watcher, watcher, DebouncedEvent, RecursiveMode};
 
 use glutin::ModifiersState;
 
+use cli::Options;
 use input::{Action, Binding, MouseBinding, KeyBinding};
 use index::{Line, Column};
 use ansi::CursorStyle;
@@ -1446,6 +1447,14 @@ impl Config {
         Ok(config)
     }
 
+    /// Overrides the `dynamic_title` configuration based on `--title`.
+    pub fn update_dynamic_title(mut self, options: &Options) -> Self {
+        if options.title.is_some() {
+            self.dynamic_title = false;
+        }
+        self
+    }
+
     fn read_file<P: AsRef<Path>>(path: P) -> Result<String> {
         let mut f = fs::File::open(path)?;
         let mut contents = String::new();
@@ -1781,6 +1790,7 @@ impl Monitor {
 
 #[cfg(test)]
 mod tests {
+    use cli::Options;
     use super::Config;
 
     #[cfg(target_os="macos")]
@@ -1800,6 +1810,26 @@ mod tests {
 
         // Sanity check that key bindings are being parsed
         assert!(!config.key_bindings.is_empty());
+    }
+
+    #[test]
+    fn dynamic_title_ignoring_options_by_default() {
+        let config: Config = ::serde_yaml::from_str(ALACRITTY_YML)
+            .expect("deserialize config");
+        let old_dynamic_title = config.dynamic_title;
+        let options = Options::default();
+        let config = config.update_dynamic_title(&options);
+        assert_eq!(old_dynamic_title, config.dynamic_title);
+    }
+
+    #[test]
+    fn dynamic_title_overridden_by_options() {
+        let config: Config = ::serde_yaml::from_str(ALACRITTY_YML)
+            .expect("deserialize config");
+        let mut options = Options::default();
+        options.title = Some("foo".to_owned());
+        let config = config.update_dynamic_title(&options);
+        assert!(!config.dynamic_title);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1803,7 +1803,7 @@ mod tests {
     }
 }
 
-#[cfg_attr(feature = "clippy", allow(enum_variant_names))]
+#[cfg_attr(feature = "cargo-clippy", allow(enum_variant_names))]
 #[derive(Deserialize, Copy, Clone)]
 enum Key {
     Key1,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1957,6 +1957,9 @@ enum Key {
     WebStop,
     Yen,
     Caret,
+    Copy,
+    Paste,
+    Cut,
 }
 
 impl Key {
@@ -2115,6 +2118,9 @@ impl Key {
             Key::WebStop => WebStop,
             Key::Yen => Yen,
             Key::Caret => Caret,
+            Key::Copy => Copy,
+            Key::Paste => Paste,
+            Key::Cut => Cut,
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -141,7 +141,11 @@ impl Display {
         // get window properties for initializing the other subsystems
         let mut viewport_size = window.inner_size_pixels()
             .expect("glutin returns window size");
-        let dpr = window.hidpi_factor();
+        let dpr = if config.font().scale_with_dpi() {
+            window.hidpi_factor()
+        } else {
+            1.0
+        };
 
         info!("device_pixel_ratio: {}", dpr);
 
@@ -149,7 +153,7 @@ impl Display {
         let mut renderer = QuadRenderer::new(config, viewport_size)?;
 
         let (glyph_cache, cell_width, cell_height) =
-            Self::new_glyph_cache(&window, &mut renderer, config)?;
+            Self::new_glyph_cache(dpr, &mut renderer, config)?;
 
 
         let dimensions = options.dimensions()
@@ -210,11 +214,10 @@ impl Display {
         })
     }
 
-    fn new_glyph_cache(window : &Window, renderer : &mut QuadRenderer, config: &Config)
+    fn new_glyph_cache(dpr: f32, renderer: &mut QuadRenderer, config: &Config)
         -> Result<(GlyphCache, f32, f32), Error>
     {
         let font = config.font().clone();
-        let dpr = window.hidpi_factor();
         let rasterizer = font::Rasterizer::new(dpr, config.use_thin_strokes())?;
 
         // Initialize glyph cache

--- a/src/display.rs
+++ b/src/display.rs
@@ -136,7 +136,7 @@ impl Display {
         let render_timer = config.render_timer();
 
         // Create the window where Alacritty will be displayed
-        let mut window = Window::new(&options.title, config.window())?;
+        let mut window = Window::new(&options, config.window())?;
 
         // get window properties for initializing the other subsystems
         let mut viewport_size = window.inner_size_pixels()

--- a/src/event.rs
+++ b/src/event.rs
@@ -59,17 +59,15 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     }
 
     fn copy_selection(&self, buffer: ::copypasta::Buffer) {
-        self.terminal
-            .selection_to_string()
-            .map(|selected| {
-                if !selected.is_empty() {
-                    Clipboard::new()
-                        .and_then(|mut clipboard| clipboard.store(selected, buffer))
-                        .unwrap_or_else(|err| {
-                            warn!("Error storing selection to clipboard. {}", Red(err));
-                        });
-                }
-            });
+        if let Some(selected) = self.terminal.selection_to_string() {
+            if !selected.is_empty() {
+                Clipboard::new()
+                    .and_then(|mut clipboard| clipboard.store(selected, buffer))
+                    .unwrap_or_else(|err| {
+                        warn!("Error storing selection to clipboard. {}", Red(err));
+                    });
+            }
+        }
     }
 
     fn clear_selection(&mut self) {
@@ -241,7 +239,7 @@ impl<N: Notify> Processor<N> {
             resize_tx,
             ref_test,
             mouse: Default::default(),
-            size_info: size_info,
+            size_info,
             hide_cursor_when_typing: config.hide_cursor_when_typing(),
             hide_cursor: false,
             received_count: 0,

--- a/src/event.rs
+++ b/src/event.rs
@@ -308,9 +308,11 @@ impl<N: Notify> Processor<N> {
                         processor.received_char(c);
                     },
                     MouseInput { state, button, modifiers, .. } => {
-                        *hide_cursor = false;
-                        processor.mouse_input(state, button, modifiers);
-                        processor.ctx.terminal.dirty = true;
+                        if *window_is_focused {
+                            *hide_cursor = false;
+                            processor.mouse_input(state, button, modifiers);
+                            processor.ctx.terminal.dirty = true;
+                        }
                     },
                     CursorMoved { position: (x, y), modifiers, .. } => {
                         let x = limit(x as i32, 0, processor.ctx.size_info.width as i32);

--- a/src/event.rs
+++ b/src/event.rs
@@ -298,7 +298,7 @@ impl<N: Notify> Processor<N> {
                     },
                     KeyboardInput { input, .. } => {
                         let glutin::KeyboardInput { state, virtual_keycode, modifiers, .. } = input;
-                        processor.process_key(state, virtual_keycode, &modifiers);
+                        processor.process_key(state, virtual_keycode, modifiers);
                         if state == ElementState::Pressed {
                             // Hide cursor while typing
                             *hide_cursor = true;

--- a/src/event.rs
+++ b/src/event.rs
@@ -113,7 +113,7 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         self.terminal.pixels_to_coords(self.mouse.x as usize, self.mouse.y as usize)
     }
 
-    fn change_font_size(&mut self, delta: i8) {
+    fn change_font_size(&mut self, delta: f32) {
         self.terminal.change_font_size(delta);
     }
 

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -437,15 +437,6 @@ impl<T> Grid<T> {
     pub fn contains(&self, point: &Point) -> bool {
         self.lines > point.line && self.cols > point.col
     }
-
-    // /// Swap two lines in the grid
-    // ///
-    // /// This could have used slice::swap internally, but we are able to have
-    // /// better error messages by doing the bounds checking ourselves.
-    // #[inline]
-    // pub fn swap_lines(&mut self, src: index::Line, dst: index::Line) {
-    //     self.raw.swap(*src, *dst);
-    // }
 }
 
 impl<'a, T> Iterator for GridIterator<'a, T> {

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -102,6 +102,7 @@ pub struct GridIterator<'a, T: 'a> {
     pub cur: Point<usize>,
 }
 
+#[derive(Copy, Clone)]
 pub enum Scroll {
     Lines(isize),
     PageUp,
@@ -396,6 +397,7 @@ impl<T: Copy + Clone> Grid<T> {
     }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]
 impl<T> Grid<T> {
     #[inline]
     pub fn num_lines(&self) -> index::Line {
@@ -557,10 +559,10 @@ impl<'a, T> RegionMut<'a, T> {
 
 pub trait IndexRegion<I, T> {
     /// Get an immutable region of Self
-    fn region<'a>(&'a self, _: I) -> Region<'a, T>;
+    fn region(&self, _: I) -> Region<T>;
 
     /// Get a mutable region of Self
-    fn region_mut<'a>(&'a mut self, _: I) -> RegionMut<'a, T>;
+    fn region_mut(&mut self, _: I) -> RegionMut<T>;
 }
 
 impl<T> IndexRegion<Range<Line>, T> for Grid<T> {
@@ -763,13 +765,11 @@ impl<'a, T: Copy + 'a> Iterator for DisplayIter<'a, T> {
 
         // Update line/col to point to next item
         self.col += 1;
-        if self.col == self.grid.num_cols() {
-            if self.offset != self.limit {
-                self.offset -= 1;
+        if self.col == self.grid.num_cols() && self.offset != self.limit {
+            self.offset -= 1;
 
-                self.col = Column(0);
-                self.line = Line(*self.grid.lines - 1 - (self.offset - self.limit));
-            }
+            self.col = Column(0);
+            self.line = Line(*self.grid.lines - 1 - (self.offset - self.limit));
         }
 
         item

--- a/src/grid/row.rs
+++ b/src/grid/row.rs
@@ -71,6 +71,7 @@ impl<T: Copy + Clone> Row<T> {
     }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]
 impl<T> Row<T> {
     pub fn shrink(&mut self, cols: Column) {
         while self.len() != *cols {
@@ -84,7 +85,7 @@ impl<T> Row<T> {
         self.inner.len()
     }
 
-    pub fn iter<'a>(&'a self) -> slice::Iter<'a, T> {
+    pub fn iter(&self) -> slice::Iter<T> {
         self.inner.iter()
     }
 }

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -84,11 +84,8 @@ impl<T> Storage<T> {
         T: Clone,
     {
         // Allocate all lines in the buffer, including scrollback history
-        //
-        // TODO (jwilm) Allocating each line at this point is expensive and
-        // delays startup. A nice solution might be having `Row` delay
-        // allocation until it's actually used.
         let inner = vec![template; cap];
+
         Storage {
             inner,
             zero: 0,
@@ -124,7 +121,7 @@ impl<T> Storage<T> {
     }
 
     /// Grow the number of lines in the buffer, filling new lines with the template
-    pub fn grow_lines(&mut self, growage: usize, template_row: Row<T>)
+    fn grow_lines(&mut self, growage: usize, template_row: Row<T>)
     where
         T: Clone,
     {
@@ -225,9 +222,6 @@ impl<T> Storage<T> {
     /// The default implementation from swap generates 8 movups and 4 movaps
     /// instructions. This implementation achieves the swap in only 8 movups
     /// instructions.
-    ///
-    // TODO Once specialization is available, Storage<T> can be fully generic
-    //      again instead of enforcing inner: Vec<Row<T>>.
     pub fn swap(&mut self, a: usize, b: usize) {
         debug_assert!(::std::mem::size_of::<Row<T>>() == 32);
 

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -68,12 +68,12 @@ impl<T: PartialEq> ::std::cmp::PartialEq for Storage<T> {
         //   Smaller Zero (3):
         //     7  8  9  | 0  1  2  3  | 4  5  6
         //     C3 C3 C3 | C1 C1 C1 C1 | C2 C2 C2
-        &bigger.inner[bigger_zero..]
-            == &smaller.inner[smaller_zero..smaller_zero + (len - bigger_zero)]
-            && &bigger.inner[..bigger_zero - smaller_zero]
-                == &smaller.inner[smaller_zero + (len - bigger_zero)..]
-            && &bigger.inner[bigger_zero - smaller_zero..bigger_zero]
-                == &smaller.inner[..smaller_zero]
+        bigger.inner[bigger_zero..]
+            == smaller.inner[smaller_zero..smaller_zero + (len - bigger_zero)]
+            && bigger.inner[..bigger_zero - smaller_zero]
+                == smaller.inner[smaller_zero + (len - bigger_zero)..]
+            && bigger.inner[bigger_zero - smaller_zero..bigger_zero]
+                == smaller.inner[..smaller_zero]
     }
 }
 

--- a/src/grid/tests.rs
+++ b/src/grid/tests.rs
@@ -20,7 +20,7 @@ use index::{Point, Line, Column};
 // Scroll up moves lines upwards
 #[test]
 fn scroll_up() {
-    println!("");
+    println!();
 
     let mut grid = Grid::new(Line(10), Column(1), 0, 0);
     for i in 0..10 {
@@ -58,7 +58,7 @@ fn scroll_up() {
 // Scroll down moves lines downwards
 #[test]
 fn scroll_down() {
-    println!("");
+    println!();
 
     let mut grid = Grid::new(Line(10), Column(1), 0, 0);
     for i in 0..10 {

--- a/src/index.rs
+++ b/src/index.rs
@@ -270,7 +270,7 @@ macro_rules! inclusive {
                 match *self {
                     Empty { .. } => (0, Some(0)),
 
-                    NonEmpty { ref start, ref end } => {
+                    NonEmpty { start, end } => {
                         let added = $steps_add_one(start, end);
                         match added {
                             Some(hint) => (hint.saturating_add(1), hint.checked_add(1)),
@@ -283,9 +283,9 @@ macro_rules! inclusive {
     }
 }
 
-fn steps_add_one_u8(start: &u8, end: &u8) -> Option<usize> {
-    if *start < *end {
-        Some((*end - *start) as usize)
+fn steps_add_one_u8(start: u8, end: u8) -> Option<usize> {
+    if start < end {
+        Some((end - start) as usize)
     } else {
         None
     }
@@ -330,11 +330,11 @@ macro_rules! ops {
         impl $ty {
             #[inline]
             #[allow(trivial_numeric_casts)]
-            fn steps_between(start: &$ty, end: &$ty, by: &$ty) -> Option<usize> {
-                if *by == $construct(0) { return None; }
-                if *start < *end {
+            fn steps_between(start: $ty, end: $ty, by: $ty) -> Option<usize> {
+                if by == $construct(0) { return None; }
+                if start < end {
                     // Note: We assume $t <= usize here
-                    let diff = (*end - *start).0;
+                    let diff = (end - start).0;
                     let by = by.0;
                     if diff % by > 0 {
                         Some(diff / by + 1)
@@ -347,8 +347,8 @@ macro_rules! ops {
             }
 
             #[inline]
-            fn steps_between_by_one(start: &$ty, end: &$ty) -> Option<usize> {
-                Self::steps_between(start, end, &$construct(1))
+            fn steps_between_by_one(start: $ty, end: $ty) -> Option<usize> {
+                Self::steps_between(start, end, $construct(1))
             }
         }
 
@@ -366,7 +366,7 @@ macro_rules! ops {
             }
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                match Self::Item::steps_between_by_one(&self.0.start, &self.0.end) {
+                match Self::Item::steps_between_by_one(self.0.start, self.0.end) {
                     Some(hint) => (hint, Some(hint)),
                     None => (0, None)
                 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -35,6 +35,8 @@ use term::SizeInfo;
 use term::mode::TermMode;
 use util::fmt::Red;
 
+pub const FONT_SIZE_STEP: f32 = 0.5;
+
 /// Processes input from glutin.
 ///
 /// An escape sequence may be emitted in case specific keys or key combinations
@@ -64,7 +66,7 @@ pub trait ActionContext {
     fn received_count(&mut self) -> &mut usize;
     fn suppress_chars(&mut self) -> &mut bool;
     fn last_modifiers(&mut self) -> &mut ModifiersState;
-    fn change_font_size(&mut self, delta: i8);
+    fn change_font_size(&mut self, delta: f32);
     fn reset_font_size(&mut self);
     fn scroll(&mut self, scroll: Scroll);
 }
@@ -243,10 +245,10 @@ impl Action {
                 ::std::process::exit(0);
             },
             Action::IncreaseFontSize => {
-               ctx.change_font_size(1);
+               ctx.change_font_size(FONT_SIZE_STEP);
             },
             Action::DecreaseFontSize => {
-               ctx.change_font_size(-1);
+               ctx.change_font_size(-FONT_SIZE_STEP);
             }
             Action::ResetFontSize => {
                ctx.reset_font_size();
@@ -741,7 +743,7 @@ mod tests {
         fn last_modifiers(&mut self) -> &mut ModifiersState {
             &mut self.last_modifiers
         }
-        fn change_font_size(&mut self, _delta: i8) {
+        fn change_font_size(&mut self, _delta: f32) {
         }
         fn reset_font_size(&mut self) {
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -105,15 +105,15 @@ impl<T: Eq> Binding<T> {
     fn is_triggered_by(
         &self,
         mode: TermMode,
-        mods: &ModifiersState,
+        mods: ModifiersState,
         input: &T
     ) -> bool {
         // Check input first since bindings are stored in one big list. This is
         // the most likely item to fail so prioritizing it here allows more
         // checks to be short circuited.
         self.trigger == *input &&
-            self.mode_matches(&mode) &&
-            self.not_mode_matches(&mode) &&
+            self.mode_matches(mode) &&
+            self.not_mode_matches(mode) &&
             self.mods_match(mods)
     }
 }
@@ -126,12 +126,12 @@ impl<T> Binding<T> {
     }
 
     #[inline]
-    fn mode_matches(&self, mode: &TermMode) -> bool {
+    fn mode_matches(&self, mode: TermMode) -> bool {
         self.mode.is_empty() || mode.intersects(self.mode)
     }
 
     #[inline]
-    fn not_mode_matches(&self, mode: &TermMode) -> bool {
+    fn not_mode_matches(&self, mode: TermMode) -> bool {
         self.notmode.is_empty() || !mode.intersects(self.notmode)
     }
 
@@ -139,10 +139,10 @@ impl<T> Binding<T> {
     ///
     /// Optimized to use single check instead of four (one per modifier)
     #[inline]
-    fn mods_match(&self, mods: &ModifiersState) -> bool {
+    fn mods_match(&self, mods: ModifiersState) -> bool {
         debug_assert!(4 == mem::size_of::<ModifiersState>());
         unsafe {
-            mem::transmute_copy::<_, u32>(&self.mods) == mem::transmute_copy::<_, u32>(mods)
+            mem::transmute_copy::<_, u32>(&self.mods) == mem::transmute_copy::<_, u32>(&mods)
         }
     }
 }
@@ -569,7 +569,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             return;
         }
 
-        self.process_mouse_bindings(&ModifiersState::default(), button);
+        self.process_mouse_bindings(ModifiersState::default(), button);
     }
 
     /// Process key input
@@ -579,11 +579,11 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         &mut self,
         state: ElementState,
         key: Option<VirtualKeyCode>,
-        mods: &ModifiersState,
+        mods: ModifiersState,
     ) {
         match (key, state) {
             (Some(key), ElementState::Pressed) => {
-                *self.ctx.last_modifiers() = *mods;
+                *self.ctx.last_modifiers() = mods;
                 *self.ctx.received_count() = 0;
                 *self.ctx.suppress_chars() = false;
 
@@ -625,7 +625,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     /// for its action to be executed.
     ///
     /// Returns true if an action is executed.
-    fn process_key_bindings(&mut self, mods: &ModifiersState, key: VirtualKeyCode) -> bool {
+    fn process_key_bindings(&mut self, mods: ModifiersState, key: VirtualKeyCode) -> bool {
         for binding in self.key_bindings {
             if binding.is_triggered_by(self.ctx.terminal_mode(), mods, &key) {
                 // binding was triggered; run the action
@@ -643,7 +643,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     /// for its action to be executed.
     ///
     /// Returns true if an action is executed.
-    fn process_mouse_bindings(&mut self, mods: &ModifiersState, button: MouseButton) -> bool {
+    fn process_mouse_bindings(&mut self, mods: ModifiersState, button: MouseButton) -> bool {
         for binding in self.mouse_bindings {
             if binding.is_triggered_by(self.ctx.terminal_mode(), mods, &button) {
                 // binding was triggered; run the action
@@ -826,9 +826,9 @@ mod tests {
             #[test]
             fn $name() {
                 if $triggers {
-                    assert!($binding.is_triggered_by($mode, &$mods, &KEY));
+                    assert!($binding.is_triggered_by($mode, $mods, &KEY));
                 } else {
-                    assert!(!$binding.is_triggered_by($mode, &$mods, &KEY));
+                    assert!(!$binding.is_triggered_by($mode, $mods, &KEY));
                 }
             }
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -140,7 +140,7 @@ impl<T> Binding<T> {
     /// Optimized to use single check instead of four (one per modifier)
     #[inline]
     fn mods_match(&self, mods: ModifiersState) -> bool {
-        debug_assert!(4 == mem::size_of::<ModifiersState>());
+        assert_eq_size!(ModifiersState, u32);
         unsafe {
             mem::transmute_copy::<_, u32>(&self.mods) == mem::transmute_copy::<_, u32>(&mods)
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -510,7 +510,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
         // Make sure the new and deprecated setting are both allowed
         let faux_scrolling_lines = self.mouse_config
-            .faux_scrolling_lines
+            .faux_scrollback_lines
             .unwrap_or(self.scrolling_config.faux_multiplier as usize);
 
         if self.ctx.terminal_mode().intersects(mouse_modes) {
@@ -797,7 +797,7 @@ mod tests {
                         triple_click: ClickHandler {
                             threshold: Duration::from_millis(1000),
                         },
-                        faux_scrolling_lines: None,
+                        faux_scrollback_lines: None,
                     },
                     scrolling_config: &config::Scrolling::default(),
                     key_bindings: &config.key_bindings()[..],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,9 +110,6 @@ impl Mul<f32> for Rgb {
 }
 
 
-#[cfg_attr(feature = "clippy", allow(too_many_arguments))]
-#[cfg_attr(feature = "clippy", allow(doc_markdown))]
-#[cfg_attr(feature = "clippy", allow(unreadable_literal))]
 #[allow(unused_mut)]
 pub mod gl {
     #![allow(non_upper_case_globals)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 #[macro_use] extern crate clap;
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
+#[macro_use] extern crate static_assertions;
 
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))]
 extern crate x11_dl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,7 @@
 // limitations under the License.
 //
 //! Alacritty - The GPU Enhanced Terminal
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(feature = "clippy", deny(clippy))]
-#![cfg_attr(feature = "clippy", deny(enum_glob_use))]
-#![cfg_attr(feature = "clippy", deny(if_not_else))]
-#![cfg_attr(feature = "clippy", deny(wrong_pub_self_convention))]
+#![cfg_attr(feature = "cargo-clippy", deny(clippy, if_not_else, enum_glob_use, wrong_pub_self_convention))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 
@@ -121,5 +116,6 @@ impl Mul<f32> for Rgb {
 #[allow(unused_mut)]
 pub mod gl {
     #![allow(non_upper_case_globals)]
+    #![cfg_attr(feature = "cargo-clippy", allow(clippy))]
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 }

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(feature = "cargo-clippy", allow(let_unit_value))]
 #![cfg(target_os = "macos")]
 use libc::{LC_CTYPE, setlocale};
 use std::ffi::{CString, CStr};

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -29,7 +29,7 @@ pub struct Logger<T> {
 
 impl<T: Send + io::Write> Logger<T> {
     // False positive, see: https://github.com/rust-lang-nursery/rust-clippy/issues/734
-    #[cfg_attr(feature = "clippy", allow(new_ret_no_self))]
+    #[cfg_attr(feature = "cargo-clippy", allow(new_ret_no_self))]
     pub fn new(output: T, level: log::LevelFilter) -> Logger<io::LineWriter<T>> {
         log::set_max_level(level);
         Logger {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use alacritty::util::fmt::Red;
 fn main() {
     // Load command line options and config
     let options = cli::Options::load();
-    let config = load_config(&options);
+    let config = load_config(&options).update_dynamic_title(&options);
 
     // Switch to home directory
     #[cfg(target_os = "macos")]
@@ -178,7 +178,7 @@ fn run(mut config: Config, options: &cli::Options) -> Result<(), Box<Error>> {
             .as_ref()
             .and_then(|monitor| monitor.pending_config())
         {
-            config = new_config;
+            config = new_config.update_dynamic_title(&options);
             display.update_config(&config);
             processor.update_config(&config);
             terminal.update_config(&config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,12 +13,7 @@
 // limitations under the License.
 //
 //! Alacritty - The GPU Enhanced Terminal
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(feature = "clippy", deny(clippy))]
-#![cfg_attr(feature = "clippy", deny(enum_glob_use))]
-#![cfg_attr(feature = "clippy", deny(if_not_else))]
-#![cfg_attr(feature = "clippy", deny(wrong_pub_self_convention))]
+#![cfg_attr(feature = "cargo-clippy", deny(clippy, if_not_else, enum_glob_use, wrong_pub_self_convention))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -183,7 +183,7 @@ impl GlyphCache {
         // Need to load at least one glyph for the face before calling metrics.
         // The glyph requested here ('m' at the time of writing) has no special
         // meaning.
-        rasterizer.get_glyph(&GlyphKey { font_key: regular, c: 'm', size: font.size() })?;
+        rasterizer.get_glyph(GlyphKey { font_key: regular, c: 'm', size: font.size() })?;
         let metrics = rasterizer.metrics(regular)?;
 
         let mut cache = GlyphCache {
@@ -211,7 +211,7 @@ impl GlyphCache {
     ) {
         let size = self.font_size;
         for i in RangeInclusive::new(32u8, 128u8) {
-            self.get(&GlyphKey {
+            self.get(GlyphKey {
                 font_key: font,
                 c: i as char,
                 size,
@@ -273,14 +273,14 @@ impl GlyphCache {
             .expect("metrics load since font is loaded at glyph cache creation")
     }
 
-    pub fn get<'a, L>(&'a mut self, glyph_key: &GlyphKey, loader: &mut L) -> &'a Glyph
+    pub fn get<'a, L>(&'a mut self, glyph_key: GlyphKey, loader: &mut L) -> &'a Glyph
         where L: LoadGlyph
     {
         let glyph_offset = self.glyph_offset;
         let rasterizer = &mut self.rasterizer;
         let metrics = &self.metrics;
         self.cache
-            .entry(*glyph_key)
+            .entry(glyph_key)
             .or_insert_with(|| {
                 let mut rasterized = rasterizer.get_glyph(glyph_key)
                     .unwrap_or_else(|_| Default::default());
@@ -306,7 +306,7 @@ impl GlyphCache {
         let font = font.to_owned().with_size(size);
         info!("Font size changed: {:?}", font.size);
         let (regular, bold, italic) = Self::compute_font_keys(&font, &mut self.rasterizer)?;
-        self.rasterizer.get_glyph(&GlyphKey { font_key: regular, c: 'm', size: font.size() })?;
+        self.rasterizer.get_glyph(GlyphKey { font_key: regular, c: 'm', size: font.size() })?;
         let metrics = self.rasterizer.metrics(regular)?;
 
         self.font_size = font.size;
@@ -842,7 +842,7 @@ impl<'a> RenderApi<'a> {
 
             // Add cell to batch
             {
-                let glyph = glyph_cache.get(&glyph_key, self);
+                let glyph = glyph_cache.get(glyph_key, self);
                 self.add_render_item(&cell, glyph);
             }
 
@@ -856,7 +856,7 @@ impl<'a> RenderApi<'a> {
                     c: '_'
                 };
 
-                let underscore = glyph_cache.get(&glyph_key, self);
+                let underscore = glyph_cache.get(glyph_key, self);
                 self.add_render_item(&cell, underscore);
             }
         }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -253,13 +253,12 @@ impl Selection {
 
         // Remove last cell if selection ends to the left of a cell
         if front_side == Side::Left && start != end {
-            if front.col != Column(0) {
-                front.col -= 1;
-            }
             // Special case when selection starts to left of first cell
-            else {
+            if front.col == Column(0) {
                 front.col = cols - 1;
                 front.line += 1;
+            } else {
+                front.col -= 1;
             }
         }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -157,8 +157,8 @@ impl Selection {
             Selection::Semantic { ref region } => {
                 Selection::span_semantic(grid, region)
             },
-            Selection::Lines { ref region, ref initial_line } => {
-                Selection::span_lines(grid, region, *initial_line)
+            Selection::Lines { ref region, initial_line } => {
+                Selection::span_lines(grid, region, initial_line)
             }
         }
     }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -130,7 +130,7 @@ impl<'a> RenderableCellsIter<'a> {
         let inner = grid.display_iter();
 
         let mut selection_range = None;
-        selection.map(|loc| {
+        if let Some(loc) = selection {
             // Get on-screen lines of the selection's locations
             let start_line = grid.buffer_line_to_visible(loc.start.line);
             let end_line = grid.buffer_line_to_visible(loc.end.line);
@@ -172,17 +172,17 @@ impl<'a> RenderableCellsIter<'a> {
                 // Update the selection
                 selection_range = Some(RangeInclusive::new(start, end));
             }
-        });
+        }
 
         RenderableCellsIter {
-            cursor: cursor,
-            cursor_offset: cursor_offset,
-            grid: grid,
-            inner: inner,
-            mode: mode,
+            cursor,
+            cursor_offset,
+            grid,
+            inner,
+            mode,
             selection: selection_range,
-            config: config,
-            colors: colors,
+            config,
+            colors,
             cursor_cells: ArrayDeque::new(),
         }.initialize(cursor_style)
     }
@@ -428,13 +428,13 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                     fg_rgb = self.colors[NamedColor::Background];
                     bg_alpha = 1.0
                 } else {
-                    bg_rgb = self.compute_fg_rgb(&cell.fg, &cell);
-                    fg_rgb = self.compute_bg_rgb(&cell.bg);
+                    bg_rgb = self.compute_fg_rgb(cell.fg, &cell);
+                    fg_rgb = self.compute_bg_rgb(cell.bg);
                 }
             } else {
-                fg_rgb = self.compute_fg_rgb(&cell.fg, &cell);
-                bg_rgb = self.compute_bg_rgb(&cell.bg);
-                bg_alpha = self.compute_bg_alpha(&cell.bg);
+                fg_rgb = self.compute_fg_rgb(cell.fg, &cell);
+                bg_rgb = self.compute_bg_rgb(cell.bg);
+                bg_alpha = self.compute_bg_alpha(cell.bg);
             }
 
             return Some(RenderableCell {
@@ -444,7 +444,7 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                 c: cell.c,
                 fg: fg_rgb,
                 bg: bg_rgb,
-                bg_alpha: bg_alpha,
+                bg_alpha,
             })
         }
     }
@@ -2217,7 +2217,7 @@ mod benches {
         mem::swap(&mut terminal.grid, &mut grid);
 
         b.iter(|| {
-            let iter = terminal.renderable_cells(&config, None, false);
+            let iter = terminal.renderable_cells(&config, false);
             for cell in iter {
                 test::black_box(cell);
             }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -404,8 +404,6 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
 
                 let index = Linear(cell.line.0 * self.grid.num_cols().0 + cell.column.0);
 
-                // XXX (jwilm) selection temp disabled
-                //
                 let selected = self.selection.as_ref()
                     .map(|range| range.contains_(index))
                     .unwrap_or(false);
@@ -1158,18 +1156,6 @@ impl Term {
         self.tabs = IndexRange::from(Column(0)..self.grid.num_cols())
             .map(|i| (*i as usize) % self.tabspaces == 0)
             .collect::<Vec<bool>>();
-
-        // if num_lines > old_lines {
-        //     // Make sure bottom of terminal is clear
-        //     let template = self.cursor.template;
-        //     self.grid
-        //         .region_mut((self.cursor.point.line + 1)..)
-        //         .each(|c| c.reset(&template));
-        //     self.alt_grid
-        //         .region_mut((self.cursor_save_alt.point.line + 1)..)
-        //         .each(|c| c.reset(&template));
-        // }
-
     }
 
     #[inline]

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -314,9 +314,9 @@ impl<'a> RenderableCellsIter<'a> {
         self.mode.contains(mode::TermMode::SHOW_CURSOR) && self.grid.contains(self.cursor)
     }
 
-    fn compute_fg_rgb(&self, fg: &Color, cell: &Cell) -> Rgb {
+    fn compute_fg_rgb(&self, fg: Color, cell: &Cell) -> Rgb {
         use self::cell::Flags;
-        match *fg {
+        match fg {
             Color::Spec(rgb) => rgb,
             Color::Named(ansi) => {
                 match (self.config.draw_bold_text_with_bright_colors(), cell.flags & Flags::DIM_BOLD) {
@@ -347,15 +347,15 @@ impl<'a> RenderableCellsIter<'a> {
     }
 
     #[inline]
-    fn compute_bg_alpha(&self, bg: &Color) -> f32 {
-        match *bg {
+    fn compute_bg_alpha(&self, bg: Color) -> f32 {
+        match bg {
             Color::Named(NamedColor::Background) => 0.0,
             _ => 1.0
         }
     }
 
-    fn compute_bg_rgb(&self, bg: &Color) -> Rgb {
-        match *bg {
+    fn compute_bg_rgb(&self, bg: Color) -> Rgb {
+        match bg {
             Color::Spec(rgb) => rgb,
             Color::Named(ansi) => self.colors[ansi],
             Color::Indexed(idx) => self.colors[idx],

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -117,7 +117,7 @@ fn set_controlling_terminal(fd: c_int) {
         // based on architecture (32/64). So a generic cast is used to make sure
         // there are no issues. To allow such a generic cast the clippy warning
         // is disabled.
-        #[cfg_attr(feature = "clippy", allow(cast_lossless))]
+        #[cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
         libc::ioctl(fd, TIOCSCTTY as _, 0)
     };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,7 +15,6 @@ use std::cmp;
 
 #[cfg(not(feature = "nightly"))]
 #[inline(always)]
-#[cfg_attr(feature = "clippy", allow(inline_always))]
 pub unsafe fn unlikely(x: bool) -> bool {
     x
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -74,23 +74,11 @@ pub mod fmt {
         /// Write a `Display` or `Debug` escaped with Red
         pub struct Red => "31";
 
+        /// Write a `Display` or `Debug` escaped with Green
+        pub struct Green => "32";
+
         /// Write a `Display` or `Debug` escaped with Yellow
         pub struct Yellow => "33";
-    }
-
-    /// Write a `Display` or `Debug` escaped with Red
-    pub struct Green<T>(pub T);
-
-    impl<T: fmt::Display> fmt::Display for Green<T> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "\x1b[32m{}\x1b[0m", self.0)
-        }
-    }
-
-    impl<T: fmt::Debug> fmt::Debug for Green<T> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "\x1b[32m{:?}\x1b[0m", self.0)
-        }
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -22,6 +22,7 @@ use glutin::GlContext;
 
 use MouseCursor;
 
+use cli::Options;
 use config::WindowConfig;
 
 /// Window errors
@@ -199,17 +200,17 @@ impl Window {
     ///
     /// This creates a window and fully initializes a window.
     pub fn new(
-        title: &str,
+        options: &Options,
         window_config: &WindowConfig,
     ) -> Result<Window> {
         let event_loop = EventsLoop::new();
 
         let window_builder = WindowBuilder::new()
-            .with_title(title)
+            .with_title(&*options.title)
             .with_visibility(false)
             .with_transparency(true)
             .with_decorations(window_config.decorations());
-        let window_builder = Window::platform_builder_ext(window_builder);
+        let window_builder = Window::platform_builder_ext(window_builder, &options.class);
         let window = create_gl_window(window_builder.clone(), &event_loop, false)
             .or_else(|_| create_gl_window(window_builder, &event_loop, true))?;
         window.show();
@@ -322,13 +323,13 @@ impl Window {
     }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
-    fn platform_builder_ext(window_builder: WindowBuilder) -> WindowBuilder {
+    fn platform_builder_ext(window_builder: WindowBuilder, wm_class: &str) -> WindowBuilder {
         use glutin::os::unix::WindowBuilderExt;
-        window_builder.with_class("alacritty".to_owned(), "Alacritty".to_owned())
+        window_builder.with_class(wm_class.to_owned(), "Alacritty".to_owned())
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd")))]
-    fn platform_builder_ext(window_builder: WindowBuilder) -> WindowBuilder {
+    fn platform_builder_ext(window_builder: WindowBuilder, _: &str) -> WindowBuilder {
         window_builder
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -25,6 +25,23 @@ use MouseCursor;
 use cli::Options;
 use config::WindowConfig;
 
+/// Default text for the window's title bar, if not overriden.
+///
+/// In X11, this the default value for the `WM_NAME` property.
+pub const DEFAULT_TITLE: &str = "Alacritty";
+
+/// Default text for general window class, X11 specific.
+///
+/// In X11, this is the default value for the `WM_CLASS` property. The
+/// second value of `WM_CLASS` is **never** changed to anything but
+/// the default value.
+///
+/// ```ignore
+/// $ xprop | grep WM_CLASS
+/// WM_CLASS(STRING) = "Alacritty", "Alacritty"
+/// ```
+pub const DEFAULT_CLASS: &str = "Alacritty";
+
 /// Window errors
 #[derive(Debug)]
 pub enum Error {
@@ -205,12 +222,14 @@ impl Window {
     ) -> Result<Window> {
         let event_loop = EventsLoop::new();
 
+        let title = options.title.as_ref().map_or(DEFAULT_TITLE, |t| t);
+        let class = options.class.as_ref().map_or(DEFAULT_CLASS, |c| c);
         let window_builder = WindowBuilder::new()
-            .with_title(&*options.title)
+            .with_title(title)
             .with_visibility(false)
             .with_transparency(true)
             .with_decorations(window_config.decorations());
-        let window_builder = Window::platform_builder_ext(window_builder, &options.class);
+        let window_builder = Window::platform_builder_ext(window_builder, &class);
         let window = create_gl_window(window_builder.clone(), &event_loop, false)
             .or_else(|_| create_gl_window(window_builder, &event_loop, true))?;
         window.show();


### PR DESCRIPTION
This rebases the scrollback PR on top of the latest master and resolves all merge conflicts.

It also fixes all existing clippy issues in the scrollback branch, two `allow`s have been added, I'd love some comment on those (see grid/mod.rs and row.rs).

This also removes `TODO`s that are not relevant anymore or already have tracking issues on github, there's only one `XXX` left in `storage.rs`, I'd also love to resolve this.

Unfortunately this is a bit messy since I've decided to merge master instead of rebasing to prevent errors and allow for a PR without having to rewrite the history. If desired I can separate the clippy and TODO fixes in a separate PR after scrollback has been rebased on top of the latest master.

This also fixes all the comments I've left on the scrollback PR.