### PR TITLE
Reset visible area when RIS is received

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -413,7 +413,7 @@ impl<T> Grid<T> {
         self.cols
     }
 
-    pub fn reset(&mut self) {
+    pub fn clear_history(&mut self) {
         self.scroll_limit = 0;
     }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1825,7 +1825,8 @@ impl ansi::Handler for Term {
         self.colors = self.original_colors;
         self.color_modified = [false; color::COUNT];
         self.cursor_style = None;
-        self.grid.reset();
+        self.grid.clear_history();
+        self.grid.region_mut(..).each(|c| c.reset(&Cell::default()));
     }
 
     #[inline]


### PR DESCRIPTION
When running bash and executing `echo -ne '\033c'`, the terminal should
be cleared. However there was an issue with the visible area not being
cleared, so all the text previously printed would still remain visible.

To fix this, whenever a `reset` call is received now, the complete
visible area is reset to `Cell::default()` (the default Cell) and the
length of the available scrollback history is reset to `0`, which
results in the scrollback history being cleared from the perspective of
the user.

This fixes #1483.