### PR TITLE
Add notes about package install on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ zypper in alacritty
 xbps-install alacritty
 ```
 
+### FreeBSD
+```sh
+pkg install alacritty
+```
+
 ## Manual Installation
 
 ### Prerequisites


### PR DESCRIPTION
Hi!
Attached patch adds a note to the readme about binary package for alacritty on FreeBSD.