### PR TITLE
Show hollow cursor for windows starting unfocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inverse/Selection color is now modelled after XTerm/VTE instead of URxvt to improve consistency
 - First click on unfocused Alacritty windows is no longer ignored on platforms other than macOS
 
+### Fixed
+
+- Windows started as unfocused now show the hollow cursor if the setting is enabled
+
 ## Version 0.2.0
 
 ### Added

--- a/src/window.rs
+++ b/src/window.rs
@@ -249,7 +249,7 @@ impl Window {
             event_loop,
             window,
             cursor_visible: true,
-            is_focused: true,
+            is_focused: false,
         };
 
         window.run_os_extensions();


### PR DESCRIPTION
Alacritty made the assumption that every window started as focused and
because of that the hollow cursor wouldn't show up for windows which are
launched without focus.

Since even the initial focus should be reported as a focus event by
winit, this could be easily fixed just setting the default window state
to unfocused instead of focused.

This fixes #1563.