### PR TITLE
Fix 'cargo-deb' desktop file name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ section = "rust"
 priority = "optional"
 assets = [
     ["target/release/alacritty", "usr/local/bin/", "755"],
-    ["Alacritty.desktop", "usr/share/applications/", "644"],
+    ["alacritty.desktop", "usr/share/applications/", "644"],
     ["alacritty-completions.bash", "usr/share/bash-completion/completions/alacritty", "644"],
     ["alacritty-completions.fish", "usr/share/fish/completions/alacritty", "644"],
     ["alacritty-completions.zsh", "usr/share/zsh/functions/Completion/alacritty", "644"],


### PR DESCRIPTION
The desktop file was incorrectly spelled `Alacritty...` instead of `alacritty...`,
this has been fixed and it should now be possible to build debs using the
`cargo-deb` tool.

This fixes #1442.