### PR TITLE
Remove `scale_with_dpi` setting from config

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -121,12 +121,6 @@ font:
     x: 0
     y: 0
 
-  # Scale the font size based on the monitor's DPI. This will lead to bigger text on HiDPI
-  # screens and make reading text a little easier.
-  # On X11 it is possible to change the DPI for each instance of alacritty by using
-  # `WINIT_HIDPI_FACTOR=1.0 alacritty` to scale the font.
-  scale_with_dpi: true
-
 # Display the time it takes to redraw each frame.
 render_timer: false
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1894,16 +1894,10 @@ fn deserialize_scale_with_dpi<'a, D>(deserializer: D) -> ::std::result::Result<O
 where
     D: de::Deserializer<'a>,
 {
-    use ::util::fmt;
     // This is necessary in order to get serde to complete deserialization of the configuration
     let _ignored = bool::deserialize(deserializer);
-    eprintln!(
-        "{}",
-        fmt::Yellow(
-            "The `scale_with_dpi` setting has been removed, \
-             on X11 the WINIT_HIDPI_FACTOR environment variable can be used instead."
-        )
-    );
+    error!("The `scale_with_dpi` setting has been removed, \
+            on X11 the WINIT_HIDPI_FACTOR environment variable can be used instead.");
     Ok(None)
 }
 


### PR DESCRIPTION
Since the `scale_with_dpi` setting has been deprecated, but it hasn't
been removed from the config, Alacritty would print an error every time
it is started.

To resolve this problem, the option is removed from the default
configuration file.