### PR TITLE
Document that alacritty requires winpty-agent on windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -166,11 +166,8 @@ nix-shell -A alacritty '<nixpkgs>'
 
 #### Windows
 
-On windows you will need to have the `{architecture}-pc-windows-msvc` toolchain installed as well as [Clang 3.9 or greater](http://releases.llvm.org/download.html).
-
-Alacritty requires winpty on windows to emulate UNIX's PTY API. 
-The agent is a single binary (`winpty-agent.exe`) which MUST be in the same directory as `alacritty.exe`.
-It's included in binary releases and fetched by `build.rs` when compiled from source.
+On windows you will need to have the `{architecture}-pc-windows-msvc` toolchain
+installed as well as [Clang 3.9 or greater](http://releases.llvm.org/download.html).
 
 #### Other
 
@@ -179,7 +176,7 @@ filling in this section of the README.
 
 ## Building
 
-### Linux
+### Linux / Windows
 
 Once all the prerequisites are installed, compiling Alacritty should be easy:
 
@@ -188,6 +185,7 @@ cargo build --release
 ```
 
 If all goes well, this should place a binary at `target/release/alacritty`.
+On Windows this directory should also contain the `winpty-agent.exe`.
 
 #### Desktop Entry
 
@@ -230,7 +228,7 @@ To choose a default terminal app, use Debian's `update-alternatives`.
 
 ```sh
 update-alternatives --config x-terminal-emulator
-``` 
+```
 
 ## Manual Page
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -168,6 +168,10 @@ nix-shell -A alacritty '<nixpkgs>'
 
 On windows you will need to have the `{architecture}-pc-windows-msvc` toolchain installed as well as [Clang 3.9 or greater](http://releases.llvm.org/download.html).
 
+Alacritty requires winpty on windows to emulate UNIX's PTY API. 
+The agent is a single binary (`winpty-agent.exe`) which MUST be in the same directory as `alacritty.exe`.
+It's included in binary releases and fetched by `build.rs` when compiled from source.
+
 #### Other
 
 If you build Alacritty on another distribution, we would love some help

--- a/README.md
+++ b/README.md
@@ -79,11 +79,18 @@ nix-env -iA nixos.alacritty
 brew cask install alacritty
 ```
 
-Once the cask is installed, it is recommended to setup the [manual page](INSTALL.md#manual-page), [shell completions](INSTALL.md#shell-completions), and [terminfo definitions](INSTALL.md#terminfo).
+Once the cask is installed, it is recommended to setup the [manual page](INSTALL.md#manual-page),
+[shell completions](INSTALL.md#shell-completions), and [terminfo definitions](INSTALL.md#terminfo).
 
 ### Other
 
-Prebuilt binaries for Linux, macOS, and Windows can be downloaded from the [GitHub releases page](https://github.com/jwilm/alacritty/releases).
+Prebuilt binaries for Linux, macOS, and Windows can be downloaded from the
+[GitHub releases page](https://github.com/jwilm/alacritty/releases).
+
+To work properly on Windows, Alacritty requires winpty to emulate UNIX's PTY API.
+The agent is a single binary (`winpty-agent.exe`) which **must** be in the same
+directory as the Alacritty executable and is available through the
+[GitHub releases page](https://github.com/jwilm/alacritty/releases).
 
 ## Configuration
 

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -55,8 +55,9 @@ elif [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$ARCH" == "i386" ]; then
     # Make sure all files can be uploaded without permission errors
     sudo chown -R $USER:$USER "./target"
 elif [ "$TRAVIS_OS_NAME" == "windows" ]; then
-    mv "./target/release/alacritty.exe" "./target/deploy/${name}.exe"
-    mv "./target/release/winpty-agent.exe" "./target/deploy/winpty-agent.exe"
+    choco install 7zip
+    7z a -tzip "./target/deploy/${name}-windows.zip" "./target/release/alacritty.exe" \
+        "./target/release/winpty-agent.exe"
 fi
 
 # Convert and add manpage if it changed


### PR DESCRIPTION
I'm not sure this is the best place to put this information because it's only supposed to be for *from-source* builds, but this affects binary releases as well. I don't know if there's a better place to put it though.

Fixes https://github.com/jwilm/alacritty/issues/1818