### PR TITLE
Fix config error with missing decorations field

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -280,10 +280,12 @@ impl<'de> Deserialize<'de> for Decorations {
                 where E: de::Error
             {
                 if value {
-                    eprintln!("deprecated decorations boolean value, use one of default|transparent|buttonless|none instead; Falling back to \"full\"");
+                    eprintln!("deprecated decorations boolean value, use one of \
+                              default|transparent|buttonless|none instead; Falling back to \"full\"");
                     Ok(Decorations::Full)
                 } else {
-                    eprintln!("deprecated decorations boolean value, use one of default|transparent|buttonless|none instead; Falling back to \"none\"");
+                    eprintln!("deprecated decorations boolean value, use one of \
+                              default|transparent|buttonless|none instead; Falling back to \"none\"");
                     Ok(Decorations::None)
                 }
             }
@@ -308,7 +310,7 @@ impl<'de> Deserialize<'de> for Decorations {
             fn visit_str<E>(self, value: &str) -> ::std::result::Result<Decorations, E>
                 where E: de::Error
             {
-                match value {
+                match value.to_lowercase().as_str() {
                     "none" => Ok(Decorations::None),
                     "full" => Ok(Decorations::Full),
                     "transparent" => {
@@ -342,6 +344,7 @@ pub struct WindowConfig {
     padding: Delta<u8>,
 
     /// Draw the window with title bar / borders
+    #[serde(default)]
     decorations: Decorations,
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -211,7 +211,7 @@ impl Action {
             Action::Paste => {
                 Clipboard::new()
                     .and_then(|clipboard| clipboard.load_primary() )
-                    .map(|contents| { self.paste(ctx, contents) })
+                    .map(|contents| { self.paste(ctx, &contents) })
                     .unwrap_or_else(|err| {
                         eprintln!("Error loading data from clipboard. {}", Red(err));
                     });
@@ -222,7 +222,7 @@ impl Action {
                 if !ctx.terminal_mode().intersects(mouse_modes) {
                     Clipboard::new()
                         .and_then(|clipboard| clipboard.load_selection() )
-                        .map(|contents| { self.paste(ctx, contents) })
+                        .map(|contents| { self.paste(ctx, &contents) })
                         .unwrap_or_else(|err| {
                             warn!("Error loading data from clipboard. {}", Red(err));
                         });
@@ -282,7 +282,7 @@ impl Action {
         }
     }
 
-    fn paste<A: ActionContext>(&self, ctx: &mut A, contents: String) {
+    fn paste<A: ActionContext>(&self, ctx: &mut A, contents: &str) {
         if ctx.terminal_mode().contains(TermMode::BRACKETED_PASTE) {
             ctx.write_to_pty(&b"\x1b[200~"[..]);
             ctx.write_to_pty(contents.replace("\x1b","").into_bytes());


### PR DESCRIPTION
The latest change to window decorations
(3b46859eceea39afb8bbc760235cc15de78d3ff3) introduced a regression when
running Alacritty without the `decorations` field specified in the
configuration file. Since serde wasn't setup to fallback to the default,
the complete config deserialization would fail.

This resolves this issue by deserializing it to the default decorations
value "Full". To make this setting a little more forgiving, this also
introduces another change which ignores the case for the configuration
options. So both `full` and `FuLl` are now accepted.