### PR TITLE
[travis] remove sudo keyword

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 
-sudo: required
 services:
   - docker
 


### PR DESCRIPTION
`sudo` keyword is obsolete, [reference](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).