### PR TITLE
feature: report Windows panics through MessageBox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New configuration field `visual_bell.color` allows changing the visual bell color
+- Crashes on Windows are now also reported with a popup in addition to stderr
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod input;
 pub mod locale;
 pub mod logging;
 pub mod meter;
+pub mod panic;
 pub mod renderer;
 pub mod selection;
 pub mod sync;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,15 @@ use alacritty::config::{self, Config, Error as ConfigError};
 use alacritty::display::Display;
 use alacritty::event_loop::{self, EventLoop, Msg};
 use alacritty::logging::{self, LoggerProxy};
+use alacritty::panic;
 use alacritty::sync::FairMutex;
 use alacritty::term::Term;
 use alacritty::tty::{self, process_should_exit};
 use alacritty::util::fmt::Red;
 
 fn main() {
+    panic::attach_handler();
+
     // When linked with the windows subsystem windows won't automatically attach
     // to the console of the parent process, so we do it explicitly. This fails
     // silently if the parent has no console.

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,53 @@
+// Copyright 2016 Joe Wilm, The Alacritty Project Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//! ANSI Terminal Stream Parsing
+
+// Use the default behavior of the other platforms.
+#[cfg(not(windows))]
+pub fn attach_handler() {}
+
+// Install a panic handler that renders the panic in a classical Windows error
+// dialog box as well as writes the panic to STDERR.
+#[cfg(windows)]
+pub fn attach_handler() {
+    use std::{io, io::Write, panic, ptr};
+    use winapi::um::winuser;
+
+    panic::set_hook(Box::new(|panic_info| {
+        let _ = writeln!(io::stderr(), "{}", panic_info);
+        let msg = format!("{}\n\nPress Ctrl-C to Copy", panic_info);
+        unsafe {
+            winuser::MessageBoxW(
+                ptr::null_mut(),
+                win32_string(&msg).as_ptr(),
+                win32_string("Alacritty: Runtime Error").as_ptr(),
+                winuser::MB_ICONERROR
+                    | winuser::MB_OK
+                    | winuser::MB_SETFOREGROUND
+                    | winuser::MB_TASKMODAL,
+            );
+        }
+    }));
+}
+
+// Converts the string slice into a Windows-standard representation for "W"-
+// suffixed function variants, which accept UTF-16 encoded string values.
+#[cfg(windows)]
+fn win32_string(value: &str) -> Vec<u16> {
+    use std::ffi::OsStr;
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+    OsStr::new(value).encode_wide().chain(once(0)).collect()
+}


### PR DESCRIPTION
Please go easy on me.  I am very new to Rust and haven't touched Win32 in —
let me check — 15 years.  Happy for whatever feedback you have.

This commit introduces a new module called `platform`, which provides
operating system and platform-level integration capability.  For now, it
targets Windows only.  It provides a panic handler that exposes such
events through the classical Win32 MessageBox facility, whereupon a user
can easily copy-and-paste the error for later forensic analysis and bug
reporting..

Why is this proposed?  In Issue #1818, I remarked that Alacritty in
Windows crashed unexpectedly since winpty was unable to find
`winpty-agent.exe`.  This error message was opaque and invisible, for I
had not started Alacritty itself from another terminal.  I reason that
few users of Alacritty on Windows would ever start a terminal from
another terminal, so it would be best to take a platform-idiomatic
approach of exposing the dialog box.