### PR TITLE
Fix trailing colors when leaving vim after resize

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1138,8 +1138,8 @@ impl Term {
         debug!("num_cols, num_lines = {}, {}", num_cols, num_lines);
 
         // Resize grids to new size
-        self.grid.resize(num_lines, num_cols, &self.cursor.template);
-        self.alt_grid.resize(num_lines, num_cols, &self.cursor_save_alt.template);
+        self.grid.resize(num_lines, num_cols, &Cell::default());
+        self.alt_grid.resize(num_lines, num_cols, &Cell::default());
 
         // Reset scrolling region to new size
         self.scroll_region = Line(0)..self.grid.num_lines();


### PR DESCRIPTION
There is an issue where the terminal would use the template cell to fill
new space after resizing the terminal. However this leads to issues
since the template cell is not always empty and thus can create some
blocks of color appearing out of nowhere.

This should fix this problem by always initializing cells with the
default cell after resizing.

This fixes #1376.