### PR TITLE
Auto copy selection to primary clipboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         viewport to extend to the top of the window.
     - `buttonless` - Similar to transparent but also removed the buttons.
 - Add support for changing the colors from 16 to 256 in the `indexed_colors` config section
-- New config `save_to_clipboard: true` in `selection` section: copy selected
-  string to primary clipboard
+- Add `save_to_clipboard` configuration option for copying selected text to the system clipboard
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         viewport to extend to the top of the window.
     - `buttonless` - Similar to transparent but also removed the buttons.
 - Add support for changing the colors from 16 to 256 in the `indexed_colors` config section
+- New config `save_to_clipboard: true` in `selection` section: copy selected
+  string to primary clipboard
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -262,6 +262,11 @@ mouse:
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
 
+  # When set to `true`, the selection string will be copied to both the primary
+  # and the selection clipboard. Otherwise, it will only be copied to the
+  # selection clipboard.
+  save_to_clipboard: false
+
 dynamic_title: true
 
 hide_cursor_when_typing: false

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -262,9 +262,9 @@ mouse:
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
 
-  # When set to `true`, the selection string will be copied to both the primary
-  # and the selection clipboard. Otherwise, it will only be copied to the
-  # selection clipboard.
+  # When set to `true`, selected text will be copied to both the primary and
+  # the selection clipboard. Otherwise, it will only be copied to the selection
+  # clipboard.
   save_to_clipboard: false
 
 dynamic_title: true

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -260,10 +260,8 @@ mouse:
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
 
-  # When set to `true`, selection string will be copied to the primary
-  # clipboard. Otherwise nothing will happen as macOS does not have selection
-  # clipboard.
-  save_to_clipboard: true
+  # When set to `true`, selected text will be copied to the primary clipboard.
+  save_to_clipboard: false
 
 dynamic_title: true
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -260,6 +260,11 @@ mouse:
 selection:
   semantic_escape_chars: ",│`|:\"' ()[]{}<>"
 
+  # When set to `true`, selection string will be copied to the primary
+  # clipboard. Otherwise nothing will happen as macOS does not have selection
+  # clipboard.
+  save_to_clipboard: true
+
 dynamic_title: true
 
 hide_cursor_when_typing: false

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,12 +40,15 @@ fn true_bool() -> bool {
 #[derive(Clone, Debug, Deserialize)]
 pub struct Selection {
     pub semantic_escape_chars: String,
+    #[serde(default, deserialize_with = "failure_default")]
+    pub save_to_clipboard: bool,
 }
 
 impl Default for Selection {
     fn default() -> Selection {
         Selection {
-            semantic_escape_chars: String::new()
+            semantic_escape_chars: String::new(),
+            save_to_clipboard: false
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,7 +8,7 @@ use std::time::{Instant};
 use serde_json as json;
 use parking_lot::MutexGuard;
 use glutin::{self, ModifiersState, Event, ElementState};
-use copypasta::{Clipboard, Load, Store};
+use copypasta::{Clipboard, Load, Store, Buffer as ClipboardBuffer};
 
 use ansi::{Handler, ClearMode};
 use grid::Scroll;
@@ -64,7 +64,7 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         self.terminal.clear_screen(ClearMode::Saved);
     }
 
-    fn copy_selection(&self, buffer: ::copypasta::Buffer) {
+    fn copy_selection(&self, buffer: ClipboardBuffer) {
         if let Some(selected) = self.terminal.selection_to_string() {
             if !selected.is_empty() {
                 Clipboard::new()
@@ -238,6 +238,7 @@ pub struct Processor<N> {
     last_modifiers: ModifiersState,
     pending_events: Vec<Event>,
     window_changes: WindowChanges,
+    save_to_clipboard: bool,
 }
 
 /// Notify that the terminal was resized
@@ -281,6 +282,7 @@ impl<N: Notify> Processor<N> {
             last_modifiers: Default::default(),
             pending_events: Vec::with_capacity(4),
             window_changes: Default::default(),
+            save_to_clipboard: config.selection().save_to_clipboard,
         }
     }
 
@@ -442,6 +444,7 @@ impl<N: Notify> Processor<N> {
                 mouse_config: &self.mouse_config,
                 key_bindings: &self.key_bindings[..],
                 mouse_bindings: &self.mouse_bindings[..],
+                save_to_clipboard: self.save_to_clipboard,
             };
 
             let mut window_is_focused = window.is_focused;
@@ -496,5 +499,6 @@ impl<N: Notify> Processor<N> {
         self.key_bindings = config.key_bindings().to_vec();
         self.mouse_bindings = config.mouse_bindings().to_vec();
         self.mouse_config = config.mouse().to_owned();
+        self.save_to_clipboard = config.selection().save_to_clipboard;
     }
 }


### PR DESCRIPTION
With `save_to_clipboard: true` in `selection` section of
`alacritty.yml`. The selected string will automatically copy to primary
clipboard.