### PR TITLE
Fix i386 CI releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ rust:
 
 matrix:
   fast_finish: true
+  include:
+    - if: tag IS present
+      os: linux
+      rust: stable
+      env: ARCH=i386
   allow_failures:
     - rust: nightly
     - os: windows

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -25,31 +25,34 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     make dmg
     mv "./target/release/osx/Alacritty.dmg" "./target/deploy/${name}.dmg"
 elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    cargo install cargo-deb
+    docker pull undeadleech/alacritty-ubuntu
+    docker pull undeadleech/alacritty-ubuntu-i386
 
     # x86_64
-    docker pull undeadleech/alacritty-ubuntu
     docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu \
         /root/.cargo/bin/cargo build --release --manifest-path /source/Cargo.toml
     sudo chown -R $USER:$USER "./target"
     tar -cvzf "./target/deploy/${name}-x86_64.tar.gz" -C "./target/release/" "alacritty"
 
     # x86_64 deb
-    DEB=$(cargo deb --no-build)
-    mv "$DEB" "./target/deploy/${name}_amd64.deb"
+    sudo docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu \
+        sh -c "cd /source && /root/.cargo/bin/cargo deb"
+    sudo chown -R $USER:$USER "./target"
+    mv "./target/debian/*.deb" "./target/deploy/${name}_amd64.deb"
 
     rm -rf "./target/release"
 
     # i386
-    docker pull undeadleech/alacritty-ubuntu-i386
-    docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu \
+    docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu-i386 \
         /root/.cargo/bin/cargo build --release --manifest-path /source/Cargo.toml
     sudo chown -R $USER:$USER "./target"
     tar -cvzf "./target/deploy/${name}-i386.tar.gz" -C "./target/release/" "alacritty"
 
     # i386 deb
-    DEB=$(cargo deb --no-build)
-    mv "$DEB" "./target/deploy/${name}_i386.deb"
+    sudo docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu-i386 \
+        sh -c "cd /source && /root/.cargo/bin/cargo deb"
+    sudo chown -R $USER:$USER "./target"
+    mv "./target/debian/*.deb" "./target/deploy/${name}_amd64.deb"
 elif [ "$TRAVIS_OS_NAME" == "windows" ]; then
     mv "./target/release/alacritty.exe" "./target/deploy/${name}.exe"
     mv "./target/release/winpty-agent.exe" "./target/deploy/winpty-agent.exe"

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -24,35 +24,36 @@ name="Alacritty-${TRAVIS_TAG}"
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     make dmg
     mv "./target/release/osx/Alacritty.dmg" "./target/deploy/${name}.dmg"
-elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
+elif [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$ARCH" != "i386" ]; then
     docker pull undeadleech/alacritty-ubuntu
-    docker pull undeadleech/alacritty-ubuntu-i386
 
     # x86_64
     docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu \
         /root/.cargo/bin/cargo build --release --manifest-path /source/Cargo.toml
-    sudo chown -R $USER:$USER "./target"
     tar -cvzf "./target/deploy/${name}-x86_64.tar.gz" -C "./target/release/" "alacritty"
 
     # x86_64 deb
-    sudo docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu \
-        sh -c "cd /source && /root/.cargo/bin/cargo deb"
-    sudo chown -R $USER:$USER "./target"
-    mv "./target/debian/*.deb" "./target/deploy/${name}_amd64.deb"
+    docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu \
+        sh -c "cd /source && \
+        /root/.cargo/bin/cargo deb --no-build --output ./target/deploy/${name}_amd64.deb"
 
-    rm -rf "./target/release"
+    # Make sure all files can be uploaded without permission errors
+    sudo chown -R $USER:$USER "./target"
+elif [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$ARCH" == "i386" ]; then
+    docker pull undeadleech/alacritty-ubuntu-i386
 
     # i386
     docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu-i386 \
         /root/.cargo/bin/cargo build --release --manifest-path /source/Cargo.toml
-    sudo chown -R $USER:$USER "./target"
     tar -cvzf "./target/deploy/${name}-i386.tar.gz" -C "./target/release/" "alacritty"
 
     # i386 deb
-    sudo docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu-i386 \
-        sh -c "cd /source && /root/.cargo/bin/cargo deb"
+    docker run -v "$(pwd):/source" undeadleech/alacritty-ubuntu-i386 \
+        sh -c "cd /source && \
+        /root/.cargo/bin/cargo deb --no-build --output ./target/deploy/${name}_i386.deb"
+
+    # Make sure all files can be uploaded without permission errors
     sudo chown -R $USER:$USER "./target"
-    mv "./target/debian/*.deb" "./target/deploy/${name}_amd64.deb"
 elif [ "$TRAVIS_OS_NAME" == "windows" ]; then
     mv "./target/release/alacritty.exe" "./target/deploy/${name}.exe"
     mv "./target/release/winpty-agent.exe" "./target/deploy/winpty-agent.exe"

--- a/ci/i386/Dockerfile
+++ b/ci/i386/Dockerfile
@@ -6,3 +6,4 @@ RUN apt-get update && apt-get install -y cmake libfreetype6-dev libfontconfig1-d
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN /root/.cargo/bin/rustup default stable-i686-unknown-linux-gnu
+RUN /root/.cargo/bin/cargo install cargo-deb

--- a/ci/x86_64/Dockerfile
+++ b/ci/x86_64/Dockerfile
@@ -5,3 +5,4 @@ ENV USER root
 RUN apt-get update && apt-get install -y cmake libfreetype6-dev libfontconfig1-dev curl
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN /root/.cargo/bin/cargo install cargo-deb


### PR DESCRIPTION
The i386 CI releases were still using x86_64 platforms for building the
output binaries, as a result the produced binaries did not work properly
on i386 systems.

This fixes #1786.