### PR TITLE
Set upper limit for scrollback history size

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,8 @@ use ansi::CursorStyle;
 
 use util::fmt::Yellow;
 
+const MAX_SCROLLBACK_LINES: u32 = 100_000;
+
 /// Function that returns true for serde default
 fn true_bool() -> bool {
     true
@@ -511,7 +513,18 @@ fn deserialize_scrolling_history<'a, D>(deserializer: D) -> ::std::result::Resul
     where D: de::Deserializer<'a>
 {
     match u32::deserialize(deserializer) {
-        Ok(lines) => Ok(lines),
+        Ok(lines) => {
+            if lines > MAX_SCROLLBACK_LINES {
+                eprintln!(
+                    "problem with config: scrollback size is {}, but expected a maximum of {}; \
+                     Using {1} instead",
+                    lines, MAX_SCROLLBACK_LINES,
+                );
+                Ok(MAX_SCROLLBACK_LINES)
+            } else {
+                Ok(lines)
+            }
+        },
         Err(err) => {
             eprintln!("problem with config: {}; Using default value", err);
             Ok(default_scrolling_history())


### PR DESCRIPTION
Since the scrollback history allocates all lines in memory, it is
possible to specify a scrollback history which is big enough to freeze
the computer due to OOM.

To resolve this issue, an upper limit of `100_000` has been set for the
scrollback history. Even though this might still cause some systems to
freeze, this should provide a good balance for most users.