### PR TITLE
Fix failing github releases

### DIFF
--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -57,7 +57,7 @@ fi
 
 # Convert and add manpage if it changed
 if [ -n "$(git diff $prev_tag HEAD alacritty.man)" ]; then
-    gzip -z "./alacritty.man" > "./target/deploy/alacritty.1.gz"
+    gzip -c "./alacritty.man" > "./target/deploy/alacritty.1.gz"
 fi
 
 # Offer extra files if they changed


### PR DESCRIPTION
The manpage was incorrectly zipped up with the `-z` option, which
doesn't exist and created a 0-size file. Since Github does not accept
0-size files, this lead to the complete release deployment failing.

Changing this to use the `-c` option should fix this problem by creating
a proper non-zero size gzip file.