### PR TITLE
Add homebrew option for macOS installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pkg install alacritty
 brew cask install alacritty
 ```
 
-Note: See the relevant installation instructions to install Alacritty's [manual page](INSTALL.md#manual-page), [shell completions](INSTALL.md#shell-completions), and [Terminfo](INSTALL.md#terminfo).
+Once the cask is installed, it is recommended to setup the [manual page](INSTALL.md#manual-page), [shell completions](INSTALL.md#shell-completions), and [terminfo definitions](INSTALL.md#terminfo).
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ emerge x11-terms/alacritty
 pkg install alacritty
 ```
 
+### macOS
+
+```sh
+brew cask install alacritty
+```
+
 ### Other
 
 Prebuilt binaries for Linux, macOS, and Windows can be downloaded from the [GitHub releases page](https://github.com/jwilm/alacritty/releases).

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ pkg install alacritty
 brew cask install alacritty
 ```
 
+Note: See the relevant installation instructions to install Alacritty's [manual page](INSTALL.md#manual-page), [shell completions](INSTALL.md#shell-completions), and [Terminfo](INSTALL.md#terminfo).
+
 ### Other
 
 Prebuilt binaries for Linux, macOS, and Windows can be downloaded from the [GitHub releases page](https://github.com/jwilm/alacritty/releases).


### PR DESCRIPTION
There is a [maintained Homebrew formula](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/alacritty.rb) that should be a preferred method of installation for macOS users. 

I did not include details about the Homebrew package manager, as this is a resource that I would imagine most macOS users interested in Alacritty would already know about, but a dependency link would be an easy addition.