### PR TITLE
Hide window on shutdown

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -426,4 +426,8 @@ impl Display {
         let nspot_x = (px + col as f32 * cw) as i32;
         self.window().set_ime_spot(nspot_x, nspot_y);
     }
+
+    pub fn hide(&self) {
+        self.window.hide();
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,7 @@ fn run(mut config: Config, options: &cli::Options) -> Result<(), Box<Error>> {
     }
 
     loop_tx.send(Msg::Shutdown).expect("Error sending shutdown to event loop");
+    display.hide();
 
     // FIXME patch notify library to have a shutdown method
     // config_reloader.join().ok();


### PR DESCRIPTION
I've noticed that closing terminal windows by logging out of the shell can take some time. Hiding the window immediately makes it look instantaneous.