### PR TITLE
Proposal: Set COLORTERM variable to advertise 24-bit support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set the environment variable `COLORTERM="truecolor"` to advertise 24-bit color support
+
 ### Changed
 
 - First click on unfocused Alacritty windows is no longer ignored on platforms other than macOS

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -211,6 +211,7 @@ pub fn new<T: ToWinsize>(config: &Config, options: &Options, size: &T, window_id
     builder.env("SHELL", shell.program());
     builder.env("HOME", pw.dir);
     builder.env("TERM", "xterm-256color"); // default term until we can supply our own
+    builder.env("COLORTERM", "truecolor"); // advertise 24-bit support
     if let Some(window_id) = window_id {
         builder.env("WINDOWID", format!("{}", window_id));
     }


### PR DESCRIPTION
Set `COLORTERM` to `truecolor` in order for applications to be able to
detect that alacritty supports 24-bit colors.

See https://gist.github.com/XVilka/8346728 for more details.

closes #1526