### PR TITLE
Opt-in to macOS Mojave Dark Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for macOS systemwide dark mode
 - Set the environment variable `COLORTERM="truecolor"` to advertise 24-bit color support
 
 ### Changed

--- a/assets/osx/Alacritty.app/Contents/Info.plist
+++ b/assets/osx/Alacritty.app/Contents/Info.plist
@@ -32,5 +32,7 @@
   <true/>
   <key>CFBundleDisplayName</key>
   <string>Alacritty</string>
+  <key>NSRequiresAquaSystemAppearance</key>
+  <string>NO</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #1484

macOS 10.14 will bring a new system wide dark mode. To enable this, the [official guides][] suggest to relink using the newest OS. This approach, however, did not work for me as described in [an issue][] in the glutin repository.

As a second option, the accompanying `Info.plist` file can also overwrite the link-time check and enable dark mode rendering if the system config is set by setting `NSRequiresAquaSystemAppearance` to `YES`. This approach seems to work flawlessly no matter if a user opts into dark mode or not.

I would appreciate it if someone can test this on macOS 10.13 as well, but I suppose the key there is unused and would not break anything.

[official guides]: https://developer.apple.com/documentation/appkit/appkit_release_notes_for_macos_10.14_beta
[an issue]: https://github.com/tomaka/glutin/issues/1053#issuecomment-409315461