### PR TITLE
Fix substraction underflow with IL sequence

### DIFF
--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1209,9 +1209,10 @@ impl Term {
     /// Text moves down; clear at bottom
     /// Expects origin to be in scroll range.
     #[inline]
-    fn scroll_down_relative(&mut self, origin: Line, lines: Line) {
+    fn scroll_down_relative(&mut self, origin: Line, mut lines: Line) {
         trace!("scroll_down_relative: origin={}, lines={}", origin, lines);
-        let lines = min(lines, self.scroll_region.end - self.scroll_region.start);
+        lines = min(lines, self.scroll_region.end - self.scroll_region.start);
+        lines = min(lines, self.scroll_region.end - origin);
 
         // Scroll between origin and bottom
         self.grid.scroll_down(&(origin..self.scroll_region.end), lines, &self.cursor.template);


### PR DESCRIPTION
The IL escape sequence (CSI Ps L) allows inserting blank, uninitialized
lines. `Ps` is a placeholder for the number of lines that should be
inserted. Before this change Alacritty would crash when a large number
of lines was passed as `Ps` parameter.

The issue was caused whenever the current line of the cursor plus the
lines that should be inserted would leave the bottom of the terminal,
since this makes indexing impossible.

This patch makes sure that the biggest amount of lines inserted does
never exceed the end of the visible region minus the current line of the
curser, which fixes the underflow issue.

This fixes #1515.

@jwilm I'd be interested in knowing what you think about this workaround.
It's not immediately obvious to me what exactly this escape sequence
should be used for. Even though the ecma documentation has some
information on it. So I'm not entirely convinced yet that this is the correct
behavior for dealing with the `IL` escape parameter being out of bounds.