### PR TITLE
Fix default hollow cursor behavior with empty conf

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1206,12 +1206,21 @@ fn deserialize_color_index<'a, D>(deserializer: D) -> ::std::result::Result<u8, 
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, Deserialize)]
+#[derive(Copy, Clone, Debug, Deserialize)]
 pub struct Cursor {
     #[serde(default, deserialize_with = "failure_default")]
     pub style: CursorStyle,
     #[serde(default="true_bool", deserialize_with = "default_true_bool")]
     pub unfocused_hollow: bool,
+}
+
+impl Default for Cursor {
+    fn default() -> Self {
+        Self {
+            style: Default::default(),
+            unfocused_hollow: true,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, Default, Deserialize)]


### PR DESCRIPTION
The `2c37da48b580237ff48f5e841015134dd459b41d` change introduced some
changes to the way cursor configuration is handled. However it did not
properly handle the default behavior of the hollow cursor when the
`cursor` field was not specified at all.

By implementing the `Default` trait for the `Cursor` struct in
`config.rs` manually, the default value of the `unfocused_hollow` field
has been corrected back to `true` when the `cursor` struct isn't present
at all.