### PR TITLE
Enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ bench = []
 gl_generator = "0.9"
 
 [profile.release]
+lto = true
 debug = 1
 
 [package.metadata.deb]


### PR DESCRIPTION
This has been disabled temporarily to improve compile times, however
there were some performance regressions caused by this change.

Since this only affects release compiles and performance is a high
priority for Alacritty, LTO has been enabled again.

This fixes #1478.