### PR TITLE
Make the macOS bundle compatible osx 10.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ APP_DIR = $(RELEASE_DIR)/osx
 APP_BINARY = $(RELEASE_DIR)/$(TARGET)
 APP_BINARY_DIR  = $(APP_DIR)/$(APP_NAME)/Contents/MacOS
 
+export MACOSX_DEPLOYMENT_TARGET = $(shell defaults read loginwindow SystemVersionStampAsString)
+
 DMG_NAME = Alacritty.dmg
 DMG_DIR = $(RELEASE_DIR)/osx
 
@@ -22,6 +24,9 @@ help: ## Prints help for targets with comments
 
 binary: | $(TARGET) ## Build release binary with cargo
 $(TARGET):
+ifneq ( "${MACOSX_DEPLOYMENT_TARGET}" , "")
+	@echo MACOSX_DEPLOYMENT_TARGET=$${MACOSX_DEPLOYMENT_TARGET}
+endif
 	cargo build --release
 
 app: | $(APP_NAME) ## Clone Alacritty.app template and mount binary

--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,9 @@ use std::path::Path;
 fn main() {
     let dest = env::var("OUT_DIR").unwrap();
     let mut file = File::create(&Path::new(&dest).join("gl_bindings.rs")).unwrap();
-
+    if cfg!(target_os = "macos"){
+        println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.12");
+    }
     Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, [
             "GL_ARB_blend_func_extended"
         ])

--- a/build.rs
+++ b/build.rs
@@ -21,9 +21,7 @@ use std::path::Path;
 fn main() {
     let dest = env::var("OUT_DIR").unwrap();
     let mut file = File::create(&Path::new(&dest).join("gl_bindings.rs")).unwrap();
-    if cfg!(target_os = "macos"){
-        println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.12");
-    }
+
     Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, [
             "GL_ARB_blend_func_extended"
         ])


### PR DESCRIPTION
On macOS 10.12.6 (as far as I can test), running `make app` creates a
bundle that refuses to start (it complain application is only compatible
with more recent versions of macOS. The binary works great when running
it directly.

As far as I can tell this fixes the issue and the bundle works great
(despite the other issues reported for login shell, but I guess that's
another story).

I'm going to _assume_ that targeting 10.11 or lower would also work.
I don't know what effect this have on the final binary and whether this
removed  some optimisation. Maybe that could be conditionally setup
depending on the version of macOS this is built on?