### PR TITLE
WIP: Reenable dynamic title support on windows

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -312,9 +312,6 @@ impl Window {
     /// Set the window title
     #[inline]
     pub fn set_title(&self, _title: &str) {
-        // Because winpty doesn't know anything about OSC escapes this gets set to an empty
-        // string on windows
-        #[cfg(not(windows))]
         self.window.set_title(_title);
     }
 


### PR DESCRIPTION
It turns out there were no issues with dynamic title support on windows,
I simply had an issue with my configuration which made me think it was
broken.

Fixes https://github.com/jwilm/alacritty/issues/1695