### PR TITLE
Fix selection of empty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clear screen properly before rendering of content to prevent various graphical glitches
 - Fix build failure on 32-bit systems
 - Windows started as unfocused now show the hollow cursor if the setting is enabled
+- Empty lines in selections are now properly copied to the clipboard
 
 ### Deprecated
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -962,9 +962,8 @@ impl Term {
                         }
                     }
 
-                    let range = cols.start..line_end;
                     if cols.end >= grid.num_cols() - 1 {
-                        self.maybe_newline(grid, line, range.end);
+                        self.maybe_newline(grid, line, line_end);
                     }
                 }
             }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -953,20 +953,18 @@ impl Term {
                 let line_length = grid_line.line_length();
                 let line_end = min(line_length, cols.end + 1);
 
-                if cols.start >= line_end {
+                if line_end.0 == 0 && cols.end >= grid.num_cols() - 1 {
                     self.push('\n');
-                } else {
+                } else if cols.start < line_end {
                     for cell in &grid_line[cols.start..line_end] {
                         if !cell.flags.contains(cell::Flags::WIDE_CHAR_SPACER) {
                             self.push(cell.c);
                         }
                     }
 
-                    let range = Some(cols.start..line_end);
+                    let range = cols.start..line_end;
                     if cols.end >= grid.num_cols() - 1 {
-                        if let Some(ref range) = range {
-                            self.maybe_newline(grid, line, range.end);
-                        }
+                        self.maybe_newline(grid, line, range.end);
                     }
                 }
             }

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -216,10 +216,11 @@ pub fn new<T: ToWinsize>(config: &Config, options: &Options, size: &T, window_id
     // TERM; default to 'alacritty' if it is available, otherwise
     // default to 'xterm-256color'. May be overridden by user's config
     // below.
-    let mut term = "alacritty";
-    if let Err(_) = Database::from_name("alacritty") {
-        term = "xterm-256color";
-    }
+    let term = if Database::from_name("alacritty").is_ok() {
+        "alacritty"
+    } else {
+        "xterm-256color"
+    };
     builder.env("TERM", term);
 
     builder.env("COLORTERM", "truecolor"); // advertise 24-bit support


### PR DESCRIPTION
When selecting multiple lines in Alacritty, there was an issue with
empty lines not being copied. This behavior has been chanaged so empty
lines should be correctly copied now.