### PR TITLE
Replace `debug = 1` with `debug = true`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ gl_generator = "0.9"
 
 [profile.release]
 lto = true
-debug = 1
+debug = true
 
 [package.metadata.deb]
 maintainer = "Joe Wilm <joe@jwilm.com>"


### PR DESCRIPTION
When I attempted to build for Debian stretch, I hit the following issue:

```
~/a/alacritty (master) 
$ cargo deb --install

cargo-deb: unable to parse Cargo.toml
  because: invalid type: integer `1`, expected a boolean for key `profile.release.debug`
```

Replacing the `1` with `true` seems to have fixed the issue!