### PR TITLE
Request user attention when bell received in macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New configuration option `persistent_logging` and CLI flag `--persistent-logging`,
     for keeping the log file after closing Alacritty
 - `ClearLogNotice` action for removing the warning and error message
+- Terminal bells on macOS will now request the user's attention in the window
 
 ### Changed
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -361,16 +361,13 @@ impl Window {
         self.window.set_urgent(is_urgent);
     }
 
-    #[cfg(
-        not(
-            any(
-                target_os = "linux",
-                target_os = "freebsd",
-                target_os = "dragonfly",
-                target_os = "openbsd"
-            )
-        )
-    )]
+    #[cfg(target_os = "macos")]
+    pub fn set_urgent(&self, is_urgent: bool) {
+        use glutin::os::macos::WindowExt;
+        self.window.request_user_attention(is_urgent);
+    }
+
+    #[cfg(windows)]
     pub fn set_urgent(&self, _is_urgent: bool) {}
 
     pub fn set_ime_spot(&self, pos: LogicalPosition) {


### PR DESCRIPTION
We now request the user's attention in macOS when a visual bell
character is received. This manifests as the window jumping up and
down in the dock.

Depends on #1403.
Depends on tomaka/winit#664 for the changes to `WindowExt` on macOS.