### PR TITLE
Bump version number to v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Version 0.2.2
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 build = "build.rs"

--- a/alacritty.man
+++ b/alacritty.man
@@ -1,4 +1,4 @@
-.TH ALACRITTY "1" "August 2018" "alacritty 0.2.1" "User Commands"
+.TH ALACRITTY "1" "August 2018" "alacritty 0.2.2" "User Commands"
 .SH NAME
 alacritty \- a cross-platform, gpu-accelerated terminal emulator
 .SH "SYNOPSIS"

--- a/assets/osx/Alacritty.app/Contents/Info.plist
+++ b/assets/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.1</string>
+  <string>0.2.2</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: alacritty # you probably want to 'snapcraft register <name>'
-version: '0.2.1' # just for humans, typically '1.2+git' or '1.3.2'
+version: '0.2.2' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Modern, GPU accelerated terminal emulator # 79 char long summary
 description: |
   Modern, GPU accelerated terminal emulator


### PR DESCRIPTION
Since the last version bump has been a while ago. The glutin PR merge seems like an appropriate time to bump the version number again.

I also want to give https://github.com/jwilm/alacritty/pull/1188 a bit more time and testing before merging it. So I'd advise bumping the version number first.

Fixes https://github.com/jwilm/alacritty/issues/1732.