### PR TITLE
Fix #1539.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- First click on unfocused Alacritty windows is no longer ignored on platforms other than macOS
+
 ## Version 0.2.0
 
 ### Added

--- a/src/event.rs
+++ b/src/event.rs
@@ -341,7 +341,7 @@ impl<N: Notify> Processor<N> {
                         processor.received_char(c);
                     },
                     MouseInput { state, button, modifiers, .. } => {
-                        if *window_is_focused {
+                        if !cfg!(target_os = "macos") || *window_is_focused {
                             *hide_cursor = false;
                             processor.mouse_input(state, button, modifiers);
                             processor.ctx.terminal.dirty = true;


### PR DESCRIPTION
Fixes a regression on non-MacOS platforms caused by the fix for
issue #1291.  The fix is to follow platform norms for mouse click
behavior on unfocused terminals.  On MacOS, the first click (that
gives the window focus) is swallowed, and has no effect on the
terminal.  On all other platforms, the first click is passed through
to the terminal.

A new config option is added to the "mouse" section of the config,
called "ignore_unfocused_click".  If unspecified, it will follow
the default for the platform.  Very few users are likely to want
to use non-platform-standard behavior here, but the option is there.