### PR TITLE
Make windows config location more sensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved the Windows configuration location from %USERPROFILE%\alacritty.yml (usually) to %APPDATA%\Roaming\alacritty\alacritty.yml
+- Windows configuration location has been moved from %USERPROFILE\alacritty.yml
+    to %APPDATA%\Roaming\alacritty\alacritty.yml
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New configuration field `visual_bell.color` allows changing the visual bell color
 - Crashes on Windows are now also reported with a popup in addition to stderr
 
+### Changed
+
+- Moved the Windows configuration location from %USERPROFILE%\alacritty.yml (usually) to %APPDATA%\Roaming\alacritty\alacritty.yml
+
 ### Fixed
 
 - Fix color issue in ncurses programs by updating terminfo pairs from 0x10000 to 0x7FFF

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ winpty = { path = "./winpty" }
 mio-named-pipes = "0.1"
 winapi = { version = "0.3.5", features = ["winuser", "synchapi", "roerrorapi", "winerror"]}
 dunce = "0.1"
+dirs = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ file, please consult the comments in the default config file.
 
 On Windows the config file is located at:
 
-`%UserProfile%\alacritty.yml`
+`%APPDATA%\Roaming\alacritty\alacritty.yml`
 
 ## Issues (known, unknown, feature requests, etc.)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1521,44 +1521,52 @@ impl Config {
             .map(|path| path.into())
     }
 
+    // TODO: Remove old configuration location warning (Deprecated 03/12/2018)
     #[cfg(windows)]
     pub fn installed_config<'a>() -> Option<Cow<'a, Path>> {
-        #[allow(deprecated)]
-        let old = ::std::env::home_dir()
+        let old = dirs::home_dir()
             .map(|path| path.join("alacritty.yml"));
         let new = dirs::config_dir()
             .map(|path| path.join("alacritty\\alacritty.yml"));
-        // TODO: Remove old configuration location warning (Deprecated 03/12/2018)
-        if let Some(old) = old.as_ref().filter(|old| old.exists()) {
-            warn!(
-                "Found old configuration at: '{}'. The file should be moved to the new location: '{}'.", 
-                old.to_string_lossy(), 
-                new.as_ref().map(|new| new.to_string_lossy()).unwrap_or_else(|| Cow::from("(UNKNOWN)"))
-            );
-        }
 
-        new.filter(|new| new.exists()).map(Cow::from)
-            .or_else(|| old.filter(|old| old.exists()).map(Cow::from))
+        if let Some(old_path) = old.as_ref().filter(|old| old.exists()) {
+            warn!(
+                "Found configuration at: '{}'. The file should be moved to the new location: '{}'.",
+                old_path.to_string_lossy(),
+                new.as_ref().map(|new| new.to_string_lossy()).unwrap(),
+            );
+
+            old.map(Cow::from)
+        } else {
+            new.filter(|new| new.exists()).map(Cow::from)
+        }
     }
 
     #[cfg(not(windows))]
     pub fn write_defaults() -> io::Result<Cow<'static, Path>> {
-        let path = ::xdg::BaseDirectories::with_prefix("alacritty")
-            .map_err(|err| io::Error::new(io::ErrorKind::NotFound, ::std::error::Error::description(&err)))
+        let path = xdg::BaseDirectories::with_prefix("alacritty")
+            .map_err(|err| io::Error::new(io::ErrorKind::NotFound, err.to_string().as_str()))
             .and_then(|p| p.place_config_file("alacritty.yml"))?;
+
         File::create(&path)?.write_all(DEFAULT_ALACRITTY_CONFIG.as_bytes())?;
+
         Ok(path.into())
     }
 
     #[cfg(windows)]
     pub fn write_defaults() -> io::Result<Cow<'static, Path>> {
         let mut path = dirs::config_dir()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "could not find profile directory"))?;
-        if !path.exists() {
-            fs::create_dir(&path)?
-        }
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "could not find profile directory")
+            }
+        )?;
+
         path = path.join("alacritty/alacritty.yml");
+
+        fs::create_dir_all(&path)?;
+
         File::create(&path)?.write_all(DEFAULT_ALACRITTY_CONFIG.as_bytes())?;
+
         Ok(path.into())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1563,7 +1563,7 @@ impl Config {
 
         path = path.join("alacritty/alacritty.yml");
 
-        fs::create_dir_all(&path)?;
+        fs::create_dir_all(path.parent().unwrap())?;
 
         File::create(&path)?.write_all(DEFAULT_ALACRITTY_CONFIG.as_bytes())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ extern crate winpty;
 extern crate dunce;
 #[cfg(windows)]
 extern crate image;
+#[cfg(windows)]
+extern crate dirs;
 
 #[cfg(target_os = "macos")]
 #[macro_use]


### PR DESCRIPTION
Contrary to my initial idea this does *not* remove platform specific code, mostly because after dealing with fallbacks and supporting the old windows location it's not worth it.

This changes the configuration file location from (in fallback order):

* `%HOME%\alacritty.yml`
* `%USERPROFILE%\alacritty.yml`
* `GetUserProfileDirectory()\alacritty.yml`

To:

* `%APPDATA%\Roaming\alacritty\alacritty.yml`

If a configuration file is found in the old location a warning is emitted pointing to the new location.

Fixes https://github.com/jwilm/alacritty/issues/1660