### PR TITLE
Add option for dynamic padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Mouse cursor alignment issues and truncated last line caused by incorrect padding calculations
 
+### Added
+
+- Configuration option for evenly spreading padding is now available (`window.dynamic_padding`)
+
 ## Version 0.2.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Option for evenly spreading extra padding around the terminal (`window.dynamic_padding`)
+
+### Changed
+
+- Extra padding is not evenly spread around the terminal by default anymore
+
 ## Version 0.2.3
 
 ### Fixed
 
 - Mouse cursor alignment issues and truncated last line caused by incorrect padding calculations
-
-### Added
-
-- Configuration option for evenly spreading padding is now available (`window.dynamic_padding`)
 
 ## Version 0.2.2
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -30,7 +30,7 @@ window:
     y: 2
 
   # Spread additional padding evenly around the terminal content.
-  dynamic_padding: true
+  dynamic_padding: false
 
   # Window decorations
   #

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -29,6 +29,9 @@ window:
     x: 2
     y: 2
 
+  # Spread additional padding evenly around the terminal content.
+  dynamic_padding: true
+
   # Window decorations
   #
   # Values for `decorations`:

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -29,6 +29,9 @@ window:
     x: 2
     y: 2
 
+  # Spread additional padding evenly around the terminal content.
+  dynamic_padding: true
+
   # Window decorations
   #
   # Available values:

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -30,7 +30,7 @@ window:
     y: 2
 
   # Spread additional padding evenly around the terminal content.
-  dynamic_padding: true
+  dynamic_padding: false
 
   # Window decorations
   #

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -30,7 +30,7 @@ window:
     y: 2
 
   # Spread additional padding evenly around the terminal content.
-  dynamic_padding: true
+  dynamic_padding: false
 
   # Window decorations
   #

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -29,6 +29,9 @@ window:
     x: 2
     y: 2
 
+  # Spread additional padding evenly around the terminal content.
+  dynamic_padding: true
+
   # Window decorations
   #
   # Values for `decorations`:

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,6 +376,10 @@ pub struct WindowConfig {
     /// Draw the window with title bar / borders
     #[serde(default)]
     decorations: Decorations,
+
+    /// Spread out additional padding evenly
+    #[serde(default="true_bool", deserialize_with = "default_true_bool")]
+    dynamic_padding: bool,
 }
 
 fn default_padding() -> Delta<u8> {
@@ -398,6 +402,10 @@ impl WindowConfig {
     pub fn decorations(&self) -> Decorations {
         self.decorations
     }
+
+    pub fn dynamic_padding(&self) -> bool {
+        self.dynamic_padding
+    }
 }
 
 impl Default for WindowConfig {
@@ -406,6 +414,7 @@ impl Default for WindowConfig {
             dimensions: Default::default(),
             padding: default_padding(),
             decorations: Default::default(),
+            dynamic_padding: true,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -414,7 +414,7 @@ impl Default for WindowConfig {
             dimensions: Default::default(),
             padding: default_padding(),
             decorations: Default::default(),
-            dynamic_padding: true,
+            dynamic_padding: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -378,7 +378,7 @@ pub struct WindowConfig {
     decorations: Decorations,
 
     /// Spread out additional padding evenly
-    #[serde(default="true_bool", deserialize_with = "default_true_bool")]
+    #[serde(default, deserialize_with = "failure_default")]
     dynamic_padding: bool,
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -152,17 +152,13 @@ impl Display {
         let dimensions = options.dimensions()
             .unwrap_or_else(|| config.dimensions());
 
-        let mut padding_x = f64::from(config.padding().x) * dpr;
-        let mut padding_y = f64::from(config.padding().y) * dpr;
+        let mut padding_x = (f64::from(config.padding().x) * dpr).floor();
+        let mut padding_y = (f64::from(config.padding().y) * dpr).floor();
 
-        // TODO: Refactor this block to be a bit nicer
         if dimensions.columns_u32() > 0 && dimensions.lines_u32() > 0 {
             // Calculate new size based on cols/lines specified in config
             let width = cell_width as u32 * dimensions.columns_u32();
             let height = cell_height as u32 * dimensions.lines_u32();
-
-            padding_x = padding_x.floor();
-            padding_y = padding_y.floor();
 
             viewport_size = PhysicalSize::new(
                 f64::from(width) + 2. * padding_x,
@@ -174,9 +170,6 @@ impl Display {
             let ch = f64::from(cell_height);
             padding_x = (padding_x + (viewport_size.width - 2. * padding_x) % cw / 2.).floor();
             padding_y = (padding_y + (viewport_size.height - 2. * padding_y) % ch / 2.).floor();
-        } else {
-            padding_x = padding_x.floor();
-            padding_y = padding_y.floor();
         }
 
         window.set_inner_size(viewport_size.to_logical(dpr));

--- a/src/display.rs
+++ b/src/display.rs
@@ -155,6 +155,7 @@ impl Display {
         let mut padding_x = f64::from(config.padding().x) * dpr;
         let mut padding_y = f64::from(config.padding().y) * dpr;
 
+        // TODO: Refactor this block to be a bit nicer
         if dimensions.columns_u32() > 0 && dimensions.lines_u32() > 0 {
             // Calculate new size based on cols/lines specified in config
             let width = cell_width as u32 * dimensions.columns_u32();
@@ -167,12 +168,15 @@ impl Display {
                 f64::from(width) + 2. * padding_x,
                 f64::from(height) + 2. * padding_y,
             );
-        } else {
+        } else if config.window().dynamic_padding() {
             // Make sure additional padding is spread evenly
             let cw = f64::from(cell_width);
             let ch = f64::from(cell_height);
             padding_x = (padding_x + (viewport_size.width - 2. * padding_x) % cw / 2.).floor();
             padding_y = (padding_y + (viewport_size.height - 2. * padding_y) % ch / 2.).floor();
+        } else {
+            padding_x = padding_x.floor();
+            padding_y = padding_y.floor();
         }
 
         window.set_inner_size(viewport_size.to_logical(dpr));
@@ -331,8 +335,12 @@ impl Display {
 
             let mut padding_x = f32::from(config.padding().x) * dpr as f32;
             let mut padding_y = f32::from(config.padding().y) * dpr as f32;
-            padding_x = (padding_x + ((width - 2. * padding_x) % cell_width) / 2.).floor();
-            padding_y = (padding_y + ((height - 2. * padding_y) % cell_height) / 2.).floor();
+
+            if config.window().dynamic_padding() {
+                padding_x = (padding_x + ((width - 2. * padding_x) % cell_width) / 2.).floor();
+                padding_y = (padding_y + ((height - 2. * padding_y) % cell_height) / 2.).floor();
+            }
+
             self.size_info.padding_x = padding_x;
             self.size_info.padding_y = padding_y;
 


### PR DESCRIPTION
This adds the `window.dynamic_padding` option which allows disabling the
dynamic spread of additional padding around the grid's content.

This fixes #1778.

I'm not quite sure yet if this should be `true` or `false` by default. If someone
has an opinion on this, please leave a comment here.