### PR TITLE
Optional dim foreground color

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -117,7 +117,9 @@ colors:
   primary:
     background: '0x000000'
     foreground: '0xeaeaea'
+    # Optional bright and dim foreground
     bright_foreground: '0xeaeaea'
+    dim_foreground: '0x9a9a9a'
 
   # Colors the cursor will use if `custom_cursor_colors` is true
   cursor:

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -117,7 +117,6 @@ colors:
   primary:
     background: '0x000000'
     foreground: '0xeaeaea'
-    # Optional bright and dim foreground
     bright_foreground: '0xeaeaea'
     dim_foreground: '0x9a9a9a'
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -117,8 +117,15 @@ colors:
   primary:
     background: '0x000000'
     foreground: '0xeaeaea'
-    bright_foreground: '0xeaeaea'
-    dim_foreground: '0x9a9a9a'
+
+    # (Optional) Bright and Dim foreground colors
+    #
+    # The dimmed foreground color is calculated automatically if it is not present.
+    # If the bright foreground color is not set, or `draw_bold_text_with_bright_colors`
+    # is `false`, the normal foreground color will be used.
+    #
+    # dim_foreground: '0x9a9a9a'
+    # bright_foreground: '0xffffff'
 
   # Colors the cursor will use if `custom_cursor_colors` is true
   cursor:

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -95,7 +95,15 @@ colors:
   primary:
     background: '0x000000'
     foreground: '0xeaeaea'
