### PR TITLE
Instructions for installing on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ xbps-install alacritty
 emerge x11-terms/alacritty
 ```
 
+### FreeBSD
+```sh
+pkg install alacritty
+```
+
 ### Windows
 
 Prebuilt binaries can be downloaded from the artifacts section of [appveyor](https://ci.appveyor.com/project/jwilm/alacritty).


### PR DESCRIPTION
Readd instructions for how to install pre-compiled alacritty packages on
FreeBSD.  This was accidentaly removed in cb6e065.