### PR TITLE
Scroll visible area when growing window

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -238,8 +238,11 @@ impl<T: Copy + Clone> Grid<T> {
         self.raw.grow_visible_lines(new_line_count, Row::new(self.cols, template));
         self.lines = new_line_count;
 
-        // Add new lines to bottom
-        self.scroll_up(&(Line(0)..new_line_count), lines_added, template);
+        // Move existing lines up if there is no scrollback to fill new lines
+        if lines_added.0 > self.scroll_limit {
+            let scroll_lines = lines_added - self.scroll_limit;
+            self.scroll_up(&(Line(0)..new_line_count), scroll_lines, template);
+        }
 
         self.scroll_limit = self.scroll_limit.saturating_sub(*lines_added);
     }
@@ -415,6 +418,11 @@ impl<T> Grid<T> {
 
     pub fn clear_history(&mut self) {
         self.scroll_limit = 0;
+    }
+
+    #[inline]
+    pub fn scroll_limit(&self) -> usize {
+        self.scroll_limit
     }
 
     /// Total number of lines in the buffer, this includes scrollback + visible lines

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1144,6 +1144,18 @@ impl Term {
             let lines = self.cursor_save_alt.point.line - num_lines + 1;
             self.alt_grid.scroll_up(&(Line(0)..old_lines), lines, &self.cursor_save_alt.template);
         }
+
+        // Move prompt down when growing if scrollback lines are available
+        if num_lines > old_lines {
+            if self.mode.contains(TermMode::ALT_SCREEN) {
+                let growage = min(num_lines - old_lines, Line(self.alt_grid.scroll_limit()));
+                self.cursor_save.point.line += growage;
+            } else {
+                let growage = min(num_lines - old_lines, Line(self.grid.scroll_limit()));
+                self.cursor.point.line += growage;
+            }
+        }
+
         debug!("num_cols, num_lines = {}, {}", num_cols, num_lines);
 
         // Resize grids to new size


### PR DESCRIPTION
Since Alacritty never had any scrollback history, the behavior when the
window height was increased was to just keep the prompt on the same line
it has been before the resize. However the usual behavior of terminal
emulators is to keep the distance from the prompt to the bottom of the
screen consistent whenever possible.

This fixes this behavior by loading lines from the scrollback buffer
when the window height is increased. This is only done when scrollback
is available, so there are only N lines available, the maximum amount of
lines which will be loaded when growing the height is N. Since the
number of lines available in the alternate screen buffer is 0, it still
behaves the same way it did before this patch.

Different terminal emulators have different behaviors when this is done
in the alt screen buffer, XTerm for example loads history from the
normal screen buffer when growing the height of the window from the
alternate screen buffer. Since this seems wrong (the alt screen is not
supposed to have any scrollback), the behavior of Termite (VTE) has been
chosen instead.

In Termite the alt screen buffer never loads any scrollback history
itself, however when the terminal height is grown while the alternate
screen is active, the normal screen's scrollback history lines are
loaded.

This fixes #1502.