### PR TITLE
Add support for rendering cursors to rusttype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed erroneous results when using the `indexed_colors` config option
-- Fixed rendering cursors other than rectangular with the RustType backend.
+- Fixed rendering cursors other than rectangular with the RustType backend
 
 ## Version 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed erroneous results when using the `indexed_colors` config option
+- Fixed rendering cursors other than rectangular with the RustType backend.
 
 ## Version 0.2.1
 

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -240,7 +240,12 @@ selection:
 
 hide_cursor_when_typing: false
 
-# - Beam
+# Cursor style
+#
+# Values for 'cursor_style':
+#   - Block
+#   - Underline
+#   - Beam
 cursor_style: Block
 
 # Whether the cursor should be a hollow block on window focus loss

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -83,10 +83,17 @@ impl ::Rasterize for RustTypeRasterizer {
                 let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
 
                 return if glyph_key.c == super::BEAM_CURSOR_CHAR {
-                    super::get_beam_cursor_glyph((metrics.line_height + metrics.descent as f64) as i32, metrics.line_height as i32, metrics.average_advance as i32)
+                    super::get_beam_cursor_glyph(
+                        (metrics.line_height + metrics.descent as f64).round() as i32,
+                        metrics.line_height.round() as i32,
+                        metrics.average_advance.round() as i32
+                    )
                 } else {
-                    // FIXME: This is not quite aligned with the normal rectangle cursor
-                    super::get_box_cursor_glyph((metrics.line_height + metrics.descent as f64) as i32, metrics.line_height as i32, metrics.average_advance as i32)
+                    super::get_box_cursor_glyph(
+                        (metrics.line_height + metrics.descent as f64).round() as i32,
+                        metrics.line_height.round() as i32,
+                        metrics.average_advance.round() as i32
+                    )
                 };
 
             }

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -75,27 +75,26 @@ impl ::Rasterize for RustTypeRasterizer {
         match glyph_key.c {
             super::UNDERLINE_CURSOR_CHAR => {
                 let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
-
                 return super::get_underline_cursor_glyph(metrics.descent as i32, metrics.average_advance as i32);
 
-            },
+            }
+            super::BEAM_CURSOR_CHAR => {
+                let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
+
+                return super::get_beam_cursor_glyph(
+                    (metrics.line_height + f64::from(metrics.descent)).round() as i32,
+                    metrics.line_height.round() as i32,
+                    metrics.average_advance.round() as i32
+                );
+            }
             super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
                 let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
 
-                return if glyph_key.c == super::BEAM_CURSOR_CHAR {
-                    super::get_beam_cursor_glyph(
-                        (metrics.line_height + metrics.descent as f64).round() as i32,
-                        metrics.line_height.round() as i32,
-                        metrics.average_advance.round() as i32
-                    )
-                } else {
-                    super::get_box_cursor_glyph(
-                        (metrics.line_height + metrics.descent as f64).round() as i32,
-                        metrics.line_height.round() as i32,
-                        metrics.average_advance.round() as i32
-                    )
-                };
-
+                return super::get_box_cursor_glyph(
+                    (metrics.line_height + f64::from(metrics.descent)).round() as i32,
+                    metrics.line_height.round() as i32,
+                    metrics.average_advance.round() as i32
+                );
             }
             _ => ()
         }

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -76,7 +76,6 @@ impl ::Rasterize for RustTypeRasterizer {
             super::UNDERLINE_CURSOR_CHAR => {
                 let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
                 return super::get_underline_cursor_glyph(metrics.descent as i32, metrics.average_advance as i32);
-
             }
             super::BEAM_CURSOR_CHAR => {
                 let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
@@ -87,7 +86,7 @@ impl ::Rasterize for RustTypeRasterizer {
                     metrics.average_advance.round() as i32
                 );
             }
-            super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
+            super::BOX_CURSOR_CHAR => {
                 let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
 
                 return super::get_box_cursor_glyph(

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -72,6 +72,27 @@ impl ::Rasterize for RustTypeRasterizer {
     }
 
     fn get_glyph(&mut self, glyph_key: GlyphKey) -> Result<RasterizedGlyph, Error> {
+        match glyph_key.c {
+            super::UNDERLINE_CURSOR_CHAR => {
+                let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
+
+                return super::get_underline_cursor_glyph(metrics.descent as i32, metrics.average_advance as i32);
+
+            },
+            super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
+                let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
+
+                return if glyph_key.c == super::BEAM_CURSOR_CHAR {
+                    super::get_beam_cursor_glyph((metrics.line_height + metrics.descent as f64) as i32, metrics.line_height as i32, metrics.average_advance as i32)
+                } else {
+                    // FIXME: This is not quite aligned with the normal rectangle cursor
+                    super::get_box_cursor_glyph((metrics.line_height + metrics.descent as f64) as i32, metrics.line_height as i32, metrics.average_advance as i32)
+                };
+
+            }
+            _ => ()
+        }
+
         let scaled_glyph = self.fonts[glyph_key.font_key.token as usize]
             .glyph(glyph_key.c)
             .ok_or(Error::MissingGlyph)?


### PR DESCRIPTION
This implements the alternative cursors for the rusttype backend which were missed in the initial implementation.

I was going to change the way these are generated to make it more obvious but:
* I'm lazy
* Font-kit should invalidate most of this work anyway

Fixes https://github.com/jwilm/alacritty/issues/1676