### PR TITLE
Allow specifying modifiers for mouse bindings

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -532,7 +532,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             return;
         }
 
-        self.process_mouse_bindings(ModifiersState::default(), button);
+        self.process_mouse_bindings(modifiers, button);
     }
 
     /// Process key input


### PR DESCRIPTION
This fixes #1462.