### PR TITLE
added `fontconfig-devel` dependency for building on Void Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ On [Void Linux](https://voidlinux.eu), install following packages before
 compiling Alacritty:
 
 ```sh
-xbps-install cmake freetype-devel freetype expat-devel fontconfig xclip
+xbps-install cmake freetype-devel freetype expat-devel fontconfig-devel fontconfig xclip
 ```
 
 #### FreeBSD


### PR DESCRIPTION
Running `cargo install --git https://github.com/jwilm/alacritty.git alacritty` on my system failed before I installed `fontconfig-devel`.