### PR TITLE
Add cargo workspace, add winpty tests to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,4 @@ script:
   - if [ -n "$CLIPPY" ]; then cargo clippy --all-features --all-targets; fi
   - if [ -z "$CLIPPY" ]; then cargo test; fi
   - if [ -z "$CLIPPY" ]; then cargo test -p font; fi
+  - if [ "$TRAVIS_OS_NAME" == "windows" ]; then cp target/debug/winpty-agent.exe target/debug/deps && cargo test -p winpty; fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "named_pipe"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,7 +2622,9 @@ name = "winpty"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "named_pipe 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winpty-sys 1.1.0 (git+https://github.com/zacps/winpty?branch=rust)",
 ]
 
@@ -2847,6 +2858,7 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
+"checksum named_pipe 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ed10a5ac4f5f7e5d75552b12c1d5d542debca81e573279dd1e4c19fde6efa6d"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ description = "GPU-accelerated terminal emulator"
 readme = "README.md"
 homepage = "https://github.com/jwilm/alacritty"
 
+[workspace]
+members = [
+    "font",
+    "copypasta",
+    "winpty"
+]
+
 [[bin]]
 doc = false
 path = "src/main.rs"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,10 +43,13 @@ before_test:
     )
 
 test_script:
-  - if [%CLIPPY%] == [true] (
-      cargo %RUST_TOOLCHAIN% clippy
-    ) else (
-      cargo %RUST_TOOLCHAIN% test
+  - if [%CLIPPY%]==[true] (
+      cargo +%RUST_TOOLCHAIN% clippy
+    )
+    else (
+      cargo +%RUST_TOOLCHAIN% test &
+      copy target\debug\winpty-agent.exe target\debug\deps &
+      cargo +%RUST_TOOLCHAIN% test -p winpty
     )
 
 cache:

--- a/winpty/src/lib.rs
+++ b/winpty/src/lib.rs
@@ -356,8 +356,6 @@ mod tests {
     use self::named_pipe::PipeClient;
     use self::winapi::um::processthreadsapi::OpenProcess;
     use self::winapi::um::winnt::READ_CONTROL;
-    
-    use std::ptr::null_mut;
 
     use {Config, ConfigFlags, SpawnConfig, SpawnFlags, Winpty};
 
@@ -443,6 +441,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     // Test that each id returned by cosole_process_list points to an actual process
     fn console_process_list_valid() {
         let mut winpty = Winpty::open(
@@ -470,7 +469,7 @@ mod tests {
                     *id as u32
                 )
             };
-            assert!(handle != null_mut());
+            assert!(!handle.is_null());
         });
     }
 }


### PR DESCRIPTION
This adds the local dependencies (`font`, `copypasta`, `winpty`) to a workspace (required for winpty's test deps), and runs those tests in CI.

I also had to ignore the `console_process_list` test because of https://github.com/rprichard/winpty/issues/135. The function isn't actually used in Alacritty proper so it's not a big issue.