### PR TITLE
Add gperf travis build dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
   - CLIPPY=""
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y gperf
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y gperf; fi
 
 install:
   - if [ -n "$CLIPPY" ]; then rustup component add clippy-preview; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ env:
   - CLIPPY="true"
   - CLIPPY=""
 
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y gperf
+
 install:
   - if [ -n "$CLIPPY" ]; then rustup component add clippy-preview; fi
 

--- a/font/src/ft/fc/font_set.rs
+++ b/font/src/ft/fc/font_set.rs
@@ -99,7 +99,7 @@ impl<'a> Iterator for Iter<'a> {
             None
         } else {
             let pattern = unsafe {
-                let ptr = *(*self.font_set.as_ptr()).fonts.offset(self.current as isize);
+                let ptr = *(*self.font_set.as_ptr()).fonts.add(self.current);
                 PatternRef::from_ptr(ptr)
             };
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -23,7 +23,9 @@
 use std::borrow::ToOwned;
 use std::cmp::Ordering;
 use std::iter::IntoIterator;
-use std::ops::{Deref, DerefMut, Range, RangeTo, RangeFrom, RangeFull, Index, IndexMut};
+use std::ops::{
+    Deref, DerefMut, Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive,
+};
 use std::slice::{self, Iter, IterMut};
 
 use index::{self, Point, Line, Column, IndexRange, RangeInclusive};
@@ -506,6 +508,22 @@ impl<T> IndexMut<RangeTo<index::Column>> for Row<T> {
     #[inline]
     fn index_mut(&mut self, index: RangeTo<index::Column>) -> &mut [T] {
         &mut self.0[..(index.end.0)]
+    }
+}
+
+impl<T> Index<RangeToInclusive<index::Column>> for Row<T> {
+    type Output = [T];
+
+    #[inline]
+    fn index(&self, index: RangeToInclusive<index::Column>) -> &[T] {
+        &self.0[..=(index.end.0)]
+    }
+}
+
+impl<T> IndexMut<RangeToInclusive<index::Column>> for Row<T> {
+    #[inline]
+    fn index_mut(&mut self, index: RangeToInclusive<index::Column>) -> &mut [T] {
+        &mut self.0[..=(index.end.0)]
     }
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1664,7 +1664,7 @@ impl ansi::Handler for Term {
             },
             ansi::LineClearMode::Left => {
                 let row = &mut self.grid[self.cursor.point.line];
-                for cell in &mut row[..(col + 1)] {
+                for cell in &mut row[..=col] {
                     cell.reset(&template);
                 }
             },


### PR DESCRIPTION
Some builds were failing with an error which mentions that `gperf` needs
to be installed.

This should fix failing builds on linux by installing the required
package before anything else.