### PR TITLE
Mention terminfo update is required when changing tabspaces

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -56,7 +56,14 @@ scrolling:
   # to the terminal.
   auto_scroll: false
 
-# Display tabs using this many cells (changes require restart)
+# Spaces per Tab
+#
+# This setting defines the width of a tab in cells. Changes to this
+# value require a restart to take effect.
+#
+# Some applications, like Emacs, rely on knowing about the width of a tab.
+# To prevent unexpected behavior in these applications, it's also required to
+# change the `it` value in terminfo when altering this setting.
 tabspaces: 8
 
 # When true, bold text is drawn using the bright variant of colors.

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -54,7 +54,14 @@ scrolling:
   # to the terminal.
   auto_scroll: false
 
-# Display tabs using this many cells (changes require restart)
+# Spaces per Tab
+#
+# This setting defines the width of a tab in cells. Changes to this
+# value require a restart to take effect.
+#
+# Some applications, like Emacs, rely on knowing about the width of a tab.
+# To prevent unexpected behavior in these applications, it's also required to
+# change the `it` value in terminfo when altering this setting.
 tabspaces: 8
 
 # When true, bold text is drawn using the bright variant of colors.


### PR DESCRIPTION
Changing tabspaces from the default (8) requires a corresponding
update to the `it` item in the terminfo entry used.

Some applications, like Emacs, rely on knowing the width of a tab, and
will experience unexpected behavior if the terminfo data does not
match the actual width used.

Closes #1482.