### PR TITLE
Fix profile.release.debug key type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ gl_generator = "0.9"
 
 [profile.release]
 lto = true
-debug = 1
+debug = true
 
 [package.metadata.deb]
 maintainer = "Joe Wilm <joe@jwilm.com>"


### PR DESCRIPTION
Changed type from integer to boolean. Faced a type mismatch while trying to install alacritty from master.