### PR TITLE
Fix for an underflow on some type conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extra padding is not evenly spread around the terminal by default anymore
 
+### Fixed
+
+- Fixed a bad type conversion which could cause underflow on a window resize
+
 ## Version 0.2.3
 
 ### Fixed

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -865,8 +865,8 @@ impl SizeInfo {
         let line = Line(y.saturating_sub(self.padding_y as usize) / (self.cell_height as usize));
 
         Point {
-            line: min(line, self.lines()),
-            col: min(col, self.cols())
+            line: min(line, Line(self.lines().saturating_sub(1))),
+            col: min(col, Column(self.cols().saturating_sub(1)))
         }
     }
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -865,8 +865,8 @@ impl SizeInfo {
         let line = Line(y.saturating_sub(self.padding_y as usize) / (self.cell_height as usize));
 
         Point {
-            line: min(line, self.lines() - 1),
-            col: min(col, self.cols() - 1)
+            line: min(line, self.lines()),
+            col: min(col, self.cols())
         }
     }
 }

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -276,8 +276,9 @@ impl<'a> EventedReadWrite for Pty<'a, NamedPipe, NamedPipe> {
 
 impl<'a> OnResize for Winpty<'a> {
     fn on_resize(&mut self, sizeinfo: &SizeInfo) {
-        if sizeinfo.cols().0 > 0 && sizeinfo.lines().0 > 0 {
-            self.set_size(sizeinfo.cols().0, sizeinfo.lines().0)
+        let (cols, lines) = (sizeinfo.cols().0 as u16, sizeinfo.lines().0 as u16);
+        if cols > 0 && lines > 0 {
+            self.set_size(cols, lines)
                 .unwrap_or_else(|_| info!("Unable to set winpty size, did it die?"));
         }
     }

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -19,6 +19,7 @@ use std::os::windows::io::{FromRawHandle, IntoRawHandle};
 use std::os::windows::fs::OpenOptionsExt;
 use std::env;
 use std::cell::UnsafeCell;
+use std::u16;
 
 use dunce::canonicalize;
 use mio;
@@ -276,9 +277,9 @@ impl<'a> EventedReadWrite for Pty<'a, NamedPipe, NamedPipe> {
 
 impl<'a> OnResize for Winpty<'a> {
     fn on_resize(&mut self, sizeinfo: &SizeInfo) {
-        let (cols, lines) = (sizeinfo.cols().0 as u16, sizeinfo.lines().0 as u16);
-        if cols > 0 && lines > 0 {
-            self.set_size(cols, lines)
+        let (cols, lines) = (sizeinfo.cols().0, sizeinfo.lines().0);
+        if cols > 0 && cols <= u16::MAX as usize && lines > 0 && lines <= u16::MAX as usize {
+            self.set_size(cols as u16, lines as u16)
                 .unwrap_or_else(|_| info!("Unable to set winpty size, did it die?"));
         }
     }

--- a/winpty/src/windows.rs
+++ b/winpty/src/windows.rs
@@ -201,7 +201,7 @@ impl<'a, 'b> Winpty<'a> {
     /// Change the size of the Windows console window.
     /// 
     /// cols & rows MUST be greater than 0
-    pub fn set_size(&mut self, cols: usize, rows: usize) -> Result<(), Err> {
+    pub fn set_size(&mut self, cols: u16, rows: u16) -> Result<(), Err> {
         assert!(cols > 0 && rows > 0);
         let mut err = null_mut() as *mut winpty_error_t;
 

--- a/winpty/src/windows.rs
+++ b/winpty/src/windows.rs
@@ -206,7 +206,7 @@ impl<'a, 'b> Winpty<'a> {
         let mut err = null_mut() as *mut winpty_error_t;
 
         unsafe {
-            winpty_set_size(self.0, cols as i32, rows as i32, &mut err);
+            winpty_set_size(self.0, i32::from(cols), i32::from(rows), &mut err);
         }
 
         if let Some(err) = check_err(err) {


### PR DESCRIPTION
This changes the winpty resize logic to ensure we'll back out in the bindings if we get passed an invalid value rather than passing it on.

It also fixes the cause of the underflow in the logic for converting calculating the `lines`, `cols` from `SizeInfo`. I'm not sure if it was like that intentionally but I haven't observed any breakage from this change.

Fixes https://github.com/jwilm/alacritty/issues/1669