### PR TITLE
Fix rotation of selection below 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed erroneous results when using the `indexed_colors` config option
 - Fixed rendering cursors other than rectangular with the RustType backend
+- Selection memory leak and glitches in the alternate screen buffer
 
 ## Version 0.2.1
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -52,6 +52,18 @@ impl Ord for Point {
     }
 }
 
+impl From<Point<usize>> for Point<isize> {
+    fn from(point: Point<usize>) -> Self {
+        Point::new(point.line as isize, point.col)
+    }
+}
+
+impl From<Point<isize>> for Point<usize> {
+    fn from(point: Point<isize>) -> Self {
+        Point::new(point.line as usize, point.col)
+    }
+}
+
 /// A line
 ///
 /// Newtype to avoid passing values incorrectly

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -101,17 +101,17 @@ impl Selection {
     pub fn rotate(&mut self, offset: isize) {
         match *self {
             Selection::Simple { ref mut region } => {
-                region.start.point.line = region.start.point.line + offset;
-                region.end.point.line = region.end.point.line + offset;
+                region.start.point.line += offset;
+                region.end.point.line += offset;
             },
             Selection::Semantic { ref mut region } => {
-                region.start.line = region.start.line + offset;
-                region.end.line = region.end.line + offset;
+                region.start.line += offset;
+                region.end.line += offset;
             },
             Selection::Lines { ref mut region, ref mut initial_line } => {
-                region.start.line = region.start.line + offset;
-                region.end.line = region.end.line + offset;
-                *initial_line = *initial_line + offset;
+                region.start.line += offset;
+                region.end.line += offset;
+                *initial_line += offset;
             }
         }
     }
@@ -227,12 +227,6 @@ impl Selection {
             col: Column(0),
             line: initial_line
         };
-
-        // Clamp selection below viewport to visible region
-        if alt_screen && start.line < 0 {
-            start.line = 0;
-            start.col = cols - 1;
-        }
 
         // Now, expand lines based on where cursor started and ended.
         if region.start.line < region.end.line {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -218,7 +218,7 @@ impl Selection {
         }
 
         Some(Span {
-            cols: cols,
+            cols,
             front: start,
             tail: end,
             ty: SpanType::Inclusive,

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -973,8 +973,9 @@ impl Term {
             }
         }
 
+        let alt_screen = self.mode.contains(TermMode::ALT_SCREEN);
         let selection = self.grid.selection.clone()?;
-        let span = selection.to_span(self)?;
+        let span = selection.to_span(self, alt_screen)?;
 
         let mut res = String::new();
 
@@ -1058,8 +1059,9 @@ impl Term {
         config: &'b Config,
         window_focused: bool,
     ) -> RenderableCellsIter {
+        let alt_screen = self.mode.contains(TermMode::ALT_SCREEN);
         let selection = self.grid.selection.as_ref()
-            .and_then(|s| s.to_span(self))
+            .and_then(|s| s.to_span(self, alt_screen))
             .map(|span| {
                 span.to_locations()
             });


### PR DESCRIPTION
Whenever the viewport is scrolled, the selection is rotated to make sure
that it moves with the viewport. However this did not correctly handle
the underflow that happens when the selection goes below 0.

This resolves that problem for the selection by moving the internal line
representation to an isize, thus correctly keeping track of the
selection start/end points even when they have a negative index. Once
the selection is converted to a span, the lines are clamped to the
visible region.

This fixes #1640 and fixes #1643.

Note that this currently breaks semantic and line selection because
the necessary adjustments to handle `isize`s haven't been made in their
span methods yet. This should be fairly simple, however opening a
temporary PR here should prevent unnecessary duplicated effort.