### PR TITLE
Relax matching of URL modifiers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,17 @@ pub struct Url {
     pub modifiers: ModifiersState,
 }
 
+impl Url {
+    // Make sure that modifiers in the config are always present,
+    // but ignore surplus modifiers.
+    pub fn mods_match_relaxed(&self, mods: ModifiersState) -> bool {
+        !((self.modifiers.shift && !mods.shift)
+            || (self.modifiers.ctrl && !mods.ctrl)
+            || (self.modifiers.alt && !mods.alt)
+            || (self.modifiers.logo && !mods.logo))
+    }
+}
+
 fn deserialize_modifiers<'a, D>(deserializer: D) -> ::std::result::Result<ModifiersState, D::Error>
     where D: de::Deserializer<'a>
 {

--- a/src/input.rs
+++ b/src/input.rs
@@ -520,7 +520,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
     // Spawn URL launcher when clicking on URLs
     fn launch_url(&self, modifiers: ModifiersState) -> Option<()> {
-        if modifiers != self.mouse_config.url.modifiers || self.ctx.mouse().block_url_launcher {
+        if !self.mouse_config.url.mods_match_relaxed(modifiers)
+            || self.ctx.mouse().block_url_launcher
+        {
             return None;
         }
 


### PR DESCRIPTION
To click on links in the alternate screen buffer, it is necessary that
the `shift` button is held down, otherwise mouse events are captured by
the application. However this would also require that `Shift` is added
to the `mouse.url.modifiers` option. Thus it is not possible anymore to
click on URLs unless the shift button is always held down.

To resolve this issue, the matching od modifiers has been relaxed. If a
modifier is specified in the config, it is always required to be held
down. However if a modifier is held down which is not specified, it is
still accpeted. This one-way relaxed matching allows clicking on links
with or without shift held down without having to make use of the
`mouse.url.modifiers` setting at all.

I'll leave this issue open for a bit just in case any other problems
should come up while testing URL selection. Until then just changing
the configuration file to include `Shift` should work.