### PR TITLE
Fix rendering of selections outside the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows started as unfocused now show the hollow cursor if the setting is enabled
 - Empty lines in selections are now properly copied to the clipboard
 - Selection start point lagging behind initial cursor position
+- Rendering of selections which start above the visible area and end below it
 
 ### Deprecated
 

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -116,6 +116,13 @@ pub enum Scroll {
     Bottom,
 }
 
+#[derive(Copy, Clone)]
+pub enum ViewportPosition {
+    Visible(Line),
+    Above,
+    Below,
+}
+
 impl<T: Copy + Clone> Grid<T> {
     pub fn new(lines: index::Line, cols: index::Column, scrollback: usize, template: T) -> Grid<T> {
         let raw = Storage::with_capacity(lines, Row::new(cols, &template));
@@ -137,18 +144,11 @@ impl<T: Copy + Clone> Grid<T> {
         }
     }
 
-    pub fn buffer_to_visible(&self, point: Point<usize>) -> Point {
-        Point {
-            line: self.buffer_line_to_visible(point.line).expect("Line not visible"),
-            col: point.col
-        }
-    }
-
-    pub fn buffer_line_to_visible(&self, line: usize) -> Option<Line> {
+    pub fn buffer_line_to_visible(&self, line: usize) -> ViewportPosition {
         if line >= self.display_offset {
             self.offset_to_line(line - self.display_offset)
         } else {
-            None
+            ViewportPosition::Below
         }
     }
 
@@ -300,11 +300,11 @@ impl<T: Copy + Clone> Grid<T> {
         *(self.num_lines() - line - 1)
     }
 
-    pub fn offset_to_line(&self, offset: usize) -> Option<Line> {
+    fn offset_to_line(&self, offset: usize) -> ViewportPosition {
         if offset < *self.num_lines() {
-            Some(self.lines - offset - 1)
+            ViewportPosition::Visible(self.lines - offset - 1)
         } else {
-            None
+            ViewportPosition::Above
         }
     }
 

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -145,10 +145,13 @@ impl<T: Copy + Clone> Grid<T> {
     }
 
     pub fn buffer_line_to_visible(&self, line: usize) -> ViewportPosition {
-        if line >= self.display_offset {
-            self.offset_to_line(line - self.display_offset)
-        } else {
+        let offset = line.saturating_sub(self.display_offset);
+        if line < self.display_offset {
             ViewportPosition::Below
+        } else if offset >= *self.num_lines() {
+            ViewportPosition::Above
+        } else {
+            ViewportPosition::Visible(self.lines - offset - 1)
         }
     }
 
@@ -298,14 +301,6 @@ impl<T: Copy + Clone> Grid<T> {
         assert!(line < self.num_lines());
 
         *(self.num_lines() - line - 1)
-    }
-
-    fn offset_to_line(&self, offset: usize) -> ViewportPosition {
-        if offset < *self.num_lines() {
-            ViewportPosition::Visible(self.lines - offset - 1)
-        } else {
-            ViewportPosition::Above
-        }
     }
 
     #[inline]


### PR DESCRIPTION
When rendering selections with both start and end outside of the visible
area, Alacritty would assume that both start and end are either above or
below the viewport and not render the selection at all.

To fix this the `buffer_line_to_visible` method now returns a
`ViewportPosition` instead of an `Option<Line>`, this allows giving more
feedback about where outside of the visible region the line is using the
`ViewportPosition::Above` and `ViewportPosition::Below` varients.

Using these newly introduced varients, a selection spanning the whole
screen is now rendered if the selection should go from above the visible
area to below it.

This fixes #1557.