### PR TITLE
Bump fontconfig dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,11 +91,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -350,10 +345,10 @@ dependencies = [
  "core-text 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype-rs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo-fontconfig 0.4.0 (git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8)",
+ "servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -371,17 +366,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "freetype-rs"
-version = "0.13.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "freetype-sys"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1048,20 +1043,27 @@ dependencies = [
 [[package]]
 name = "servo-fontconfig"
 version = "0.4.0"
-source = "git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8#be2b94de833ec69cf767186262a5fb8360fa5b45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo-fontconfig-sys 4.0.3 (git+https://github.com/jwilm/libfontconfig?branch=updated-2017-10-8)",
+ "servo-fontconfig-sys 4.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "servo-fontconfig-sys"
-version = "4.0.3"
-source = "git+https://github.com/jwilm/libfontconfig?branch=updated-2017-10-8#5c1845e1bffa11cf4d3e6fb27f456bf5c814ce1b"
+version = "4.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "expat-sys 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-freetype-sys 4.0.3",
+]
+
+[[package]]
+name = "servo-freetype-sys"
+version = "4.0.3"
+dependencies = [
+ "freetype-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1467,7 +1469,6 @@ dependencies = [
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-"checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
@@ -1499,8 +1500,8 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-"checksum freetype-rs 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1418e2a055fec8efe18c1a90a54b2cf5e649e583830dd4c71226c4e3bc920c6"
-"checksum freetype-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccfb6d96cac99921f0c2142a91765f6c219868a2c45bdfe7d65a08775f18127"
+"checksum freetype-rs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3fb99e73163c657efba34c8a15226b6f4faeb6a01069a146129e7304e1bc297"
+"checksum freetype-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9485e9956855c197f5139e6e51335b90db5a8f2327d623f43ba71b33f51fe5af"
 "checksum fsevent 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c4bbbf71584aeed076100b5665ac14e3d85eeb31fdbb45fbd41ef9a682b5ec05"
 "checksum fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a772d36c338d07a032d5375a36f15f9a7043bf0cb8ce7cee658e037c6032874"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -1578,8 +1579,8 @@ dependencies = [
 "checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
 "checksum serde_json 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d30ec34ac923489285d24688c7a9c0898d16edff27fc1f1bd854edeff6ca3b7f"
 "checksum serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051"
-"checksum servo-fontconfig 0.4.0 (git+https://github.com/jwilm/rust-fontconfig?branch=updated-2017-10-8)" = "<none>"
-"checksum servo-fontconfig-sys 4.0.3 (git+https://github.com/jwilm/libfontconfig?branch=updated-2017-10-8)" = "<none>"
+"checksum servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9"
+"checksum servo-fontconfig-sys 4.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b46d201addcfbd25c1798ad1281d98c40743824e0b0f1e611bd3d5d0d31a7b8d"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,6 @@ assets = [
     ["alacritty-completions.zsh", "usr/share/zsh/vendor-completions/_alacritty", "644"],
     ["alacritty.info", "usr/share/terminfo/a/alacritty", "644"],
 ]
+
+[patch.crates-io]
+servo-freetype-sys = { path = "servo-freetype-proxy" }

--- a/font/Cargo.toml
+++ b/font/Cargo.toml
@@ -12,8 +12,8 @@ foreign-types = "0.3"
 log = "0.4"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-servo-fontconfig = { git = "https://github.com/jwilm/rust-fontconfig", branch = "updated-2017-10-8" }
-freetype-rs = "0.13"
+servo-fontconfig = "0.4.0"
+freetype-rs = "0.19"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.6"

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -31,7 +31,7 @@ struct FixedSize {
 }
 
 struct Face {
-    ft_face: freetype::Face<'static>,
+    ft_face: freetype::Face,
     key: FontKey,
     load_flags: freetype::face::LoadFlag,
     render_mode: freetype::RenderMode,
@@ -365,12 +365,16 @@ impl FreeTypeRasterizer {
         let hinting = pat.hintstyle().next().unwrap_or(fc::HintStyle::Slight);
         let rgba = pat.rgba().next().unwrap_or(fc::Rgba::Unknown);
 
-        use freetype::face::*;
-
         match (antialias, hinting, rgba) {
-            (false, fc::HintStyle::None, _) => NO_HINTING | MONOCHROME,
-            (false, _, _) => TARGET_MONO | MONOCHROME,
-            (true, fc::HintStyle::None, _) => NO_HINTING | TARGET_NORMAL,
+            (false, fc::HintStyle::None, _) => {
+                freetype::face::LoadFlag::NO_HINTING | freetype::face::LoadFlag::MONOCHROME
+            }
+            (false, _, _) => {
+                freetype::face::LoadFlag::TARGET_MONO | freetype::face::LoadFlag::MONOCHROME
+            }
+            (true, fc::HintStyle::None, _) => {
+                freetype::face::LoadFlag::NO_HINTING | freetype::face::LoadFlag::TARGET_NORMAL
+            }
             // hintslight does *not* use LCD hinting even when a subpixel mode
             // is selected.
             //
@@ -385,19 +389,21 @@ impl FreeTypeRasterizer {
             // subpixel render modes like `FT_RENDER_MODE_LCD`. Libraries like
             // cairo take the same approach and consider `hintslight` to always
             // prefer `FT_LOAD_TARGET_LIGHT`
-            (true, fc::HintStyle::Slight, _) => TARGET_LIGHT,
+            (true, fc::HintStyle::Slight, _) => freetype::face::LoadFlag::TARGET_LIGHT,
             // If LCD hinting is to be used, must select hintmedium or hintfull,
             // have AA enabled, and select a subpixel mode.
-            (true, _, fc::Rgba::Rgb) |
-            (true, _, fc::Rgba::Bgr) => TARGET_LCD,
-            (true, _, fc::Rgba::Vrgb) |
-            (true, _, fc::Rgba::Vbgr) => TARGET_LCD_V,
+            (true, _, fc::Rgba::Rgb) | (true, _, fc::Rgba::Bgr) => {
+                freetype::face::LoadFlag::TARGET_LCD
+            }
+            (true, _, fc::Rgba::Vrgb) | (true, _, fc::Rgba::Vbgr) => {
+                freetype::face::LoadFlag::TARGET_LCD_V
+            }
             // For non-rgba modes with either Medium or Full hinting, just use
             // the default hinting algorithm.
             //
             // TODO should Medium/Full control whether to use the auto hinter?
-            (true, _, fc::Rgba::Unknown) => TARGET_NORMAL,
-            (true, _, fc::Rgba::None) => TARGET_NORMAL,
+            (true, _, fc::Rgba::Unknown) => freetype::face::LoadFlag::TARGET_NORMAL,
+            (true, _, fc::Rgba::None) => freetype::face::LoadFlag::TARGET_NORMAL,
         }
     }
 
@@ -407,10 +413,8 @@ impl FreeTypeRasterizer {
 
         match (antialias, rgba) {
             (false, _) => freetype::RenderMode::Mono,
-            (_, fc::Rgba::Rgb) |
-            (_, fc::Rgba::Bgr) => freetype::RenderMode::Lcd,
-            (_, fc::Rgba::Vrgb) |
-            (_, fc::Rgba::Vbgr) => freetype::RenderMode::LcdV,
+            (_, fc::Rgba::Rgb) | (_, fc::Rgba::Bgr) => freetype::RenderMode::Lcd,
+            (_, fc::Rgba::Vrgb) | (_, fc::Rgba::Vbgr) => freetype::RenderMode::LcdV,
             (true, _) => freetype::RenderMode::Normal,
         }
     }

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -365,16 +365,11 @@ impl FreeTypeRasterizer {
         let hinting = pat.hintstyle().next().unwrap_or(fc::HintStyle::Slight);
         let rgba = pat.rgba().next().unwrap_or(fc::Rgba::Unknown);
 
+        use freetype::face::LoadFlag;
         match (antialias, hinting, rgba) {
-            (false, fc::HintStyle::None, _) => {
-                freetype::face::LoadFlag::NO_HINTING | freetype::face::LoadFlag::MONOCHROME
-            }
-            (false, _, _) => {
-                freetype::face::LoadFlag::TARGET_MONO | freetype::face::LoadFlag::MONOCHROME
-            }
-            (true, fc::HintStyle::None, _) => {
-                freetype::face::LoadFlag::NO_HINTING | freetype::face::LoadFlag::TARGET_NORMAL
-            }
+            (false, fc::HintStyle::None, _) => LoadFlag::NO_HINTING | LoadFlag::MONOCHROME,
+            (false, _, _) => LoadFlag::TARGET_MONO | LoadFlag::MONOCHROME,
+            (true, fc::HintStyle::None, _) => LoadFlag::NO_HINTING | LoadFlag::TARGET_NORMAL,
             // hintslight does *not* use LCD hinting even when a subpixel mode
             // is selected.
             //
@@ -389,21 +384,17 @@ impl FreeTypeRasterizer {
             // subpixel render modes like `FT_RENDER_MODE_LCD`. Libraries like
             // cairo take the same approach and consider `hintslight` to always
             // prefer `FT_LOAD_TARGET_LIGHT`
-            (true, fc::HintStyle::Slight, _) => freetype::face::LoadFlag::TARGET_LIGHT,
+            (true, fc::HintStyle::Slight, _) => LoadFlag::TARGET_LIGHT,
             // If LCD hinting is to be used, must select hintmedium or hintfull,
             // have AA enabled, and select a subpixel mode.
-            (true, _, fc::Rgba::Rgb) | (true, _, fc::Rgba::Bgr) => {
-                freetype::face::LoadFlag::TARGET_LCD
-            }
-            (true, _, fc::Rgba::Vrgb) | (true, _, fc::Rgba::Vbgr) => {
-                freetype::face::LoadFlag::TARGET_LCD_V
-            }
+            (true, _, fc::Rgba::Rgb) | (true, _, fc::Rgba::Bgr) => LoadFlag::TARGET_LCD,
+            (true, _, fc::Rgba::Vrgb) | (true, _, fc::Rgba::Vbgr) => LoadFlag::TARGET_LCD_V,
             // For non-rgba modes with either Medium or Full hinting, just use
             // the default hinting algorithm.
             //
             // TODO should Medium/Full control whether to use the auto hinter?
-            (true, _, fc::Rgba::Unknown) => freetype::face::LoadFlag::TARGET_NORMAL,
-            (true, _, fc::Rgba::None) => freetype::face::LoadFlag::TARGET_NORMAL,
+            (true, _, fc::Rgba::Unknown) => LoadFlag::TARGET_NORMAL,
+            (true, _, fc::Rgba::None) => LoadFlag::TARGET_NORMAL,
         }
     }
 

--- a/servo-freetype-proxy/Cargo.toml
+++ b/servo-freetype-proxy/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "servo-freetype-sys"
+version = "4.0.3"
+authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
+
+[lib]
+name = "freetype_sys"
+path = "src/lib.rs"
+
+[dependencies]
+freetype-sys = "*"

--- a/servo-freetype-proxy/README.md
+++ b/servo-freetype-proxy/README.md
@@ -1,0 +1,4 @@
+This crate only exists to allow us to force `servo-fontconfig-sys` to
+use `freetype-sys` instead of `servo-freetype-sys`, which is in turn
+needed so that we don't try to link with `freetype` multiple times from
+different crates.

--- a/servo-freetype-proxy/src/lib.rs
+++ b/servo-freetype-proxy/src/lib.rs
@@ -1,0 +1,2 @@
+extern crate freetype_sys;
+pub use freetype_sys::*;


### PR DESCRIPTION
The patch uses the Cargo.toml `patch` section to force a single downstream choice of freetype-sys instead of relying on forks of other crates. It also bumps the fontconfig/freetype dependencies in the process.