### PR TITLE
Store grid cells in renderer and drop terminal lock before rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rendering now occurs without the terminal locked which improves performance
 - Clear screen properly before rendering of content to prevent various graphical glitches
 - Fix build failure on 32-bit systems
 - Windows started as unfocused now show the hollow cursor if the setting is enabled

--- a/src/display.rs
+++ b/src/display.rs
@@ -24,7 +24,7 @@ use config::Config;
 use font::{self, Rasterize};
 use meter::Meter;
 use renderer::{self, GlyphCache, QuadRenderer};
-use term::{Term, SizeInfo};
+use term::{Term, SizeInfo, RenderableCell};
 use sync::FairMutex;
 
 use window::{self, Size, Pixels, Window, SetInnerSize};
@@ -331,7 +331,7 @@ impl Display {
         let background_color = terminal.background_color();
 
         let window_focused = self.window.is_focused;
-        self.renderer.grid_cells = terminal
+        let grid_cells: Vec<RenderableCell> = terminal
             .renderable_cells(config, window_focused)
             .collect();
 
@@ -378,7 +378,7 @@ impl Display {
 
                 self.renderer.with_api(config, &size_info, visual_bell_intensity, |mut api| {
                     // Draw the grid
-                    api.render_cells(api.grid_cells.iter(), glyph_cache);
+                    api.render_cells(grid_cells.iter(), glyph_cache);
                 });
             }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -378,7 +378,7 @@ impl Display {
 
                 self.renderer.with_api(config, &size_info, visual_bell_intensity, |mut api| {
                     // Draw the grid
-                    api.render_grid(glyph_cache);
+                    api.render_cells(api.grid_cells.iter(), glyph_cache);
                 });
             }
 
@@ -415,3 +415,4 @@ impl Display {
         self.window().set_ime_spot(nspot_x, nspot_y);
     }
 }
+

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -364,7 +364,6 @@ pub struct QuadRenderer {
     active_tex: GLuint,
     batch: Batch,
     rx: mpsc::Receiver<Msg>,
-    pub grid_cells: Vec<RenderableCell>,
 }
 
 #[derive(Debug)]
@@ -376,7 +375,6 @@ pub struct RenderApi<'a> {
     program: &'a mut ShaderProgram,
     config: &'a Config,
     visual_bell_intensity: f32,
-    pub grid_cells: &'a Vec<RenderableCell>
 }
 
 #[derive(Debug)]
@@ -618,7 +616,6 @@ impl QuadRenderer {
             active_tex: 0,
             batch: Batch::new(),
             rx: msg_rx,
-            grid_cells: Vec::new(),
         };
 
         let atlas = Atlas::new(ATLAS_SIZE);
@@ -666,7 +663,6 @@ impl QuadRenderer {
             program: &mut self.program,
             visual_bell_intensity: visual_bell_intensity as _,
             config,
-            grid_cells: &self.grid_cells,
         });
 
         unsafe {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -820,6 +820,7 @@ impl<'a> RenderApi<'a> {
             self.render_batch();
         }
     }
+
     pub fn render_cells<'b, I>(
         &mut self,
         cells: I,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -372,6 +372,7 @@ impl<'a> RenderableCellsIter<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct RenderableCell {
     /// A _Display_ line (not necessarily an _Active_ line)
     pub line: Line,


### PR DESCRIPTION
This PR stores grid cells in the renderer when `fn draw()` is called and then releases the terminal lock so that rendering can be done without the terminal locked.

This also creates a new function `fn render_grid()` which is almost the exact same as `fn render_cells()` but uses the reference to the grid passed by the renderer to the render api, I think this might be the only way to do it without copying the entire grid to turn it into an iterator.

`RenderableCell` derives debug so it can be stored in the renderer

These changes give me about a 400ms speedup when rendering a 500mb alt-screen-random-write file with cat.

Fixes https://github.com/jwilm/alacritty/issues/1535
Hopefully fixes https://github.com/jwilm/alacritty/issues/1529 (can't test on macos)