### PR TITLE
Remove re-export of glutin size types

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -18,8 +18,8 @@ use std::sync::mpsc;
 use std::f64;
 
 use parking_lot::MutexGuard;
+use glutin::dpi::{LogicalPosition, PhysicalSize};
 
-use {LogicalPosition, PhysicalSize, Rgb};
 use cli;
 use config::Config;
 use font::{self, Rasterize};
@@ -27,9 +27,8 @@ use meter::Meter;
 use renderer::{self, GlyphCache, QuadRenderer};
 use term::{Term, SizeInfo, RenderableCell};
 use sync::FairMutex;
-
 use window::{self, Window};
-
+use Rgb;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/event.rs
+++ b/src/event.rs
@@ -23,7 +23,7 @@ use term::{Term, SizeInfo, TermMode, Search};
 use util::limit;
 use util::fmt::Red;
 use window::Window;
-use PhysicalSize;
+use glutin::dpi::PhysicalSize;
 
 /// Byte sequences are sent to a `Notify` in response to some events
 pub trait Notify {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,6 @@ use std::ops::Mul;
 pub use grid::Grid;
 pub use term::Term;
 
-/// Re-export size and position types from glutin/winit
-pub use glutin::dpi::{PhysicalSize,LogicalSize,LogicalPosition,PhysicalPosition};
-
 /// Facade around [winit's `MouseCursor`](glutin::MouseCursor)
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum MouseCursor {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -28,10 +28,11 @@ use gl::types::*;
 use gl;
 use index::{Column, Line, RangeInclusive};
 use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
+use Rgb;
 
 use config::{self, Config, Delta};
 use term::{self, cell, RenderableCell};
-use {PhysicalSize, Rgb};
+use glutin::dpi::PhysicalSize;
 
 // Shader paths for live reload
 static TEXT_SHADER_F_PATH: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/res/text.f.glsl");

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,12 +24,11 @@ use glutin::{
     self, ContextBuilder, ControlFlow, Event, EventsLoop,
     MouseCursor as GlutinMouseCursor, WindowBuilder,
 };
-
-use {LogicalPosition, LogicalSize, MouseCursor, PhysicalSize};
-
+use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 
 use cli::Options;
 use config::{Decorations, WindowConfig};
+use MouseCursor;
 
 #[cfg(windows)]
 static WINDOW_ICON: &'static [u8] = include_bytes!("../assets/windows/alacritty.ico");


### PR DESCRIPTION
This is a follow-up to #1403, since it seems like I've only pushed to my local version instead of also pushing to mkeeler's branch.

This is only a code-style improvement regarding the re-exports of glutin types in Alacritty's src/lib.rs.