### PR TITLE
Deduplicated font faces with yaml anchors

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -92,19 +92,19 @@ tabspaces: 8
 font:
   # Normal (roman) font face
   normal:
-    family: monospace
+    family: &font_face Source Code Pro
     # The `style` can be specified to pick a specific face.
     #style: Regular
 
   # Bold font face
   bold:
-    family: monospace
+    family: *font_face
     # The `style` can be specified to pick a specific face.
     #style: Bold
 
   # Italic font face
   italic:
-    family: monospace
+    family: *font_face
     # The `style` can be specified to pick a specific face.
     #style: Italic
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -92,19 +92,19 @@ tabspaces: 8
 font:
   # Normal (roman) font face
   normal:
-    family: &font_face monospace
+    family: &font_family monospace
     # The `style` can be specified to pick a specific face.
     #style: Regular
 
   # Bold font face
   bold:
-    family: *font_face
+    family: *font_family
     # The `style` can be specified to pick a specific face.
     #style: Bold
 
   # Italic font face
   italic:
-    family: *font_face
+    family: *font_family
     # The `style` can be specified to pick a specific face.
     #style: Italic
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -92,7 +92,7 @@ tabspaces: 8
 font:
   # Normal (roman) font face
   normal:
-    family: &font_face Source Code Pro
+    family: &font_face monospace
     # The `style` can be specified to pick a specific face.
     #style: Regular
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -87,19 +87,19 @@ tabspaces: 8
 font:
   # Normal (roman) font face
   normal:
-    family: Menlo
+    family: &font_face Menlo
     # The `style` can be specified to pick a specific face.
     #style: Regular
 
   # Bold font face
   bold:
-    family: Menlo
+    family: *font_face
     # The `style` can be specified to pick a specific face.
     #style: Bold
 
   # Italic font face
   italic:
-    family: Menlo
+    family: *font_face
     # The `style` can be specified to pick a specific face.
     #style: Italic
 

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -87,19 +87,19 @@ tabspaces: 8
 font:
   # Normal (roman) font face
   normal:
-    family: &font_face Menlo
+    family: &font_family Menlo
     # The `style` can be specified to pick a specific face.
     #style: Regular
 
   # Bold font face
   bold:
-    family: *font_face
+    family: *font_family
     # The `style` can be specified to pick a specific face.
     #style: Bold
 
   # Italic font face
   italic:
-    family: *font_face
+    family: *font_family
     # The `style` can be specified to pick a specific face.
     #style: Italic
 

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -76,19 +76,19 @@ tabspaces: 8
 font:
   # Normal (roman) font face
   normal:
-    family: &font_face Consolas
+    family: &font_family Consolas
     # The `style` can be specified to pick a specific face.
     #style: Regular
 
   # Bold font face
   bold:
-    family: *font_face
+    family: *font_family
     # The `style` can be specified to pick a specific face.
     #style: Bold
 
   # Italic font face
   italic:
-    family: *font_face
+    family: *font_family
     # The `style` can be specified to pick a specific face.
     #style: Italic
 

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -76,19 +76,19 @@ tabspaces: 8
 font:
   # Normal (roman) font face
   normal:
-    family: Consolas
+    family: &font_face Consolas
     # The `style` can be specified to pick a specific face.
     #style: Regular
 
   # Bold font face
   bold:
-    family: Consolas
+    family: *font_face
     # The `style` can be specified to pick a specific face.
     #style: Bold
 
   # Italic font face
   italic:
-    family: Consolas
+    family: *font_face
     # The `style` can be specified to pick a specific face.
     #style: Italic
 


### PR DESCRIPTION
For all the font faces, deduplicated the different font face families by using a YAML anchor (example on [wikipedia](https://en.wikipedia.org/wiki/YAML#Advanced_components)). I haven't rerun the tests but it Works On My Machine™, which implies that it's being correctly handled by the (presumably cross platform) yaml parser. This change makes it easier to change your font face, since you only have to change it in one place.