### PR TITLE
Add keybinding action for clearing warns/errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Option for evenly spreading extra padding around the terminal (`window.dynamic_padding`)
+- Display notice about errors and warnings inside Alacritty
+- Log all messages to both stderr and a log file in the system's temporary directory
+- New configuration option `persistent_logging` and CLI flag `--persistent-logging`,
+    for keeping the log file after closing Alacritty
+- `ClearLogNotice` action for removing the warning and error message
 
 ### Changed
 
@@ -31,11 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `mouse.url.modifiers` option to specify keyboard modifiers for opening URLs on click
 - Binaries for macOS, Windows and Debian-based systems are now published with GitHub releases
 - The keys F16-F24 have been added as options for key bindings
-- Display notice about errors and warnings inside Alacritty
-- Log all messages to both stderr and a log file in the system's temporary directory
-- New configuration option `persistent_logging` and CLI flag `--persistent-logging`,
-    for keeping the log file after closing Alacritty
-- `ClearLogNotice` action for removing the warning and error message
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log all messages to both stderr and a log file in the system's temporary directory
 - New configuration option `persistent_logging` and CLI flag `--persistent-logging`,
     for keeping the log file after closing Alacritty
+- `ClearLogNotice` action for removing the warning and error message
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -375,6 +375,7 @@ live_config_reload: true
 #   - ClearHistory
 #   - Hide
 #   - Quit
+#   - ClearLogNotice
 #
 # Values for `command`:
 #   The `command` field must be a map containing a `program` string and
@@ -399,6 +400,8 @@ key_bindings:
   - { key: Key0,     mods: Control, action: ResetFontSize                }
   - { key: Equals,   mods: Control, action: IncreaseFontSize             }
   - { key: Subtract, mods: Control, action: DecreaseFontSize             }
+  - { key: L,        mods: Control, action: ClearLogNotice               }
+  - { key: L,        mods: Control, chars: "\x0c"                        }
   - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }
   - { key: Home,                    chars: "\x1b[H",   mode: ~AppCursor  }
   - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -366,6 +366,7 @@ live_config_reload: true
 #   - ClearHistory
 #   - Hide
 #   - Quit
+#   - ClearLogNotice
 #
 # Values for `command`:
 #   The `command` field must be a map containing a `program` string and
@@ -396,6 +397,8 @@ key_bindings:
   - { key: Minus,    mods: Command, action: DecreaseFontSize             }
   - { key: K,        mods: Command, action: ClearHistory                 }
   - { key: K,        mods: Command, chars: "\x0c"                        }
+  - { key: L,        mods: Control, action: ClearLogNotice               }
+  - { key: L,        mods: Control, chars: "\x0c"                        }
   - { key: PageUp,   mods: Shift,   chars: "\x1b[5;2~"                   }
   - { key: PageUp,   mods: Control, chars: "\x1b[5;5~"                   }
   - { key: PageUp,                  chars: "\x1b[5~"                     }

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -343,6 +343,7 @@ shell:
 #   - ClearHistory
 #   - Hide
 #   - Quit
+#   - ClearLogNotice
 #
 # Values for `command`:
 #   The `command` field must be a map containing a `program` string and
@@ -365,6 +366,8 @@ key_bindings:
   - { key: Key0,     mods: Control, action: ResetFontSize                }
   - { key: Equals,   mods: Control, action: IncreaseFontSize             }
   - { key: Subtract, mods: Control, action: DecreaseFontSize             }
+  - { key: L,        mods: Control, action: ClearLogNotice               }
+  - { key: L,        mods: Control, chars: "\x0c"                        }
   - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }
   - { key: Home,                    chars: "\x1b[H",   mode: ~AppCursor  }
   - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }

--- a/src/config.rs
+++ b/src/config.rs
@@ -746,7 +746,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.write_str("Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, \
                             ResetFontSize, ScrollPageUp, ScrollPageDown, ScrollToTop, \
-                            ScrollToBottom, ClearHistory, Hide, or Quit")
+                            ScrollToBottom, ClearHistory, Hide, ClearLogNotice or Quit")
             }
 
             fn visit_str<E>(self, value: &str) -> ::std::result::Result<ActionWrapper, E>
@@ -766,6 +766,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
                     "ClearHistory" => Action::ClearHistory,
                     "Hide" => Action::Hide,
                     "Quit" => Action::Quit,
+                    "ClearLogNotice" => Action::ClearLogNotice,
                     _ => return Err(E::invalid_value(Unexpected::Str(value), &self)),
                 }))
             }

--- a/src/event.rs
+++ b/src/event.rs
@@ -171,6 +171,11 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     fn hide_window(&mut self) {
         self.window_changes.hide = true;
     }
+
+    #[inline]
+    fn clear_log(&mut self) {
+        self.terminal.clear_log();
+    }
 }
 
 /// The ActionContext can't really have direct access to the Window

--- a/src/input.rs
+++ b/src/input.rs
@@ -76,6 +76,7 @@ pub trait ActionContext {
     fn clear_history(&mut self);
     fn hide_window(&mut self);
     fn url(&self, _: Point<usize>) -> Option<String>;
+    fn clear_log(&mut self);
 }
 
 /// Describes a state and action to take in that state
@@ -200,6 +201,9 @@ pub enum Action {
 
     /// Quits Alacritty.
     Quit,
+
+    /// Clears warning and error notices.
+    ClearLogNotice,
 }
 
 impl Action {
@@ -292,6 +296,9 @@ impl Action {
             Action::ClearHistory => {
                 ctx.clear_history();
             },
+            Action::ClearLogNotice => {
+                ctx.clear_log();
+            }
         }
     }
 
@@ -885,6 +892,7 @@ mod tests {
         }
         fn hide_window(&mut self) {
         }
+        fn clear_log(&mut self) {}
     }
 
     macro_rules! test_clickstate {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -877,6 +877,14 @@ impl Term {
         &self.grid.selection
     }
 
+    /// Clear displayed errors and warnings.
+    pub fn clear_log(&mut self) {
+        if let Some(ref mut logger_proxy) = self.logger_proxy {
+            logger_proxy.clear();
+        }
+    }
+
+
     pub fn selection_mut(&mut self) -> &mut Option<Selection> {
         &mut self.grid.selection
     }
@@ -1831,11 +1839,7 @@ impl ansi::Handler for Term {
                 }
             },
             ansi::ClearMode::All => {
-                // Clear displayed errors and warnings
-                if let Some(ref mut logger_proxy) = self.logger_proxy {
-                    logger_proxy.clear();
-                }
-
+                self.clear_log();
                 self.grid.region_mut(..).each(|c| c.reset(&template));
             },
             ansi::ClearMode::Above => {


### PR DESCRIPTION
Since running `clear` inside of tmux doesn't actually clear any part of
the screen, but just resets the scrolling region, the warning and error
notices can't be removed without quitting tmux or Alacritty.

As a solution, a new action `ClearLogNotice` has been added which has
been bound to Ctrl+L by default. As a result, Ctrl+L can be used inside
of tmux to remove the messages, even though tmux doesn't clear the
screen.

This fixes #1811.