### PR TITLE
Set env variables before window start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resizing of windows without decorations
 - On Wayland, key repetition works again
 - On macOS, Alacritty will now use the integrated GPU again when available
+- On Linux, the `WINIT_HIDPI_FACTOR` environment variable can be set from the config now
 
 ## Version 0.2.1
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ extern crate dirs;
 use std::error::Error;
 use std::sync::Arc;
 
+#[cfg(target_os = "macos")]
+use std::env;
+
 #[cfg(not(windows))]
 use std::os::unix::io::AsRawFd;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,6 @@ extern crate dirs;
 use std::error::Error;
 use std::sync::Arc;
 
-#[cfg(target_os = "macos")]
-use std::env;
-
 #[cfg(not(windows))]
 use std::os::unix::io::AsRawFd;
 
@@ -115,6 +112,9 @@ fn run(mut config: Config, options: &cli::Options) -> Result<(), Box<Error>> {
     if let Some(config_path) = config.path() {
         info!("Configuration loaded from {}", config_path.display());
     };
+
+    // Set environment variables
+    tty::setup_env(&config);
 
     // Create a display.
     //


### PR DESCRIPTION
The environment variables specified in the configuration file are now
all set before the window is created. As a result, this makes it
possible to add the `WINIT_HIDPI_FACTOR` env variable directly to the
Alacritty configuration.

This fixes https://github.com/jwilm/alacritty/issues/1768.