### PR TITLE
Fix deserialization of old decorations values

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -279,29 +279,27 @@ impl<'de> Deserialize<'de> for Decorations {
                 f.write_str("Some subset of full|transparent|buttonless|none")
             }
 
-            fn visit_bool<E>(self, value: bool) -> ::std::result::Result<Decorations, E>
-                where E: de::Error
-            {
-                if value {
-                    eprintln!("deprecated decorations boolean value, use one of \
-                              default|transparent|buttonless|none instead; Falling back to \"full\"");
-                    Ok(Decorations::Full)
-                } else {
-                    eprintln!("deprecated decorations boolean value, use one of \
-                              default|transparent|buttonless|none instead; Falling back to \"none\"");
-                    Ok(Decorations::None)
-                }
-            }
-
             #[cfg(target_os = "macos")]
             fn visit_str<E>(self, value: &str) -> ::std::result::Result<Decorations, E>
                 where E: de::Error
             {
-                match value {
+                match value.to_lowercase().as_str() {
                     "transparent" => Ok(Decorations::Transparent),
                     "buttonless" => Ok(Decorations::Buttonless),
                     "none" => Ok(Decorations::None),
                     "full" => Ok(Decorations::Full),
+                    "true" => {
+                        eprintln!("deprecated decorations boolean value, use one of \
+                                   default|transparent|buttonless|none instead;\
+                                   Falling back to \"full\"");
+                        Ok(Decorations::Full)
+                    },
+                    "false" => {
+                        eprintln!("deprecated decorations boolean value, use one of \
+                                   default|transparent|buttonless|none instead;\
+                                   Falling back to \"none\"");
+                        Ok(Decorations::None)
+                    },
                     _ => {
                         eprintln!("invalid decorations value: {}; Using default value", value);
                         Ok(Decorations::Full)
@@ -316,14 +314,22 @@ impl<'de> Deserialize<'de> for Decorations {
                 match value.to_lowercase().as_str() {
                     "none" => Ok(Decorations::None),
                     "full" => Ok(Decorations::Full),
-                    "transparent" => {
+                    "true" => {
+                        eprintln!("deprecated decorations boolean value, use one of \
+                                   default|transparent|buttonless|none instead; \
+                                   Falling back to \"full\"");
+                        Ok(Decorations::Full)
+                    },
+                    "false" => {
+                        eprintln!("deprecated decorations boolean value, use one of \
+                                   default|transparent|buttonless|none instead; \
+                                   Falling back to \"none\"");
+                        Ok(Decorations::None)
+                    },
+                    "transparent" | "buttonless" => {
                         eprintln!("macos-only decorations value: {}; Using default value", value);
                         Ok(Decorations::Full)
                     },
-                    "buttonless" => {
-                        eprintln!("macos-only decorations value: {}; Using default value", value);
-                        Ok(Decorations::Full)
-                    }
                     _ => {
                         eprintln!("invalid decorations value: {}; Using default value", value);
                         Ok(Decorations::Full)

--- a/src/config.rs
+++ b/src/config.rs
@@ -289,14 +289,14 @@ impl<'de> Deserialize<'de> for Decorations {
                     "none" => Ok(Decorations::None),
                     "full" => Ok(Decorations::Full),
                     "true" => {
-                        eprintln!("deprecated decorations boolean value, use one of \
-                                   default|transparent|buttonless|none instead;\
+                        eprintln!("deprecated decorations boolean value, \
+                                   use one of transparent|buttonless|none|full instead; \
                                    Falling back to \"full\"");
                         Ok(Decorations::Full)
                     },
                     "false" => {
-                        eprintln!("deprecated decorations boolean value, use one of \
-                                   default|transparent|buttonless|none instead;\
+                        eprintln!("deprecated decorations boolean value, \
+                                   use one of transparent|buttonless|none|full instead; \
                                    Falling back to \"none\"");
                         Ok(Decorations::None)
                     },
@@ -315,14 +315,14 @@ impl<'de> Deserialize<'de> for Decorations {
                     "none" => Ok(Decorations::None),
                     "full" => Ok(Decorations::Full),
                     "true" => {
-                        eprintln!("deprecated decorations boolean value, use one of \
-                                   default|transparent|buttonless|none instead; \
+                        eprintln!("deprecated decorations boolean value, \
+                                   use one of none|full instead; \
                                    Falling back to \"full\"");
                         Ok(Decorations::Full)
                     },
                     "false" => {
-                        eprintln!("deprecated decorations boolean value, use one of \
-                                   default|transparent|buttonless|none instead; \
+                        eprintln!("deprecated decorations boolean value, \
+                                   use one of none|full instead; \
                                    Falling back to \"none\"");
                         Ok(Decorations::None)
                     },


### PR DESCRIPTION
The deprecated `window.decoration` values `true` and `false` were using
the `visit_bool` visitor for serde. However it seems like with yaml, the
str visitor is used instead.

To print the correct deprecation notice, the bool visitor has been
removed and the warning has been added for the `"true"` and `"false"`
str visitor.