### PR TITLE
Remove debug from release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ gl_generator = "0.9"
 
 [profile.release]
 lto = true
-debug = 1
 
 [package.metadata.deb]
 maintainer = "Joe Wilm <joe@jwilm.com>"


### PR DESCRIPTION
The default release profile should probably not have debug symbols in it, by default. Developers can always opt-in to it manually if needed.