### PR TITLE
fix erroneous indexed_color results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed erroneous results when using the `indexed_colors` config option
+
 ## Version 0.2.1
 
 ### Added

--- a/src/term/color.rs
+++ b/src/term/color.rs
@@ -101,7 +101,6 @@ impl List {
         for r in 0..6 {
             for g in 0..6 {
                 for b in 0..6 {
-
                     // Override colors 16..232 with the config (if present)
                     if let Some(indexed_color) = colors
                         .indexed_colors
@@ -109,14 +108,12 @@ impl List {
                         .find(|ic| ic.index == index as u8)
                     {
                         self[index] = indexed_color.color;
-                        index += 1;
-                        continue;
+                    } else {
+                        self[index] = Rgb { r: if r == 0 { 0 } else { r * 40 + 55 },
+                            b: if b == 0 { 0 } else { b * 40 + 55 },
+                            g: if g == 0 { 0 } else { g * 40 + 55 },
+                        };
                     }
-
-                    self[index] = Rgb { r: if r == 0 { 0 } else { r * 40 + 55 },
-                        b: if b == 0 { 0 } else { b * 40 + 55 },
-                        g: if g == 0 { 0 } else { g * 40 + 55 },
-                    };
                     index += 1;
                 }
             }

--- a/src/term/color.rs
+++ b/src/term/color.rs
@@ -101,14 +101,12 @@ impl List {
         for r in 0..6 {
             for g in 0..6 {
                 for b in 0..6 {
-                    // Index of the color is number of named colors + rgb
-                    let color_index = 16 + r + g + b;
 
                     // Override colors 16..232 with the config (if present)
                     if let Some(indexed_color) = colors
                         .indexed_colors
                         .iter()
-                        .find(|ic| ic.index == color_index)
+                        .find(|ic| ic.index == index as u8)
                     {
                         self[index] = indexed_color.color;
                         index += 1;


### PR DESCRIPTION
First off thanks for Alacritty, I've been loving it!

Since v0.2.1 I attempted to set custom indexed_colors and noticed that I was getting erroneous results.

If set to a color value of 200, nothing would get set:
`- { index: 200, color: '0x2ec6c6' }`

If set to a color value of 20, 20 would be set along with other indexed numbers (random from 25-160):
`- { index: 20, color: '0x2ec6c6' }`

20 20: Rgb { r: 46, g: 198, b: 198 }
25 20: Rgb { r: 46, g: 198, b: 198 }
30 20: Rgb { r: 46, g: 198, b: 198 }
35 20: Rgb { r: 46, g: 198, b: 198 }
40 20: Rgb { r: 46, g: 198, b: 198 }
55 20: Rgb { r: 46, g: 198, b: 198 }
60 20: Rgb { r: 46, g: 198, b: 198 }
65 20: Rgb { r: 46, g: 198, b: 198 }
70 20: Rgb { r: 46, g: 198, b: 198 }
90 20: Rgb { r: 46, g: 198, b: 198 }
95 20: Rgb { r: 46, g: 198, b: 198 }
100 20: Rgb { r: 46, g: 198, b: 198 }
125 20: Rgb { r: 46, g: 198, b: 198 }
130 20: Rgb { r: 46, g: 198, b: 198 }
160 20: Rgb { r: 46, g: 198, b: 198 }

This PR compares the ic.index value to the full_cube mutable index variable instead of 16 + r + g + b. Using this method I was able to get consistent and accurate indexed_color results.