### PR TITLE
Remove redundant copy when selecting font_key

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -827,12 +827,13 @@ impl<'a> RenderApi<'a> {
         for cell in cells {
             // Get font key for cell
             // FIXME this is super inefficient.
-            let mut font_key = glyph_cache.font_key;
-            if cell.flags.contains(cell::Flags::BOLD) {
-                font_key = glyph_cache.bold_key;
+            let font_key = if cell.flags.contains(cell::Flags::BOLD) {
+                glyph_cache.bold_key
             } else if cell.flags.contains(cell::Flags::ITALIC) {
-                font_key = glyph_cache.italic_key;
-            }
+                glyph_cache.italic_key
+            } else {
+                glyph_cache.font_key
+            };
 
             let glyph_key = GlyphKey {
                 font_key,


### PR DESCRIPTION
Small PR to stop the redundant copying of `glyph_cache.font_key` for each cell when the cell is bold or italic, probably will only make the slightest perf improvement if rendering loads of underlined or bold cells