-    bright_foreground: '0xeaeaea'
+
+    # (Optional) Bright and Dim foreground colors
+    #
+    # The dimmed foreground color is calculated automatically if it is not present.
+    # If the bright foreground color is not set, or `draw_bold_text_with_bright_colors`
+    # is `false`, the normal foreground color will be used.
+    #
+    # dim_foreground: '0x9a9a9a'
+    # bright_foreground: '0xffffff'
 
   # Colors the cursor will use if `custom_cursor_colors` is true
   cursor:

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -607,6 +607,7 @@ impl NamedColor {
             NamedColor::BrightMagenta => NamedColor::Magenta,
             NamedColor::BrightCyan => NamedColor::Cyan,
             NamedColor::BrightWhite => NamedColor::White,
+            NamedColor::BrightForeground => NamedColor::Foreground,
             val => val
         }
     }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -576,6 +576,7 @@ impl NamedColor {
             NamedColor::Magenta => NamedColor::BrightMagenta,
             NamedColor::Cyan => NamedColor::BrightCyan,
             NamedColor::White => NamedColor::BrightWhite,
+            NamedColor::DimForeground => NamedColor::Foreground,
             NamedColor::DimBlack => NamedColor::Black,
             NamedColor::DimRed => NamedColor::Red,
             NamedColor::DimGreen => NamedColor::Green,

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -560,6 +560,8 @@ pub enum NamedColor {
     DimWhite,
     /// The bright foreground color
     BrightForeground,
+    /// Dim foreground
+    DimForeground,
 }
 
 impl NamedColor {
@@ -596,6 +598,7 @@ impl NamedColor {
             NamedColor::Magenta => NamedColor::DimMagenta,
             NamedColor::Cyan => NamedColor::DimCyan,
             NamedColor::White => NamedColor::DimWhite,
+            NamedColor::Foreground => NamedColor::DimForeground,
             NamedColor::BrightBlack => NamedColor::Black,
             NamedColor::BrightRed => NamedColor::Red,
             NamedColor::BrightGreen => NamedColor::Green,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1022,11 +1022,13 @@ pub struct PrimaryColors {
     pub background: Rgb,
     #[serde(deserialize_with = "rgb_from_hex")]
     pub foreground: Rgb,
-    #[serde(default, deserialize_with = "deserialize_bright_foreground")]
+    #[serde(default, deserialize_with = "deserialize_optional_color")]
     pub bright_foreground: Option<Rgb>,
+    #[serde(default, deserialize_with = "deserialize_optional_color")]
+    pub dim_foreground: Option<Rgb>,
 }
 
-fn deserialize_bright_foreground<'a, D>(deserializer: D) -> ::std::result::Result<Option<Rgb>, D::Error>
+fn deserialize_optional_color<'a, D>(deserializer: D) -> ::std::result::Result<Option<Rgb>, D::Error>
     where D: de::Deserializer<'a>
 {
     match Option::deserialize(deserializer) {
@@ -1048,6 +1050,7 @@ impl Default for PrimaryColors {
             background: Rgb { r: 0, g: 0, b: 0 },
             foreground: Rgb { r: 0xea, g: 0xea, b: 0xea },
             bright_foreground: None,
+            dim_foreground: None,
         }
     }
 }

--- a/src/term/color.rs
+++ b/src/term/color.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use {Rgb, ansi};
 use config::Colors;
 
-pub const COUNT: usize = 269;
+pub const COUNT: usize = 270;
 
 /// List of indexed colors
 ///
@@ -13,7 +13,7 @@ pub const COUNT: usize = 269;
 /// the configured foreground color, item 257 is the configured background
 /// color, item 258 is the cursor foreground color, item 259 is the cursor
 /// background color. Following that are 8 positions for dim colors.
-/// Item 268 is the bright foreground color.
+/// Item 268 is the bright foreground color, 269 the dim foreground.
 #[derive(Copy, Clone)]
 pub struct List([Rgb; COUNT]);
 
@@ -65,6 +65,10 @@ impl List {
         self[ansi::NamedColor::Cursor]     = colors.cursor.cursor;
 
         // Dims
+        self[ansi::NamedColor::DimForeground] = colors
+            .primary
+            .dim_foreground
+            .unwrap_or(colors.primary.foreground * 0.66);
         match colors.dim {
             Some(ref dim) => {
                 trace!("Using config-provided dim colors");

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -275,11 +275,11 @@ impl<'a> RenderableCellsIter<'a> {
             Color::Spec(rgb) => rgb,
             Color::Named(ansi) => {
                 match (self.config.draw_bold_text_with_bright_colors(), cell.flags & Flags::DIM_BOLD) {
+                    // Cell is marked as dim, has priority over brightened bold
+                    (_,    self::cell::Flags::DIM) |
+                    (_,    self::cell::Flags::DIM_BOLD) => self.colors[ansi.to_dim()],
                     // Draw bold text in bright colors *and* contains bold flag.
-                    (true, self::cell::Flags::DIM_BOLD) |
                     (true, self::cell::Flags::BOLD)     => self.colors[ansi.to_bright()],
-                    // Cell is marked as dim and not bold
-                    (_,    self::cell::Flags::DIM)      => self.colors[ansi.to_dim()],
                     // None of the above, keep original color.
                     _ => self.colors[ansi]
                 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -275,11 +275,18 @@ impl<'a> RenderableCellsIter<'a> {
             Color::Spec(rgb) => rgb,
             Color::Named(ansi) => {
                 match (self.config.draw_bold_text_with_bright_colors(), cell.flags & Flags::DIM_BOLD) {
-                    // Cell is marked as dim, has priority over brightened bold
-                    (_,    self::cell::Flags::DIM) |
-                    (_,    self::cell::Flags::DIM_BOLD) => self.colors[ansi.to_dim()],
+                    // If no bright foreground is set, treat it like the BOLD flag doesn't exist
+                    (_, self::cell::Flags::DIM_BOLD)
+                        if ansi == NamedColor::Foreground
+                            && self.config.colors().primary.bright_foreground.is_none() =>
+                    {
+                        self.colors[NamedColor::DimForeground]
+                    }
                     // Draw bold text in bright colors *and* contains bold flag.
-                    (true, self::cell::Flags::BOLD)     => self.colors[ansi.to_bright()],
+                    (true,  self::cell::Flags::BOLD)     => self.colors[ansi.to_bright()],
+                    // Cell is marked as dim and not bold
+                    (_,     self::cell::Flags::DIM) |
+                    (false, self::cell::Flags::DIM_BOLD) => self.colors[ansi.to_dim()],
                     // None of the above, keep original color.
                     _ => self.colors[ansi]
                 }


### PR DESCRIPTION
Optional color for the dim foreground (`\e[2m`)
Defaults to 2/3 of the foreground color. (same as other colors)
Fixes #1448 

The option in `alacritty.yml` is in `colors.primary.dim_foreground`, to be in the same place as `bright_foreground`.