### PR TITLE
Fix-#1833:Detach Child process to avoid zombie processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bad type conversion which could cause underflow on a window resize
 - Alacritty now spawns a login shell on macOS, as with Terminal.app and iTerm2
+- Fixed zombie processes sticking around after launching URLs
 
 ## Version 0.2.3
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -238,8 +238,8 @@ impl Action {
                 trace!("running command: {} {:?}", program, args);
 
                 match start_daemon(program, args) {
-                    Ok(child) => {
-                        debug!("spawned new proc with pid: {}", child.id());
+                    Ok(_) => {
+                        debug!("spawned new proc");
                     },
                     Err(err) => {
                         warn!("couldn't run command: {}", err);

--- a/src/input.rs
+++ b/src/input.rs
@@ -20,10 +20,7 @@
 //! determine what to do when a non-modifier key is pressed.
 use std::borrow::Cow;
 use std::mem;
-use std::process::Command;
 use std::time::Instant;
-#[cfg(not(windows))]
-use std::os::unix::process::CommandExt;
 
 use copypasta::{Clipboard, Load, Buffer as ClipboardBuffer};
 use glutin::{ElementState, MouseButton, TouchPhase, MouseScrollDelta, ModifiersState, KeyboardInput};
@@ -35,6 +32,7 @@ use index::{Line, Column, Side, Point};
 use term::SizeInfo;
 use term::mode::TermMode;
 use util::fmt::Red;
+use util::start_daemon;
 
 pub const FONT_SIZE_STEP: f32 = 0.5;
 
@@ -239,24 +237,7 @@ impl Action {
             Action::Command(ref program, ref args) => {
                 trace!("running command: {} {:?}", program, args);
 
-                #[cfg(not(windows))]
-                let spawned = Command::new(program)
-                    .args(args)
-                    .before_exec(|| {
-                        // Detach forked process from Alacritty. This will cause
-                        // init or whatever to clean up child processes for us.
-                        unsafe { ::libc::daemon(1, 0); }
-                        Ok(())
-                    })
-                    .spawn();
-
-                #[cfg(windows)]
-                let spawned = Command::new(program)
-                    .args(args)
-                    .spawn();
-
-                match spawned
-                {
+                match start_daemon(program, args) {
                     Ok(child) => {
                         debug!("spawned new proc with pid: {}", child.id());
                     },
@@ -557,30 +538,10 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         let mut args = launcher.args().to_vec();
         args.push(text);
 
-        #[cfg(not(windows))]
-        let _spawned = Command::new(launcher.program())
-                    .args(&args)
-                    .before_exec(|| {
-                        // Detach forked process from Alacritty. This will cause
-                        // init or whatever to clean up child processes for us.
-                        unsafe { ::libc::daemon(1, 0); }
-                        Ok(())
-                    })
-                    .spawn();
-        #[cfg(windows)]
-        let _spawned = Command::new(launcher.program())
-                    .args(&args)
-                    .spawn();
-
-        match _spawned
-                {
-                    Ok(child) => {
-                        debug!("spawned new proc with pid: {}", child.id());
-                    },
-                    Err(err) => {
-                        warn!("couldn't run command: {}", err);
-                    },
-                }
+        match start_daemon(launcher.program(), &args) {
+            Ok(_) => debug!("Launched: {} {:?}", launcher.program(), args),
+            Err(_) => warn!("Unable to launch: {} {:?}", launcher.program(), args),
+        }
 
         Some(())
     }


### PR DESCRIPTION
Attempts to fix #1833. While I am new to learning rust(Very new). I intend to use alacritty for a long time my attempt to give something back. So if I have done something wrong or something you would like to see added please let me know.