### PR TITLE
Add commandline flag --start-maximized, -m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Option for evenly spreading extra padding around the terminal (`window.dynamic_padding`)
-- New configuration option `window.start_maximized` and CLI flag `--start-maximized`/`-m`
+- New configuration option `window.start_maximized` and CLI flag `--start-maximized`,
     for maximizing alacritty on start
 - Display notice about errors and warnings inside Alacritty
 - Log all messages to both stderr and a log file in the system's temporary directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Option for evenly spreading extra padding around the terminal (`window.dynamic_padding`)
-- Option for maximizing alacritty on start (`window.start_maximized`)
+- New configuration option `window.start_maximized` and CLI flag `--start-maximized`/`-m`
+    for maximizing alacritty on start
 - Display notice about errors and warnings inside Alacritty
 - Log all messages to both stderr and a log file in the system's temporary directory
 - New configuration option `persistent_logging` and CLI flag `--persistent-logging`,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ pub struct Options {
     pub print_events: bool,
     pub ref_test: bool,
     pub dimensions: Option<Dimensions>,
+    pub start_maximized: Option<bool>,
     pub title: Option<String>,
     pub class: Option<String>,
     pub log_level: log::LevelFilter,
@@ -41,6 +42,7 @@ impl Default for Options {
             print_events: false,
             ref_test: false,
             dimensions: None,
+            start_maximized: None,
             title: None,
             class: None,
             log_level: log::LevelFilter::Warn,
@@ -82,6 +84,10 @@ impl Options {
                 .value_names(&["columns", "lines"])
                 .help("Defines the window dimensions. Falls back to size specified by \
                        window manager if set to 0x0 [default: 80x24]"))
+            .arg(Arg::with_name("start-maximized")
+                .long("start-maximized")
+                .short("m")
+                .help("Start window maximized. Overrides dimensions if set."))
             .arg(Arg::with_name("title")
                 .long("title")
                 .short("t")
@@ -146,6 +152,10 @@ impl Options {
             }
         }
 
+        if matches.is_present("start-maximized") {
+            options.start_maximized = Some(true);
+        }
+
         options.class = matches.value_of("class").map(|c| c.to_owned());
         options.title = matches.value_of("title").map(|t| t.to_owned());
 
@@ -184,6 +194,10 @@ impl Options {
 
     pub fn dimensions(&self) -> Option<Dimensions> {
         self.dimensions
+    }
+
+    pub fn start_maximized(&self) -> Option<bool> {
+        self.start_maximized
     }
 
     pub fn command(&self) -> Option<&Shell> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,7 +86,6 @@ impl Options {
                        window manager if set to 0x0 [default: 80x24]"))
             .arg(Arg::with_name("start-maximized")
                 .long("start-maximized")
-                .short("m")
                 .help("Start window maximized. Overrides dimensions if set."))
             .arg(Arg::with_name("title")
                 .long("title")

--- a/src/display.rs
+++ b/src/display.rs
@@ -161,7 +161,10 @@ impl Display {
         let mut padding_x = (f64::from(config.padding().x) * dpr).floor();
         let mut padding_y = (f64::from(config.padding().y) * dpr).floor();
 
-        if dimensions.columns_u32() > 0 && dimensions.lines_u32() > 0 {
+        let start_maximized = options.start_maximized()
+            .unwrap_or_else(|| config.window().start_maximized());
+
+        if !start_maximized && dimensions.columns_u32() > 0 && dimensions.lines_u32() > 0 {
             // Calculate new size based on cols/lines specified in config
             let width = cell_width as u32 * dimensions.columns_u32();
             let height = cell_height as u32 * dimensions.lines_u32();

--- a/src/window.rs
+++ b/src/window.rs
@@ -150,7 +150,7 @@ impl Window {
 
         let title = options.title.as_ref().map_or(DEFAULT_TITLE, |t| t);
         let class = options.class.as_ref().map_or(DEFAULT_TITLE, |c| c);
-        let start_maximized = options.start_maximized.unwrap_or(window_config.start_maximized());
+        let start_maximized = options.start_maximized.unwrap_or_else(|| window_config.start_maximized());
         let window_builder = Window::get_platform_window(title, start_maximized, window_config);
         let window_builder = Window::platform_builder_ext(window_builder, &class);
         let window = create_gl_window(window_builder.clone(), &event_loop, false)

--- a/src/window.rs
+++ b/src/window.rs
@@ -150,7 +150,8 @@ impl Window {
 
         let title = options.title.as_ref().map_or(DEFAULT_TITLE, |t| t);
         let class = options.class.as_ref().map_or(DEFAULT_TITLE, |c| c);
-        let window_builder = Window::get_platform_window(title, window_config);
+        let start_maximized = options.start_maximized.unwrap_or(window_config.start_maximized());
+        let window_builder = Window::get_platform_window(title, start_maximized, window_config);
         let window_builder = Window::platform_builder_ext(window_builder, &class);
         let window = create_gl_window(window_builder.clone(), &event_loop, false)
             .or_else(|_| create_gl_window(window_builder, &event_loop, true))?;
@@ -290,7 +291,7 @@ impl Window {
     }
 
     #[cfg(not(any(target_os = "macos", windows)))]
-    pub fn get_platform_window(title: &str, window_config: &WindowConfig) -> WindowBuilder {
+    pub fn get_platform_window(title: &str, start_maximized: bool, window_config: &WindowConfig) -> WindowBuilder {
         let decorations = match window_config.decorations() {
             Decorations::None => false,
             _ => true,
@@ -300,12 +301,12 @@ impl Window {
             .with_title(title)
             .with_visibility(false)
             .with_transparency(true)
-            .with_maximized(window_config.start_maximized())
+            .with_maximized(start_maximized)
             .with_decorations(decorations)
     }
 
     #[cfg(windows)]
-    pub fn get_platform_window(title: &str, window_config: &WindowConfig) -> WindowBuilder {
+    pub fn get_platform_window(title: &str, start_maximized: bool, window_config: &WindowConfig) -> WindowBuilder {
         let icon = Icon::from_bytes_with_format(WINDOW_ICON, ImageFormat::ICO).unwrap();
 
         let decorations = match window_config.decorations() {
@@ -318,19 +319,19 @@ impl Window {
             .with_visibility(cfg!(windows))
             .with_decorations(decorations)
             .with_transparency(true)
-            .with_maximized(window_config.start_maximized())
+            .with_maximized(start_maximized)
             .with_window_icon(Some(icon))
     }
 
     #[cfg(target_os = "macos")]
-    pub fn get_platform_window(title: &str, window_config: &WindowConfig) -> WindowBuilder {
+    pub fn get_platform_window(title: &str, start_maximized: bool, window_config: &WindowConfig) -> WindowBuilder {
         use glutin::os::macos::WindowBuilderExt;
 
         let window = WindowBuilder::new()
             .with_title(title)
             .with_visibility(false)
             .with_transparency(true)
-            .with_maximized(window_config.start_maximized());
+            .with_maximized(start_maximized);
 
         match window_config.decorations() {
             Decorations::Full => window,


### PR DESCRIPTION
This lets you pass in `--start-maximized` or `-m` as commandline flags.

1. Is this unnecessary clutter?
2. Should I wait until #1835 lands?
3. Is passing `start_maximized` into `get_platform_window` the cleanest way to do things?