### PR TITLE
Fix Selection While Scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selection memory leak and glitches in the alternate screen buffer
 - Invalid default configuration on macOS and Linux
 - Middle mouse pasting if mouse mode is enabled
-- Selections now properly update as you scroll the scrollback buffer while selecting.
+- Selections now properly update as you scroll the scrollback buffer while selecting
 
 ## Version 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selection memory leak and glitches in the alternate screen buffer
 - Invalid default configuration on macOS and Linux
 - Middle mouse pasting if mouse mode is enabled
+- Selections now properly update as you scroll the scrollback buffer while selecting.
 
 ## Version 0.2.1
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -59,14 +59,16 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     fn scroll(&mut self, scroll: Scroll) {
         self.terminal.scroll_display(scroll);
 
-        let (x, y) = (self.mouse().x, self.mouse().y);
-        let size_info = self.size_info();
-        let point = size_info.pixels_to_coords(x, y);
-        let cell_side = self.mouse().cell_side;
-        self.update_selection(Point {
-            line: point.line,
-            col: point.col
-        }, cell_side);
+        if let ElementState::Pressed = self.mouse().left_button_state {
+            let (x, y) = (self.mouse().x, self.mouse().y);
+            let size_info = self.size_info();
+            let point = size_info.pixels_to_coords(x, y);
+            let cell_side = self.mouse().cell_side;
+            self.update_selection(Point {
+                line: point.line,
+                col: point.col
+            }, cell_side);
+        }
     }
 
     fn clear_history(&mut self) {

--- a/src/event.rs
+++ b/src/event.rs
@@ -58,6 +58,15 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
 
     fn scroll(&mut self, scroll: Scroll) {
         self.terminal.scroll_display(scroll);
+
+        let (x, y) = (self.mouse().x, self.mouse().y);
+        let size_info = self.size_info();
+        let point = size_info.pixels_to_coords(x, y);
+        let cell_side = self.mouse().cell_side;
+        self.update_selection(Point {
+            line: point.line,
+            col: point.col
+        }, cell_side);
     }
 
     fn clear_history(&mut self) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -350,6 +350,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         let motion_mode = TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG;
         let report_mode = TermMode::MOUSE_REPORT_CLICK | motion_mode;
 
+        let cell_side = self.get_mouse_side();
+        self.ctx.mouse_mut().cell_side = cell_side;
+
         // Don't launch URLs if mouse has moved
         if prev_line != self.ctx.mouse().line
             || prev_col != self.ctx.mouse().column

--- a/src/input.rs
+++ b/src/input.rs
@@ -350,9 +350,6 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         let motion_mode = TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG;
         let report_mode = TermMode::MOUSE_REPORT_CLICK | motion_mode;
 
-        let cell_side = self.get_mouse_side();
-        self.ctx.mouse_mut().cell_side = cell_side;
-
         // Don't launch URLs if mouse has moved
         if prev_line != self.ctx.mouse().line
             || prev_col != self.ctx.mouse().column


### PR DESCRIPTION
Properly update an active selection while scrolling the main scrollback buffer.

- [x] Standard scrolling support
- [x] Rebase down to three commits (cell_side update, standard scrolling, changelog)
- ~Faux scrolling support~ succeeded by #1644 and #1640 (possibly)

Fixes #1598.