### PR TITLE
Adjust font sizes for changing device pixel ratios

### DIFF
--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -81,7 +81,6 @@ impl Descriptor {
 pub struct Rasterizer {
     fonts: HashMap<FontKey, Font>,
     keys: HashMap<(FontDesc, Size), FontKey>,
-    device_pixel_ratio: f32,
     use_thin_strokes: bool,
 }
 
@@ -128,12 +127,10 @@ impl ::std::fmt::Display for Error {
 impl ::Rasterize for Rasterizer {
     type Err = Error;
 
-    fn new(device_pixel_ratio: f32, use_thin_strokes: bool) -> Result<Rasterizer, Error> {
-        info!("device_pixel_ratio: {}", device_pixel_ratio);
+    fn new(use_thin_strokes: bool) -> Result<Rasterizer, Error> {
         Ok(Rasterizer {
             fonts: HashMap::new(),
             keys: HashMap::new(),
-            device_pixel_ratio,
             use_thin_strokes,
         })
     }
@@ -197,7 +194,7 @@ impl Rasterizer {
         for descriptor in descriptors {
             if descriptor.style_name == style {
                 // Found the font we want
-                let scaled_size = f64::from(size.as_f32_pts()) * f64::from(self.device_pixel_ratio);
+                let scaled_size = f64::from(size.as_f32_pts());
                 let font = descriptor.to_font(scaled_size, true);
                 return Ok(font);
             }
@@ -221,7 +218,7 @@ impl Rasterizer {
             Slant::Normal => false,
             _ => true,
         };
-        let scaled_size = f64::from(size.as_f32_pts()) * f64::from(self.device_pixel_ratio);
+        let scaled_size = f64::from(size.as_f32_pts());
 
         let descriptors = descriptors_for_family(&desc.name[..]);
         for descriptor in descriptors {
@@ -250,7 +247,7 @@ impl Rasterizer {
         glyph: GlyphKey,
         font: &Font,
     ) -> Option<Result<RasterizedGlyph, Error>> {
-        let scaled_size = self.device_pixel_ratio * glyph.size.as_f32_pts();
+        let scaled_size = glyph.size.as_f32_pts();
         font.get_glyph(glyph.c, f64::from(scaled_size), self.use_thin_strokes)
             .map(|r| Some(Ok(r)))
             .unwrap_or_else(|e| match e {
@@ -258,7 +255,6 @@ impl Rasterizer {
                 _ => Some(Err(e)),
             })
     }
-
 }
 
 /// Specifies the intended rendering orientation of the font for obtaining glyph metrics

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -63,7 +63,6 @@ pub struct FreeTypeRasterizer {
     faces: HashMap<FontKey, Face>,
     library: Library,
     keys: HashMap<PathBuf, FontKey>,
-    device_pixel_ratio: f32,
 }
 
 #[inline]
@@ -74,14 +73,13 @@ fn to_freetype_26_6(f: f32) -> isize {
 impl ::Rasterize for FreeTypeRasterizer {
     type Err = Error;
 
-    fn new(device_pixel_ratio: f32, _: bool) -> Result<FreeTypeRasterizer, Error> {
+    fn new(_: bool) -> Result<FreeTypeRasterizer, Error> {
         let library = Library::init()?;
 
         Ok(FreeTypeRasterizer {
             faces: HashMap::new(),
             keys: HashMap::new(),
             library,
-            device_pixel_ratio,
         })
     }
 
@@ -144,7 +142,7 @@ impl FreeTypeRasterizer {
     /// Load a font face according to `FontDesc`
     fn get_face(&mut self, desc: &FontDesc, size: Size) -> Result<FontKey, Error> {
         // Adjust for DPI
-        let size = Size::new(size.as_f32_pts() * self.device_pixel_ratio * 96. / 72.);
+        let size = Size::new(size.as_f32_pts() * 96. / 72.);
 
         match desc.style {
             Style::Description { slant, weight } => {
@@ -335,7 +333,7 @@ impl FreeTypeRasterizer {
 
         let size = face.non_scalable.as_ref()
             .map(|v| v.pixelsize as f32)
-            .unwrap_or_else(|| glyph_key.size.as_f32_pts() * self.device_pixel_ratio * 96. / 72.);
+            .unwrap_or_else(|| glyph_key.size.as_f32_pts() * 96. / 72.);
 
         face.ft_face.set_char_size(to_freetype_26_6(size), 0, 0, 0)?;
 

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -217,6 +217,14 @@ impl ::std::ops::Add for Size {
     }
 }
 
+impl ::std::ops::Mul<f32> for Size {
+    type Output = Size;
+
+    fn mul(self, other: f32) -> Size {
+        Size(self.0 * other as i16)
+    }
+}
+
 pub struct RasterizedGlyph {
     pub c: char,
     pub width: i32,
@@ -343,7 +351,7 @@ pub trait Rasterize {
     type Err: ::std::error::Error + Send + Sync + 'static;
 
     /// Create a new Rasterizer
-    fn new(device_pixel_ratio: f32, use_thin_strokes: bool) -> Result<Self, Self::Err>
+    fn new(use_thin_strokes: bool) -> Result<Self, Self::Err>
     where
         Self: Sized;
 

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -8,7 +8,6 @@ use super::{FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph, Size, Slant, 
 
 pub struct RustTypeRasterizer {
     fonts: Vec<rusttype::Font<'static>>,
-    dpi_ratio: f32,
 }
 
 impl ::Rasterize for RustTypeRasterizer {
@@ -21,7 +20,7 @@ impl ::Rasterize for RustTypeRasterizer {
     }
 
     fn metrics(&self, key: FontKey, size: Size) -> Result<Metrics, Error> {
-        let scale = Scale::uniform(size.as_f32_pts() * self.dpi_ratio * 96. / 72.);
+        let scale = Scale::uniform(size.as_f32_pts() * 96. / 72.);
         let vmetrics = self.fonts[key.token as usize].v_metrics(scale);
         let hmetrics = self.fonts[key.token as usize]
             .glyph(
@@ -75,7 +74,7 @@ impl ::Rasterize for RustTypeRasterizer {
             .glyph(glyph_key.c)
             .ok_or(Error::MissingGlyph)?
             .scaled(Scale::uniform(
-                glyph_key.size.as_f32_pts() * self.dpi_ratio * 96. / 72.,
+                glyph_key.size.as_f32_pts() * 96. / 72.,
             ));
 
         let glyph = scaled_glyph.positioned(point(0.0, 0.0));

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -14,10 +14,9 @@ pub struct RustTypeRasterizer {
 impl ::Rasterize for RustTypeRasterizer {
     type Err = Error;
 
-    fn new(device_pixel_ratio: f32, _: bool) -> Result<RustTypeRasterizer, Error> {
+    fn new(_: bool) -> Result<RustTypeRasterizer, Error> {
         Ok(RustTypeRasterizer {
             fonts: Vec::new(),
-            dpi_ratio: device_pixel_ratio,
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,7 @@ fn run(mut config: Config, options: &cli::Options) -> Result<(), Box<Error>> {
     // Need the Rc<RefCell<_>> here since a ref is shared in the resize callback
     let mut processor = event::Processor::new(
         event_loop::Notifier(event_loop.channel()),
-        display.resize_channel(),
+        display.message_channel(),
         options,
         &config,
         options.ref_test,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -287,6 +287,7 @@ impl GlyphCache {
                 loader.load_glyph(&rasterized)
         })
     }
+
     pub fn update_font_size<L: LoadGlyph>(
         &mut self,
         font: &config::Font,
@@ -301,7 +302,7 @@ impl GlyphCache {
         let font = font.to_owned().with_size(size);
         info!("Font size changed: {:?}", font.size);
         let (regular, bold, italic) = Self::compute_font_keys(&font, &mut self.rasterizer)?;
-      
+
         self.rasterizer.get_glyph(GlyphKey { font_key: regular, c: 'm', size: font.size() })?;
         let metrics = self.rasterizer.metrics(regular, size)?;
 


### PR DESCRIPTION
This fixes an issue if you move an Alacritty terminal from an external (non-"retina") monitor plugged into a MacBook to its main display, which has double the pixel density. It uses an event from glutin to respond to this change.

To make it work, I removed any references to device pixel ratio from the font handling code (GlyphCache / Rasterizer) and I simply multiply the font size by the new device ratio. This is because originally, glyphs rendered at 2x pixel density would be cached under their original font size. I feel like this makes those font classes a little more honest about what they're caching.