### PR TITLE
Fix invalid default config

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -1,10 +1,9 @@
 # Configuration for Alacritty, the GPU enhanced terminal emulator.
 
-
 # Any items in the `env` entry below will be added as
 # environment variables. Some entries may override variables
 # set by alacritty itself.
-env:
+#env:
   # TERM variable
   #
   # This value is used to set the `$TERM` environment variable for
@@ -12,7 +11,7 @@ env:
   # check the local terminfo database and use 'alacritty' if it is
   # available, otherwise 'xterm-256color' is used.
   #
-  # TERM: xterm-256color
+  #TERM: xterm-256color
 
 window:
   # Window dimensions (changes require restart)

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -3,7 +3,7 @@
 # Any items in the `env` entry below will be added as
 # environment variables. Some entries may override variables
 # set by alacritty itself.
-env:
+#env:
   # TERM variable
   #
   # This value is used to set the `$TERM` environment variable for
@@ -11,7 +11,7 @@ env:
   # check the local terminfo database and use 'alacritty' if it is
   # available, otherwise 'xterm-256color' is used.
   #
-  # TERM: xterm-256color
+  #TERM: xterm-256color
 
 window:
   # Window dimensions (changes require restart)


### PR DESCRIPTION
Serde has problems deserializing yaml files which contain sections
without any values. Since the `TERM` setting has been removed recently,
the `env` section was completely empty leading to deserialization
errors.

To resolve this the `env` section has been commented-out by default, if
the user wants to set a variable, it is now necessary to uncomment that
section.

Some minor tweaks have also been made to the existing `TERM` comments,
to clearly indicate these are value examples instead of comments.