### PR TITLE
Rust 2018, NLL fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 description = "GPU-accelerated terminal emulator"
 readme = "README.md"
 homepage = "https://github.com/jwilm/alacritty"
+edition = "2018"
 
 [workspace]
 members = [

--- a/build.rs
+++ b/build.rs
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #[cfg(windows)]
-extern crate embed_resource;
+use embed_resource;
 #[cfg(windows)]
-extern crate tempfile;
+use tempfile;
 #[cfg(windows)]
-extern crate reqwest;
+use reqwest;
 #[cfg(windows)]
-extern crate zip;
-
-extern crate gl_generator;
+use zip;
 
 use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
 

--- a/copypasta/src/lib.rs
+++ b/copypasta/src/lib.rs
@@ -85,4 +85,4 @@ pub use macos::{Clipboard, Error};
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub use windows::{Clipboard, Error};
+pub use crate::windows::{Clipboard, Error};

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -270,9 +270,7 @@ impl FreeTypeRasterizer {
     fn face_for_glyph(&mut self, glyph_key: GlyphKey, have_recursed: bool) -> Result<FontKey, Error> {
         let c = glyph_key.c;
 
-        let use_initial_face = if self.faces.contains_key(&glyph_key.font_key) {
-            // Get face and unwrap since we just checked for presence.
-            let face = &self.faces[&glyph_key.font_key];
+        let use_initial_face = if let Some(face) = self.faces.get(&glyph_key.font_key) {
             let index = face.ft_face.get_char_index(c as usize);
 
             index != 0 || have_recursed

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -58,7 +58,7 @@ pub use ft::{Error, FreeTypeRasterizer as Rasterizer};
 #[cfg(windows)]
 pub mod rusttype;
 #[cfg(windows)]
-pub use rusttype::{Error, RustTypeRasterizer as Rasterizer};
+pub use crate::rusttype::{Error, RustTypeRasterizer as Rasterizer};
 
 // If target is macos, reexport everything from darwin
 #[cfg(target_os = "macos")]
@@ -348,13 +348,13 @@ pub trait Rasterize {
         Self: Sized;
 
     /// Get `Metrics` for the given `FontKey`
-    fn metrics(&self, FontKey, Size) -> Result<Metrics, Self::Err>;
+    fn metrics(&self, _: FontKey, _: Size) -> Result<Metrics, Self::Err>;
 
     /// Load the font described by `FontDesc` and `Size`
-    fn load_font(&mut self, &FontDesc, Size) -> Result<FontKey, Self::Err>;
+    fn load_font(&mut self, _: &FontDesc, _: Size) -> Result<FontKey, Self::Err>;
 
     /// Rasterize the glyph described by `GlyphKey`.
-    fn get_glyph(&mut self, GlyphKey) -> Result<RasterizedGlyph, Self::Err>;
+    fn get_glyph(&mut self, _: GlyphKey) -> Result<RasterizedGlyph, Self::Err>;
 
     /// Update the Rasterizer's DPI factor
     fn update_dpr(&mut self, device_pixel_ratio: f32);

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -11,7 +11,7 @@ pub struct RustTypeRasterizer {
     dpi_ratio: f32,
 }
 
-impl ::Rasterize for RustTypeRasterizer {
+impl crate::Rasterize for RustTypeRasterizer {
     type Err = Error;
 
     fn new(device_pixel_ratio: f32, _: bool) -> Result<RustTypeRasterizer, Error> {

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -19,9 +19,9 @@ use std::str;
 
 use vte;
 use base64;
-use index::{Column, Line, Contains};
+use crate::index::{Column, Line, Contains};
 
-use ::{MouseCursor, Rgb};
+use crate::{MouseCursor, Rgb};
 
 // Parse color arguments
 //
@@ -176,10 +176,10 @@ pub trait TermInfo {
 /// writing specific handler impls for tests far easier.
 pub trait Handler {
     /// OSC to set window title
-    fn set_title(&mut self, &str) {}
+    fn set_title(&mut self, _: &str) {}
 
     /// Set the window's mouse cursor
-    fn set_mouse_cursor(&mut self, MouseCursor) {}
+    fn set_mouse_cursor(&mut self, _: MouseCursor) {}
 
     /// Set the cursor style
     fn set_cursor_style(&mut self, _: Option<CursorStyle>) {}
@@ -188,42 +188,42 @@ pub trait Handler {
     fn input(&mut self, _c: char) {}
 
     /// Set cursor to position
-    fn goto(&mut self, Line, Column) {}
+    fn goto(&mut self, _: Line, _: Column) {}
 
     /// Set cursor to specific row
-    fn goto_line(&mut self, Line) {}
+    fn goto_line(&mut self, _: Line) {}
 
     /// Set cursor to specific column
-    fn goto_col(&mut self, Column) {}
+    fn goto_col(&mut self, _: Column) {}
 
     /// Insert blank characters in current line starting from cursor
-    fn insert_blank(&mut self, Column) {}
+    fn insert_blank(&mut self, _: Column) {}
 
     /// Move cursor up `rows`
-    fn move_up(&mut self, Line) {}
+    fn move_up(&mut self, _: Line) {}
 
     /// Move cursor down `rows`
-    fn move_down(&mut self, Line) {}
+    fn move_down(&mut self, _: Line) {}
 
     /// Identify the terminal (should write back to the pty stream)
     ///
     /// TODO this should probably return an io::Result
-    fn identify_terminal<W: io::Write>(&mut self, &mut W) {}
+    fn identify_terminal<W: io::Write>(&mut self, _: &mut W) {}
 
     // Report device status
-    fn device_status<W: io::Write>(&mut self, &mut W, usize) {}
+    fn device_status<W: io::Write>(&mut self, _: &mut W, _: usize) {}
 
     /// Move cursor forward `cols`
-    fn move_forward(&mut self, Column) {}
+    fn move_forward(&mut self, _: Column) {}
 
     /// Move cursor backward `cols`
-    fn move_backward(&mut self, Column) {}
+    fn move_backward(&mut self, _: Column) {}
 
     /// Move cursor down `rows` and set to column 1
-    fn move_down_and_cr(&mut self, Line) {}
+    fn move_down_and_cr(&mut self, _: Line) {}
 
     /// Move cursor up `rows` and set to column 1
-    fn move_up_and_cr(&mut self, Line) {}
+    fn move_up_and_cr(&mut self, _: Line) {}
 
     /// Put `count` tabs
     fn put_tab(&mut self, _count: i64) {}
@@ -252,28 +252,28 @@ pub trait Handler {
     fn set_horizontal_tabstop(&mut self) {}
 
     /// Scroll up `rows` rows
-    fn scroll_up(&mut self, Line) {}
+    fn scroll_up(&mut self, _: Line) {}
 
     /// Scroll down `rows` rows
-    fn scroll_down(&mut self, Line) {}
+    fn scroll_down(&mut self, _: Line) {}
 
     /// Insert `count` blank lines
-    fn insert_blank_lines(&mut self, Line) {}
+    fn insert_blank_lines(&mut self, _: Line) {}
 
     /// Delete `count` lines
-    fn delete_lines(&mut self, Line) {}
+    fn delete_lines(&mut self, _: Line) {}
 
     /// Erase `count` chars in current line following cursor
     ///
     /// Erase means resetting to the default state (default colors, no content,
     /// no mode flags)
-    fn erase_chars(&mut self, Column) {}
+    fn erase_chars(&mut self, _: Column) {}
 
     /// Delete `count` chars
     ///
     /// Deleting a character is like the delete key on the keyboard - everything
     /// to the right of the deleted things is shifted left.
-    fn delete_chars(&mut self, Column) {}
+    fn delete_chars(&mut self, _: Column) {}
 
     /// Move backward `count` tabs
     fn move_backward_tabs(&mut self, _count: i64) {}
@@ -313,10 +313,10 @@ pub trait Handler {
     fn set_mode(&mut self, _mode: Mode) {}
 
     /// Unset mode
-    fn unset_mode(&mut self, Mode) {}
+    fn unset_mode(&mut self, _: Mode) {}
 
     /// DECSTBM - Set the terminal scrolling region
-    fn set_scrolling_region(&mut self, Range<Line>) {}
+    fn set_scrolling_region(&mut self, _: Range<Line>) {}
 
     /// DECKPAM - Set keypad to applications mode (ESCape instead of digits)
     fn set_keypad_application_mode(&mut self) {}
@@ -328,22 +328,22 @@ pub trait Handler {
     ///
     /// 'Invoke' one of G0 to G3 in the GL area. Also referred to as shift in,
     /// shift out and locking shift depending on the set being activated
-    fn set_active_charset(&mut self, CharsetIndex) {}
+    fn set_active_charset(&mut self, _: CharsetIndex) {}
 
     /// Assign a graphic character set to G0, G1, G2 or G3
     ///
     /// 'Designate' a graphic character set as one of G0 to G3, so that it can
     /// later be 'invoked' by `set_active_charset`
-    fn configure_charset(&mut self, CharsetIndex, StandardCharset) {}
+    fn configure_charset(&mut self, _: CharsetIndex, _: StandardCharset) {}
 
     /// Set an indexed color value
-    fn set_color(&mut self, usize, Rgb) {}
+    fn set_color(&mut self, _: usize, _: Rgb) {}
 
     /// Reset an indexed color to original value
-    fn reset_color(&mut self, usize) {}
+    fn reset_color(&mut self, _: usize) {}
 
     /// Set the clipboard
-    fn set_clipboard(&mut self, &str) {}
+    fn set_clipboard(&mut self, _: &str) {}
 
     /// Run the dectest routine
     fn dectest(&mut self) {}
@@ -1393,9 +1393,9 @@ pub mod C1 {
 #[cfg(test)]
 mod tests {
     use std::io;
-    use index::{Line, Column};
+    use crate::index::{Line, Column};
     use super::{Processor, Handler, Attr, TermInfo, Color, StandardCharset, CharsetIndex, parse_rgb_color, parse_number};
-    use ::Rgb;
+    use crate::Rgb;
 
     /// The /dev/null of `io::Write`
     struct Void;

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -112,7 +112,7 @@ struct ProcessorState {
 ///
 /// Processor creates a Performer when running advance and passes the Performer
 /// to `vte::Parser`.
-struct Performer<'a, H: Handler + TermInfo + 'a, W: io::Write + 'a> {
+struct Performer<'a, H: Handler + TermInfo, W: io::Write> {
     _state: &'a mut ProcessorState,
     handler: &'a mut H,
     writer: &'a mut W
@@ -1225,7 +1225,7 @@ fn parse_color(attrs: &[i64], i: &mut usize) -> Option<Color> {
                 *i += 2;
                 let idx = attrs[*i];
                 match idx {
-                    0 ... 255 => {
+                    0 ..= 255 => {
                         Some(Color::Indexed(idx as u8))
                     },
                     _ => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 extern crate log;
 use clap::{Arg, App};
-use index::{Line, Column};
-use config::{Dimensions, Shell};
-use window::{DEFAULT_TITLE, DEFAULT_CLASS};
+use crate::index::{Line, Column};
+use crate::config::{Dimensions, Shell};
+use crate::window::{DEFAULT_TITLE, DEFAULT_CLASS};
 use std::path::{Path, PathBuf};
 use std::borrow::Cow;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use ::log;
-use clap::{Arg, App};
+use clap::{Arg, App, crate_name, crate_version, crate_authors, crate_description};
+
 use crate::index::{Line, Column};
 use crate::config::{Dimensions, Shell};
 use crate::window::{DEFAULT_TITLE, DEFAULT_CLASS};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-extern crate log;
+use ::log;
 use clap::{Arg, App};
 use crate::index::{Line, Column};
 use crate::config::{Dimensions, Shell};
@@ -186,11 +186,11 @@ impl Options {
         self.dimensions
     }
 
-    pub fn command(&self) -> Option<&Shell> {
+    pub fn command(&self) -> Option<&Shell<'_>> {
         self.command.as_ref()
     }
 
-    pub fn config_path(&self) -> Option<Cow<Path>> {
+    pub fn config_path(&self) -> Option<Cow<'_, Path>> {
         self.config.as_ref().map(|p| Cow::Borrowed(p.as_path()))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -296,7 +296,7 @@ impl<'de> Deserialize<'de> for Decorations {
         impl<'de> Visitor<'de> for DecorationsVisitor {
             type Value = Decorations;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("Some subset of full|transparent|buttonless|none")
             }
 
@@ -709,7 +709,7 @@ impl<'a> de::Deserialize<'a> for ModsWrapper {
         impl<'a> Visitor<'a> for ModsVisitor {
             type Value = ModsWrapper;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("Some subset of Command|Shift|Super|Alt|Option|Control")
             }
 
@@ -752,7 +752,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
         impl<'a> Visitor<'a> for ActionVisitor {
             type Value = ActionWrapper;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, \
                             ResetFontSize, ScrollPageUp, ScrollPageDown, ScrollToTop, \
                             ScrollToBottom, ClearHistory, Hide, ClearLogNotice or Quit")
@@ -827,7 +827,7 @@ impl<'a> de::Deserialize<'a> for ModeWrapper {
         impl<'a> Visitor<'a> for ModeVisitor {
             type Value = ModeWrapper;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("Combination of AppCursor | AppKeypad, possibly with negation (~)")
             }
 
@@ -873,7 +873,7 @@ impl<'a> de::Deserialize<'a> for MouseButton {
         impl<'a> Visitor<'a> for MouseButtonVisitor {
             type Value = MouseButton;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("Left, Right, Middle, or a number")
             }
 
@@ -967,7 +967,7 @@ impl<'a> de::Deserialize<'a> for RawBinding {
                 impl<'a> Visitor<'a> for FieldVisitor {
                     type Value = Field;
 
-                    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                         f.write_str("binding fields")
                     }
 
@@ -995,7 +995,7 @@ impl<'a> de::Deserialize<'a> for RawBinding {
         impl<'a> Visitor<'a> for RawBindingVisitor {
             type Value = RawBinding;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("binding specification")
             }
 
@@ -1357,7 +1357,7 @@ fn rgb_from_hex<'a, D>(deserializer: D) -> ::std::result::Result<Rgb, D::Error>
     impl<'a> Visitor<'a> for RgbVisitor {
         type Value = Rgb;
 
-        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.write_str("Hex colors spec like 'ffaabb'")
         }
 
@@ -1416,7 +1416,7 @@ impl FromStr for Rgb {
 }
 
 impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::NotFound | Error::Empty => None,
             Error::ReadingEnvHome(ref err) => Some(err),
@@ -1437,7 +1437,7 @@ impl ::std::error::Error for Error {
 }
 
 impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Error::NotFound | Error::Empty => write!(f, "{}", ::std::error::Error::description(self)),
             Error::ReadingEnvHome(ref err) => {
@@ -1625,7 +1625,7 @@ impl Config {
             .map(|p| p.as_path())
     }
 
-    pub fn shell(&self) -> Option<&Shell> {
+    pub fn shell(&self) -> Option<&Shell<'_>> {
         self.shell.as_ref()
     }
 
@@ -1831,7 +1831,7 @@ impl DeserializeSize for Size {
         {
             type Value = f64;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("f64 or u64")
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 use std::collections::HashMap;
 
-use ::Rgb;
+use crate::Rgb;
 use font::Size;
 use serde_yaml;
 use serde::{self, de, Deserialize};
@@ -23,10 +23,10 @@ use notify::{Watcher, watcher, DebouncedEvent, RecursiveMode};
 
 use glutin::ModifiersState;
 
-use cli::Options;
-use input::{Action, Binding, MouseBinding, KeyBinding};
-use index::{Line, Column};
-use ansi::{CursorStyle, NamedColor, Color};
+use crate::cli::Options;
+use crate::input::{Action, Binding, MouseBinding, KeyBinding};
+use crate::index::{Line, Column};
+use crate::ansi::{CursorStyle, NamedColor, Color};
 
 const MAX_SCROLLBACK_LINES: u32 = 100_000;
 
@@ -735,10 +735,10 @@ impl<'a> de::Deserialize<'a> for ModsWrapper {
     }
 }
 
-struct ActionWrapper(::input::Action);
+struct ActionWrapper(crate::input::Action);
 
 impl ActionWrapper {
-    fn into_inner(self) -> ::input::Action {
+    fn into_inner(self) -> crate::input::Action {
         self.0
     }
 }
@@ -811,7 +811,7 @@ impl CommandWrapper {
     }
 }
 
-use ::term::{mode, TermMode};
+use crate::term::{mode, TermMode};
 
 struct ModeWrapper {
     pub mode: TermMode,
@@ -1008,7 +1008,7 @@ impl<'a> de::Deserialize<'a> for RawBinding {
                 let mut mods: Option<ModifiersState> = None;
                 let mut key: Option<Key> = None;
                 let mut chars: Option<String> = None;
-                let mut action: Option<::input::Action> = None;
+                let mut action: Option<crate::input::Action> = None;
                 let mut mode: Option<TermMode> = None;
                 let mut not_mode: Option<TermMode> = None;
                 let mut mouse: Option<::glutin::MouseButton> = None;
@@ -1812,7 +1812,7 @@ pub struct Delta<T: Default> {
 }
 
 trait DeserializeSize : Sized {
-    fn deserialize<'a, D>(D) -> ::std::result::Result<Self, D::Error>
+    fn deserialize<'a, D>(_: D) -> ::std::result::Result<Self, D::Error>
         where D: serde::de::Deserializer<'a>;
 }
 
@@ -2020,7 +2020,7 @@ pub trait OnConfigReload {
     fn on_config_reload(&mut self);
 }
 
-impl OnConfigReload for ::display::Notifier {
+impl OnConfigReload for crate::display::Notifier {
     fn on_config_reload(&mut self) {
         self.notify();
     }
@@ -2045,7 +2045,7 @@ impl Monitor {
         let (config_tx, config_rx) = mpsc::channel();
 
         Monitor {
-            _thread: ::util::thread::spawn_named("config watcher", move || {
+            _thread: crate::util::thread::spawn_named("config watcher", move || {
                 let (tx, rx) = mpsc::channel();
                 // The Duration argument is a debouncing period.
                 let mut watcher = watcher(tx, Duration::from_millis(10))
@@ -2088,7 +2088,7 @@ impl Monitor {
 
 #[cfg(test)]
 mod tests {
-    use cli::Options;
+    use crate::cli::Options;
     use super::Config;
 
     #[cfg(target_os="macos")]

--- a/src/display.rs
+++ b/src/display.rs
@@ -20,16 +20,16 @@ use std::f64;
 use parking_lot::MutexGuard;
 use glutin::dpi::{LogicalPosition, PhysicalSize};
 
-use cli;
-use config::Config;
+use crate::cli;
+use crate::config::Config;
 use font::{self, Rasterize};
-use meter::Meter;
-use renderer::{self, GlyphCache, QuadRenderer};
-use term::{Term, SizeInfo, RenderableCell};
-use sync::FairMutex;
-use window::{self, Window};
-use logging::LoggerProxy;
-use Rgb;
+use crate::meter::Meter;
+use crate::renderer::{self, GlyphCache, QuadRenderer};
+use crate::term::{Term, SizeInfo, RenderableCell};
+use crate::sync::FairMutex;
+use crate::window::{self, Window};
+use crate::logging::LoggerProxy;
+use crate::Rgb;
 
 #[derive(Debug)]
 pub enum Error {
@@ -476,8 +476,8 @@ impl Display {
 
     /// Adjust the IME editor position according to the new location of the cursor
     pub fn update_ime_position(&mut self, terminal: &Term) {
-        use index::{Column, Line, Point};
-        use term::SizeInfo;
+        use crate::index::{Column, Line, Point};
+        use crate::term::SizeInfo;
         let Point{line: Line(row), col: Column(col)} = terminal.cursor().point;
         let SizeInfo{cell_width: cw,
                     cell_height: ch,

--- a/src/display.rs
+++ b/src/display.rs
@@ -44,7 +44,7 @@ pub enum Error {
 }
 
 impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::Window(ref err) => Some(err),
             Error::Font(ref err) => Some(err),
@@ -62,7 +62,7 @@ impl ::std::error::Error for Error {
 }
 
 impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Error::Window(ref err) => err.fmt(f),
             Error::Font(ref err) => err.fmt(f),
@@ -292,9 +292,9 @@ impl Display {
     /// Process pending resize events
     pub fn handle_resize(
         &mut self,
-        terminal: &mut MutexGuard<Term>,
+        terminal: &mut MutexGuard<'_, Term>,
         config: &Config,
-        items: &mut [&mut OnResize],
+        items: &mut [&mut dyn OnResize],
     ) {
         // Resize events new_size and are handled outside the poll_events
         // iterator. This has the effect of coalescing multiple resize

--- a/src/event.rs
+++ b/src/event.rs
@@ -34,7 +34,7 @@ pub trait Notify {
     fn notify<B: Into<Cow<'static, [u8]>>>(&mut self, _: B);
 }
 
-pub struct ActionContext<'a, N: 'a> {
+pub struct ActionContext<'a, N> {
     pub notifier: &'a mut N,
     pub terminal: &'a mut Term,
     pub size_info: &'a mut SizeInfo,
@@ -456,7 +456,7 @@ impl<N: Notify> Processor<N> {
         {
             // Ditto on lazy initialization for context and processor.
             let context;
-            let mut processor: input::Processor<ActionContext<N>>;
+            let mut processor: input::Processor<'_, ActionContext<'_, N>>;
 
             let print_events = self.print_events;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,19 +10,19 @@ use parking_lot::MutexGuard;
 use glutin::{self, ModifiersState, Event, ElementState};
 use copypasta::{Clipboard, Load, Store, Buffer as ClipboardBuffer};
 
-use ansi::{Handler, ClearMode};
-use grid::Scroll;
-use config::{self, Config};
-use cli::Options;
-use display::OnResize;
-use index::{Line, Column, Side, Point};
-use input::{self, MouseBinding, KeyBinding};
-use selection::Selection;
-use sync::FairMutex;
-use term::{Term, SizeInfo, TermMode, Search};
-use util::limit;
-use util::fmt::Red;
-use window::Window;
+use crate::ansi::{Handler, ClearMode};
+use crate::grid::Scroll;
+use crate::config::{self, Config};
+use crate::cli::Options;
+use crate::display::OnResize;
+use crate::index::{Line, Column, Side, Point};
+use crate::input::{self, MouseBinding, KeyBinding};
+use crate::selection::Selection;
+use crate::sync::FairMutex;
+use crate::term::{Term, SizeInfo, TermMode, Search};
+use crate::util::limit;
+use crate::util::fmt::Red;
+use crate::window::Window;
 use glutin::dpi::PhysicalSize;
 
 /// Byte sequences are sent to a `Notify` in response to some events
@@ -30,7 +30,7 @@ pub trait Notify {
     /// Notify that an escape sequence should be written to the pty
     ///
     /// TODO this needs to be able to error somehow
-    fn notify<B: Into<Cow<'static, [u8]>>>(&mut self, B);
+    fn notify<B: Into<Cow<'static, [u8]>>>(&mut self, _: B);
 }
 
 pub struct ActionContext<'a, N: 'a> {
@@ -421,7 +421,7 @@ impl<N: Notify> Processor<N> {
                         processor.on_focus_change(is_focused);
                     },
                     DroppedFile(path) => {
-                        use input::ActionContext;
+                        use crate::input::ActionContext;
                         let path: String = path.to_string_lossy().into();
                         processor.ctx.write_to_pty(path.into_bytes());
                     },

--- a/src/event.rs
+++ b/src/event.rs
@@ -20,6 +20,7 @@ use crate::input::{self, MouseBinding, KeyBinding};
 use crate::selection::Selection;
 use crate::sync::FairMutex;
 use crate::term::{Term, SizeInfo, TermMode, Search};
+use crate::term::cell::Cell;
 use crate::util::limit;
 use crate::util::fmt::Red;
 use crate::window::Window;
@@ -336,7 +337,7 @@ impl<N: Notify> Processor<N> {
                         if ref_test {
                             // dump grid state
                             let mut grid = processor.ctx.terminal.grid().clone();
-                            grid.initialize_all(&::term::cell::Cell::default());
+                            grid.initialize_all(&Cell::default());
                             grid.truncate();
 
                             let serialized_grid = json::to_string(&grid)

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -12,13 +12,13 @@ use mio_more::channel::{self, Receiver, Sender};
 #[cfg(not(windows))]
 use mio::unix::UnixReady;
 
-use ansi;
-use display;
-use event;
-use tty;
-use term::Term;
-use util::thread;
-use sync::FairMutex;
+use crate::ansi;
+use crate::display;
+use crate::event;
+use crate::tty;
+use crate::term::Term;
+use crate::util::thread;
+use crate::sync::FairMutex;
 
 /// Messages that may be sent to the `EventLoop`
 #[derive(Debug)]
@@ -393,7 +393,7 @@ impl<T> EventLoop<T>
                                         break 'event_loop;
                                     }
 
-                                if ::tty::process_should_exit() {
+                                if crate::tty::process_should_exit() {
                                     break 'event_loop;
                                 }
                             }

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -99,7 +99,7 @@ pub struct Grid<T> {
     max_scroll_limit: usize,
 }
 
-pub struct GridIterator<'a, T: 'a> {
+pub struct GridIterator<'a, T> {
     /// Immutable grid reference
     grid: &'a Grid<T>,
 
@@ -411,7 +411,7 @@ impl<T> Grid<T> {
         self.lines
     }
 
-    pub fn display_iter(&self) -> DisplayIter<T> {
+    pub fn display_iter(&self) -> DisplayIter<'_, T> {
         DisplayIter::new(self)
     }
 
@@ -454,7 +454,7 @@ impl<T> Grid<T> {
         self.raw.truncate();
     }
 
-    pub fn iter_from(&self, point: Point<usize>) -> GridIterator<T> {
+    pub fn iter_from(&self, point: Point<usize>) -> GridIterator<'_, T> {
         GridIterator {
             grid: self,
             cur: point,
@@ -557,7 +557,7 @@ impl<'point, T> IndexMut<&'point Point> for Grid<T> {
 /// A subset of lines in the grid
 ///
 /// May be constructed using Grid::region(..)
-pub struct Region<'a, T: 'a> {
+pub struct Region<'a, T> {
     start: Line,
     end: Line,
     raw: &'a Storage<T>,
@@ -566,7 +566,7 @@ pub struct Region<'a, T: 'a> {
 /// A mutable subset of lines in the grid
 ///
 /// May be constructed using Grid::region_mut(..)
-pub struct RegionMut<'a, T: 'a> {
+pub struct RegionMut<'a, T> {
     start: Line,
     end: Line,
     raw: &'a mut Storage<T>,
@@ -585,14 +585,14 @@ impl<'a, T> RegionMut<'a, T> {
 
 pub trait IndexRegion<I, T> {
     /// Get an immutable region of Self
-    fn region(&self, _: I) -> Region<T>;
+    fn region(&self, _: I) -> Region<'_, T>;
 
     /// Get a mutable region of Self
-    fn region_mut(&mut self, _: I) -> RegionMut<T>;
+    fn region_mut(&mut self, _: I) -> RegionMut<'_, T>;
 }
 
 impl<T> IndexRegion<Range<Line>, T> for Grid<T> {
-    fn region(&self, index: Range<Line>) -> Region<T> {
+    fn region(&self, index: Range<Line>) -> Region<'_, T> {
         assert!(index.start < self.num_lines());
         assert!(index.end <= self.num_lines());
         assert!(index.start <= index.end);
@@ -602,7 +602,7 @@ impl<T> IndexRegion<Range<Line>, T> for Grid<T> {
             raw: &self.raw
         }
     }
-    fn region_mut(&mut self, index: Range<Line>) -> RegionMut<T> {
+    fn region_mut(&mut self, index: Range<Line>) -> RegionMut<'_, T> {
         assert!(index.start < self.num_lines());
         assert!(index.end <= self.num_lines());
         assert!(index.start <= index.end);
@@ -615,7 +615,7 @@ impl<T> IndexRegion<Range<Line>, T> for Grid<T> {
 }
 
 impl<T> IndexRegion<RangeTo<Line>, T> for Grid<T> {
-    fn region(&self, index: RangeTo<Line>) -> Region<T> {
+    fn region(&self, index: RangeTo<Line>) -> Region<'_, T> {
         assert!(index.end <= self.num_lines());
         Region {
             start: Line(0),
@@ -623,7 +623,7 @@ impl<T> IndexRegion<RangeTo<Line>, T> for Grid<T> {
             raw: &self.raw
         }
     }
-    fn region_mut(&mut self, index: RangeTo<Line>) -> RegionMut<T> {
+    fn region_mut(&mut self, index: RangeTo<Line>) -> RegionMut<'_, T> {
         assert!(index.end <= self.num_lines());
         RegionMut {
             start: Line(0),
@@ -634,7 +634,7 @@ impl<T> IndexRegion<RangeTo<Line>, T> for Grid<T> {
 }
 
 impl<T> IndexRegion<RangeFrom<Line>, T> for Grid<T> {
-    fn region(&self, index: RangeFrom<Line>) -> Region<T> {
+    fn region(&self, index: RangeFrom<Line>) -> Region<'_, T> {
         assert!(index.start < self.num_lines());
         Region {
             start: index.start,
@@ -642,7 +642,7 @@ impl<T> IndexRegion<RangeFrom<Line>, T> for Grid<T> {
             raw: &self.raw
         }
     }
-    fn region_mut(&mut self, index: RangeFrom<Line>) -> RegionMut<T> {
+    fn region_mut(&mut self, index: RangeFrom<Line>) -> RegionMut<'_, T> {
         assert!(index.start < self.num_lines());
         RegionMut {
             start: index.start,
@@ -653,7 +653,7 @@ impl<T> IndexRegion<RangeFrom<Line>, T> for Grid<T> {
 }
 
 impl<T> IndexRegion<RangeFull, T> for Grid<T> {
-    fn region(&self, _: RangeFull) -> Region<T> {
+    fn region(&self, _: RangeFull) -> Region<'_, T> {
         Region {
             start: Line(0),
             end: self.num_lines(),
@@ -661,7 +661,7 @@ impl<T> IndexRegion<RangeFull, T> for Grid<T> {
         }
     }
 
-    fn region_mut(&mut self, _: RangeFull) -> RegionMut<T> {
+    fn region_mut(&mut self, _: RangeFull) -> RegionMut<'_, T> {
         RegionMut {
             start: Line(0),
             end: self.num_lines(),
@@ -670,13 +670,13 @@ impl<T> IndexRegion<RangeFull, T> for Grid<T> {
     }
 }
 
-pub struct RegionIter<'a, T: 'a> {
+pub struct RegionIter<'a, T> {
     end: Line,
     cur: Line,
     raw: &'a Storage<T>,
 }
 
-pub struct RegionIterMut<'a, T: 'a> {
+pub struct RegionIterMut<'a, T> {
     end: Line,
     cur: Line,
     raw: &'a mut Storage<T>,
@@ -741,7 +741,7 @@ impl<'a, T> Iterator for RegionIterMut<'a, T> {
 // -------------------------------------------------------------------------------------------------
 
 /// Iterates over the visible area accounting for buffer transform
-pub struct DisplayIter<'a, T: 'a> {
+pub struct DisplayIter<'a, T> {
     grid: &'a Grid<T>,
     offset: usize,
     limit: usize,

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -17,8 +17,8 @@
 use std::cmp::{min, max, Ordering};
 use std::ops::{Deref, Range, Index, IndexMut, RangeTo, RangeFrom, RangeFull};
 
-use index::{self, Point, Line, Column, IndexRange};
-use selection::Selection;
+use crate::index::{self, Point, Line, Column, IndexRange};
+use crate::selection::Selection;
 
 mod row;
 pub use self::row::Row;

--- a/src/grid/row.rs
+++ b/src/grid/row.rs
@@ -85,7 +85,7 @@ impl<T> Row<T> {
         self.inner.len()
     }
 
-    pub fn iter(&self) -> slice::Iter<T> {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
         self.inner.iter()
     }
 }

--- a/src/grid/row.rs
+++ b/src/grid/row.rs
@@ -19,7 +19,7 @@ use std::ops::{Range, RangeTo, RangeFrom, RangeFull, RangeToInclusive};
 use std::cmp::{max, min};
 use std::slice;
 
-use index::Column;
+use crate::index::Column;
 
 /// A row in the grid
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -14,7 +14,7 @@
 use std::ops::{Index, IndexMut};
 use std::slice;
 
-use index::Line;
+use crate::index::Line;
 use super::Row;
 
 /// Maximum number of invisible lines before buffer is resized
@@ -308,7 +308,7 @@ impl<T> IndexMut<Line> for Storage<T> {
 }
 
 #[cfg(test)]
-use index::Column;
+use crate::index::Column;
 
 /// Grow the buffer one line at the end of the buffer
 ///

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -277,8 +277,7 @@ impl<T> Index<usize> for Storage<T> {
     type Output = Row<T>;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
-        let index = self.compute_index(index); // borrowck
-        &self.inner[index]
+        &self.inner[self.compute_index(index)]
     }
 }
 

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -14,6 +14,8 @@
 use std::ops::{Index, IndexMut};
 use std::slice;
 
+use static_assertions::assert_eq_size;
+
 use crate::index::Line;
 use super::Row;
 

--- a/src/grid/tests.rs
+++ b/src/grid/tests.rs
@@ -15,7 +15,7 @@
 //! Tests for the Gird
 
 use super::{Grid, BidirectionalIterator};
-use index::{Point, Line, Column};
+use crate::index::{Point, Line, Column};
 
 // Scroll up moves lines upwards
 #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -257,12 +257,8 @@ macro_rules! inclusive {
             fn next(&mut self) -> Option<$ty> {
                 use crate::index::RangeInclusive::*;
 
-                // this function has a sort of odd structure due to borrowck issues
-                // we may need to replace self.range, so borrows of start and end need to end early
-
-                let at_end;
                 match *self {
-                    Empty { .. } => return None, // empty iterators yield no values
+                    Empty { .. } => None, // empty iterators yield no values
 
                     NonEmpty { ref mut start, ref mut end } => {
 
@@ -270,15 +266,13 @@ macro_rules! inclusive {
                         if start <= end {
                             let old = *start;
                             *start = old + 1;
-                            return Some(old);
+                            Some(old)
+                        } else {
+                            *self = Empty { at: *end };
+                            None
                         }
-                        at_end = *end;
                     }
-                };
-
-                // got this far; the range is empty, replace it
-                *self = Empty { at: at_end };
-                None
+                }
             }
 
             #[inline]

--- a/src/index.rs
+++ b/src/index.rs
@@ -77,7 +77,7 @@ impl From<Point> for Point<usize> {
 pub struct Line(pub usize);
 
 impl fmt::Display for Line {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -89,7 +89,7 @@ impl fmt::Display for Line {
 pub struct Column(pub usize);
 
 impl fmt::Display for Column {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -101,7 +101,7 @@ impl fmt::Display for Column {
 pub struct Linear(pub usize);
 
 impl fmt::Display for Linear {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Linear({})", self.0)
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -255,7 +255,7 @@ macro_rules! inclusive {
 
             #[inline]
             fn next(&mut self) -> Option<$ty> {
-                use index::RangeInclusive::*;
+                use crate::index::RangeInclusive::*;
 
                 // this function has a sort of odd structure due to borrowck issues
                 // we may need to replace self.range, so borrows of start and end need to end early
@@ -283,7 +283,7 @@ macro_rules! inclusive {
 
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                use index::RangeInclusive::*;
+                use crate::index::RangeInclusive::*;
 
                 match *self {
                     Empty { .. } => (0, Some(0)),

--- a/src/input.rs
+++ b/src/input.rs
@@ -25,14 +25,14 @@ use std::time::Instant;
 use copypasta::{Clipboard, Load, Buffer as ClipboardBuffer};
 use glutin::{ElementState, MouseButton, TouchPhase, MouseScrollDelta, ModifiersState, KeyboardInput};
 
-use config::{self, Key};
-use grid::Scroll;
-use event::{ClickState, Mouse};
-use index::{Line, Column, Side, Point};
-use term::SizeInfo;
-use term::mode::TermMode;
-use util::fmt::Red;
-use util::start_daemon;
+use crate::config::{self, Key};
+use crate::grid::Scroll;
+use crate::event::{ClickState, Mouse};
+use crate::index::{Line, Column, Side, Point};
+use crate::term::SizeInfo;
+use crate::term::mode::TermMode;
+use crate::util::fmt::Red;
+use crate::util::start_daemon;
 
 pub const FONT_SIZE_STEP: f32 = 0.5;
 
@@ -52,10 +52,10 @@ pub struct Processor<'a, A: 'a> {
 }
 
 pub trait ActionContext {
-    fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, B);
+    fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, _: B);
     fn terminal_mode(&self) -> TermMode;
     fn size_info(&self) -> SizeInfo;
-    fn copy_selection(&self, ClipboardBuffer);
+    fn copy_selection(&self, _: ClipboardBuffer);
     fn clear_selection(&mut self);
     fn update_selection(&mut self, point: Point, side: Side);
     fn simple_selection(&mut self, point: Point, side: Side);
@@ -769,12 +769,12 @@ mod tests {
 
     use glutin::{VirtualKeyCode, Event, WindowEvent, ElementState, MouseButton, ModifiersState};
 
-    use term::{SizeInfo, Term, TermMode};
-    use event::{Mouse, ClickState, WindowChanges};
-    use config::{self, Config, ClickHandler};
-    use index::{Point, Side};
-    use selection::Selection;
-    use grid::Scroll;
+    use crate::term::{SizeInfo, Term, TermMode};
+    use crate::event::{Mouse, ClickState, WindowChanges};
+    use crate::config::{self, Config, ClickHandler};
+    use crate::index::{Point, Side};
+    use crate::selection::Selection;
+    use crate::grid::Scroll;
 
     use super::{Action, Binding, Processor};
     use copypasta::Buffer as ClipboardBuffer;

--- a/src/input.rs
+++ b/src/input.rs
@@ -939,7 +939,7 @@ mod tests {
                     processor.mouse_input(state, button, modifiers);
                 };
 
-                assert!(match mouse.click_state {
+                assert!(match processor.ctx.mouse.click_state {
                     $end_state => processor.ctx.last_action == $last_action,
                     _ => false
                 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,8 @@ pub mod window;
 
 use std::ops::Mul;
 
-pub use grid::Grid;
-pub use term::Term;
+pub use crate::grid::Grid;
+pub use crate::term::Term;
 
 /// Facade around [winit's `MouseCursor`](glutin::MouseCursor)
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,8 @@
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 
-#[macro_use] extern crate bitflags;
-#[macro_use] extern crate clap;
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
-#[macro_use] extern crate static_assertions;
 
 #[cfg(windows)]
 extern crate mio_named_pipes;
@@ -40,7 +37,6 @@ extern crate objc;
 
 #[macro_use]
 pub mod macros;
-
 pub mod ansi;
 pub mod cli;
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,6 @@
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate static_assertions;
 
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly",
-          target_os = "openbsd"))]
-extern crate x11_dl;
-
 #[cfg(windows)]
 extern crate mio_named_pipes;
 #[cfg(windows)]
@@ -41,30 +37,6 @@ extern crate image;
 #[cfg(target_os = "macos")]
 #[macro_use]
 extern crate objc;
-
-extern crate arraydeque;
-extern crate cgmath;
-extern crate copypasta;
-extern crate env_logger;
-extern crate errno;
-extern crate fnv;
-extern crate font;
-extern crate glutin;
-extern crate libc;
-extern crate mio;
-extern crate mio_more;
-extern crate notify;
-extern crate parking_lot;
-extern crate serde;
-extern crate serde_json;
-extern crate serde_yaml;
-extern crate unicode_width;
-extern crate vte;
-extern crate xdg;
-extern crate base64;
-extern crate terminfo;
-extern crate url;
-extern crate time;
 
 #[macro_use]
 pub mod macros;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -120,11 +120,11 @@ impl Logger {
 }
 
 impl log::Log for Logger {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
         metadata.level() <= self.level
     }
 
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         if self.enabled(record.metadata()) && record.target().starts_with("alacritty") {
             let msg = format!(
                 "[{}] [{}] {}\n",

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -17,7 +17,7 @@
 //! The main executable is supposed to call `initialize()` exactly once during
 //! startup. All logging messages are written to stdout, given that their
 //! log-level is sufficient for the level configured in `cli::Options`.
-use cli;
+use crate::cli;
 use log::{self, Level};
 use time;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn run(
     mut config: Config,
     options: &cli::Options,
     mut logger_proxy: LoggerProxy,
-) -> Result<(), Box<Error>> {
+) -> Result<(), Box<dyn Error>> {
     info!("Welcome to Alacritty.");
     if let Some(config_path) = config.path() {
         info!("Configuration loaded from {}", config_path.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,13 +23,13 @@
 // See https://msdn.microsoft.com/en-us/library/4cc7ya5b.aspx for more details.
 #![windows_subsystem = "windows"]
 
-#[macro_use]
-extern crate alacritty;
-
-#[macro_use]
-extern crate log;
 #[cfg(target_os = "macos")]
-extern crate dirs;
+use dirs;
+
+#[cfg(windows)]
+use winapi::um::wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS};
+
+use log::{info, error};
 
 use std::error::Error;
 use std::sync::Arc;
@@ -40,18 +40,12 @@ use std::env;
 #[cfg(not(windows))]
 use std::os::unix::io::AsRawFd;
 
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
-use winapi::um::wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS};
-
-use alacritty::cli;
-use alacritty::config::{self, Config, Error as ConfigError};
-use alacritty::display::Display;
-use alacritty::event;
-use alacritty::event_loop::{self, EventLoop, Msg};
 #[cfg(target_os = "macos")]
 use alacritty::locale;
+use alacritty::{cli, event, die};
+use alacritty::config::{self, Config, Error as ConfigError};
+use alacritty::display::Display;
+use alacritty::event_loop::{self, EventLoop, Msg};
 use alacritty::logging::{self, LoggerProxy};
 use alacritty::sync::FairMutex;
 use alacritty::term::Term;

--- a/src/meter.rs
+++ b/src/meter.rs
@@ -75,9 +75,7 @@ impl<'a> Sampler<'a> {
 
 impl<'a> Drop for Sampler<'a> {
     fn drop(&mut self) {
-        // Work around borrowck
-        let duration = self.alive_duration();
-        self.meter.add_sample(duration);
+        self.meter.add_sample(self.alive_duration());
     }
 }
 

--- a/src/meter.rs
+++ b/src/meter.rs
@@ -86,7 +86,7 @@ impl Meter {
     }
 
     /// Get a sampler
-    pub fn sampler(&mut self) -> Sampler {
+    pub fn sampler(&mut self) -> Sampler<'_> {
         Sampler::new(self)
     }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -65,7 +65,7 @@ pub enum Error {
 }
 
 impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::ShaderCreation(ref err) => Some(err),
         }
@@ -79,7 +79,7 @@ impl ::std::error::Error for Error {
 }
 
 impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Error::ShaderCreation(ref err) => {
                 write!(f, "There was an error initializing the shaders: {}", err)
@@ -660,7 +660,7 @@ impl QuadRenderer {
         func: F,
     ) -> T
     where
-        F: FnOnce(RenderApi) -> T,
+        F: FnOnce(RenderApi<'_>) -> T,
     {
         while let Ok(msg) = self.rx.try_recv() {
             match msg {
@@ -704,7 +704,7 @@ impl QuadRenderer {
 
     pub fn with_loader<F, T>(&mut self, func: F) -> T
     where
-        F: FnOnce(LoaderApi) -> T,
+        F: FnOnce(LoaderApi<'_>) -> T,
     {
         unsafe {
             gl::ActiveTexture(gl::TEXTURE0);
@@ -897,7 +897,7 @@ impl<'a> RenderApi<'a> {
             };
 
             // Add cell to batch
-            let glyph = glyph_cache.get(glyph_key, self); // borrowck multiple mutable borrows
+            let glyph = glyph_cache.get(glyph_key, self);
             self.add_render_item(&cell, glyph);
 
             // Render zero-width characters
@@ -1288,7 +1288,7 @@ pub enum ShaderCreationError {
 }
 
 impl ::std::error::Error for ShaderCreationError {
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             ShaderCreationError::Io(ref err) => Some(err),
             _ => None,
@@ -1305,7 +1305,7 @@ impl ::std::error::Error for ShaderCreationError {
 }
 
 impl ::std::fmt::Display for ShaderCreationError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             ShaderCreationError::Io(ref err) => write!(f, "couldn't read shader: {}", err),
             ShaderCreationError::Compile(ref _path, ref s) => {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -897,10 +897,8 @@ impl<'a> RenderApi<'a> {
             };
 
             // Add cell to batch
-            {
-                let glyph = glyph_cache.get(glyph_key, self);
-                self.add_render_item(&cell, glyph);
-            }
+            let glyph = glyph_cache.get(glyph_key, self); // borrowck multiple mutable borrows
+            self.add_render_item(&cell, glyph);
 
             // Render zero-width characters
             for c in (&chars[1..]).iter().filter(|c| **c != ' ') {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -24,14 +24,14 @@ use std::time::Duration;
 use cgmath;
 use fnv::FnvHasher;
 use font::{self, FontDesc, FontKey, GlyphKey, Rasterize, RasterizedGlyph, Rasterizer};
-use gl::types::*;
-use gl;
-use index::{Column, Line, RangeInclusive};
+use crate::gl::types::*;
+use crate::gl;
+use crate::index::{Column, Line, RangeInclusive};
 use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
-use Rgb;
+use crate::Rgb;
 
-use config::{self, Config, Delta};
-use term::{self, cell, RenderableCell};
+use crate::config::{self, Config, Delta};
+use crate::term::{self, cell, RenderableCell};
 use glutin::dpi::PhysicalSize;
 
 // Shader paths for live reload

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -21,8 +21,8 @@
 use std::cmp::{min, max};
 use std::ops::Range;
 
-use index::{Point, Column, Side};
-use term::Search;
+use crate::index::{Point, Column, Side};
+use crate::term::Search;
 
 /// Describes a region of a 2-dimensional area
 ///
@@ -431,7 +431,7 @@ impl Span {
 /// look like [ B] and [E ].
 #[cfg(test)]
 mod test {
-    use index::{Line, Column, Side, Point};
+    use crate::index::{Line, Column, Side, Point};
     use super::{Selection, Span, SpanType};
 
     struct Dimensions(Point);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -38,7 +38,7 @@ impl<T> FairMutex<T> {
     }
 
     /// Lock the mutex
-    pub fn lock(&self) -> MutexGuard<T> {
+    pub fn lock(&self) -> MutexGuard<'_, T> {
         // Must bind to a temporary or the lock will be freed before going
         // into data.lock()
         let _next = self.next.lock();

--- a/src/term/cell.rs
+++ b/src/term/cell.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use bitflags::bitflags;
+
 use crate::ansi::{NamedColor, Color};
 use crate::grid;
 use crate::index::Column;

--- a/src/term/cell.rs
+++ b/src/term/cell.rs
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use ansi::{NamedColor, Color};
-use grid;
-use index::Column;
+use crate::ansi::{NamedColor, Color};
+use crate::grid;
+use crate::index::Column;
 
 // Maximum number of zerowidth characters which will be stored per cell.
 pub const MAX_ZEROWIDTH_CHARS: usize = 5;
@@ -153,8 +153,8 @@ impl Cell {
 mod tests {
     use super::{Cell, LineLength};
 
-    use grid::Row;
-    use index::Column;
+    use crate::grid::Row;
+    use crate::index::Column;
 
     #[test]
     fn line_length_works() {

--- a/src/term/color.rs
+++ b/src/term/color.rs
@@ -1,8 +1,8 @@
 use std::ops::{Index, IndexMut};
 use std::fmt;
 
-use {Rgb, ansi};
-use config::Colors;
+use crate::{Rgb, ansi};
+use crate::config::Colors;
 
 pub const COUNT: usize = 270;
 

--- a/src/term/color.rs
+++ b/src/term/color.rs
@@ -154,7 +154,7 @@ impl List {
 }
 
 impl fmt::Debug for List {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("List[..]")
     }
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -391,9 +391,9 @@ impl<'a> RenderableCellsIter<'a> {
                     cell.flags & Flags::DIM_BOLD,
                     idx
                 ) {
-                    (true,  self::cell::Flags::BOLD, 0...7)  => idx as usize + 8,
-                    (false, self::cell::Flags::DIM,  8...15) => idx as usize - 8,
-                    (false, self::cell::Flags::DIM,  0...7)  => idx as usize + 260,
+                    (true,  self::cell::Flags::BOLD, 0..=7)  => idx as usize + 8,
+                    (false, self::cell::Flags::DIM,  8..=15) => idx as usize - 8,
+                    (false, self::cell::Flags::DIM,  0..=7)  => idx as usize + 260,
                     _ => idx as usize,
                 };
 
@@ -1128,7 +1128,7 @@ impl Term {
         &'b self,
         config: &'b Config,
         window_focused: bool,
-    ) -> RenderableCellsIter {
+    ) -> RenderableCellsIter<'_> {
         let alt_screen = self.mode.contains(TermMode::ALT_SCREEN);
         let selection = self.grid.selection.as_ref()
             .and_then(|s| s.to_span(self, alt_screen))
@@ -2068,7 +2068,7 @@ impl ansi::Handler for Term {
 
 #[cfg(test)]
 mod tests {
-    extern crate serde_json;
+    use serde_json;
 
     use super::{Cell, Term, SizeInfo};
     use crate::term::{cell, Search};
@@ -2419,8 +2419,8 @@ mod benches {
     use std::mem;
     use std::path::Path;
 
-    use grid::Grid;
-    use config::Config;
+    use crate::grid::Grid;
+    use crate::config::Config;
 
     use super::{SizeInfo, Term};
     use super::cell::Cell;

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -23,15 +23,15 @@ use unicode_width::UnicodeWidthChar;
 use url::Url;
 
 use font::{self, Size};
-use ansi::{self, Color, NamedColor, Attr, Handler, CharsetIndex, StandardCharset, CursorStyle};
-use grid::{BidirectionalIterator, Grid, Indexed, IndexRegion, DisplayIter, Scroll, ViewportPosition};
-use index::{self, Point, Column, Line, IndexRange, Contains, RangeInclusive, Linear};
-use selection::{self, Selection, Locations};
-use config::{Config, VisualBellAnimation};
-use {MouseCursor, Rgb};
+use crate::ansi::{self, Color, NamedColor, Attr, Handler, CharsetIndex, StandardCharset, CursorStyle};
+use crate::grid::{BidirectionalIterator, Grid, Indexed, IndexRegion, DisplayIter, Scroll, ViewportPosition};
+use crate::index::{self, Point, Column, Line, IndexRange, Contains, RangeInclusive, Linear};
+use crate::selection::{self, Selection, Locations};
+use crate::config::{Config, VisualBellAnimation};
+use crate::{MouseCursor, Rgb};
 use copypasta::{Clipboard, Load, Store};
-use input::FONT_SIZE_STEP;
-use logging::LoggerProxy;
+use crate::input::FONT_SIZE_STEP;
+use crate::logging::LoggerProxy;
 
 pub mod cell;
 pub mod color;
@@ -2083,16 +2083,16 @@ mod tests {
     extern crate serde_json;
 
     use super::{Cell, Term, SizeInfo};
-    use term::{cell, Search};
+    use crate::term::{cell, Search};
 
-    use grid::{Grid, Scroll};
-    use index::{Point, Line, Column, Side};
-    use ansi::{self, Handler, CharsetIndex, StandardCharset};
-    use selection::Selection;
+    use crate::grid::{Grid, Scroll};
+    use crate::index::{Point, Line, Column, Side};
+    use crate::ansi::{self, Handler, CharsetIndex, StandardCharset};
+    use crate::selection::Selection;
     use std::mem;
-    use input::FONT_SIZE_STEP;
+    use crate::input::FONT_SIZE_STEP;
     use font::Size;
-    use config::Config;
+    use crate::config::Config;
 
     #[test]
     fn semantic_selection_works() {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -499,6 +499,8 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
 }
 
 pub mod mode {
+    use bitflags::bitflags;
+
     bitflags! {
         pub struct TermMode: u16 {
             const SHOW_CURSOR         = 0b00_0000_0000_0001;

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -18,7 +18,7 @@ use std::{env, io};
 
 use terminfo::Database;
 
-use config::Config;
+use crate::config::Config;
 
 #[cfg(not(windows))]
 mod unix;
@@ -39,13 +39,13 @@ pub trait EventedReadWrite {
 
     fn register(
         &mut self,
-        &mio::Poll,
-        &mut Iterator<Item = &usize>,
-        mio::Ready,
-        mio::PollOpt,
+        _: &mio::Poll,
+        _: &mut Iterator<Item = &usize>,
+        _: mio::Ready,
+        _: mio::PollOpt,
     ) -> io::Result<()>;
-    fn reregister(&mut self, &mio::Poll, mio::Ready, mio::PollOpt) -> io::Result<()>;
-    fn deregister(&mut self, &mio::Poll) -> io::Result<()>;
+    fn reregister(&mut self, _: &mio::Poll, _: mio::Ready, _: mio::PollOpt) -> io::Result<()>;
+    fn deregister(&mut self, _: &mio::Poll) -> io::Result<()>;
 
     fn reader(&mut self) -> &mut Self::Reader;
     fn read_token(&self) -> mio::Token;

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -40,7 +40,7 @@ pub trait EventedReadWrite {
     fn register(
         &mut self,
         _: &mio::Poll,
-        _: &mut Iterator<Item = &usize>,
+        _: &mut dyn Iterator<Item = &usize>,
         _: mio::Ready,
         _: mio::PollOpt,
     ) -> io::Result<()>;

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -15,11 +15,11 @@
 //! tty related functionality
 //!
 
-use tty::EventedReadWrite;
-use term::SizeInfo;
-use display::OnResize;
-use config::{Config, Shell};
-use cli::Options;
+use crate::tty::EventedReadWrite;
+use crate::term::SizeInfo;
+use crate::display::OnResize;
+use crate::config::{Config, Shell};
+use crate::cli::Options;
 use mio;
 
 use libc::{self, c_int, pid_t, winsize, SIGCHLD, TIOCSCTTY, WNOHANG};

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -149,7 +149,7 @@ struct Passwd<'a> {
 /// # Unsafety
 ///
 /// If `buf` is changed while `Passwd` is alive, bad thing will almost certainly happen.
-fn get_pw_entry(buf: &mut [i8; 1024]) -> Passwd {
+fn get_pw_entry(buf: &mut [i8; 1024]) -> Passwd<'_> {
     // Create zeroed passwd struct
     let mut entry: libc::passwd = unsafe { ::std::mem::uninitialized() };
 
@@ -329,7 +329,7 @@ impl EventedReadWrite for Pty {
     fn register(
         &mut self,
         poll: &mio::Poll,
-        token: &mut Iterator<Item = &usize>,
+        token: &mut dyn Iterator<Item = &usize>,
         interest: mio::Ready,
         poll_opts: mio::PollOpt,
     ) -> io::Result<()> {

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -31,11 +31,11 @@ use winapi::shared::winerror::WAIT_TIMEOUT;
 use winpty::{ConfigFlags, MouseMode, SpawnConfig, SpawnFlags, Winpty};
 use winpty::Config as WinptyConfig;
 
-use config::{Config, Shell};
-use display::OnResize;
-use cli::Options;
-use tty::EventedReadWrite;
-use term::SizeInfo;
+use crate::config::{Config, Shell};
+use crate::display::OnResize;
+use crate::cli::Options;
+use crate::tty::EventedReadWrite;
+use crate::term::SizeInfo;
 
 /// Handle to the winpty agent process. Required so we know when it closes.
 static mut HANDLE: *mut c_void = 0usize as *mut c_void;

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,13 +50,13 @@ pub mod fmt {
                 pub struct $s<T>(pub T);
 
                 impl<T: fmt::Display> fmt::Display for $s<T> {
-                    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                         write!(f, concat!("\x1b[", $color, "m{}\x1b[0m"), self.0)
                     }
                 }
 
                 impl<T: fmt::Debug> fmt::Debug for $s<T> {
-                    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                         write!(f, concat!("\x1b[", $color, "m{:?}\x1b[0m"), self.0)
                     }
                 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -93,7 +93,7 @@ pub struct DeviceProperties {
 }
 
 impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::ContextCreation(ref err) => Some(err),
             Error::Context(ref err) => Some(err),
@@ -109,7 +109,7 @@ impl ::std::error::Error for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             Error::ContextCreation(ref err) => write!(f, "Error creating GL context; {}", err),
             Error::Context(ref err) => write!(f, "Error operating on render context; {}", err),

--- a/src/window.rs
+++ b/src/window.rs
@@ -14,7 +14,7 @@
 use std::convert::From;
 use std::fmt::Display;
 
-use gl;
+use crate::gl;
 use glutin::GlContext;
 #[cfg(windows)]
 use glutin::Icon;
@@ -26,9 +26,9 @@ use glutin::{
 };
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 
-use cli::Options;
-use config::{Decorations, WindowConfig};
-use MouseCursor;
+use crate::cli::Options;
+use crate::config::{Decorations, WindowConfig};
+use crate::MouseCursor;
 
 #[cfg(windows)]
 static WINDOW_ICON: &'static [u8] = include_bytes!("../assets/windows/alacritty.ico");

--- a/tests/ref.rs
+++ b/tests/ref.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json as json;
-extern crate alacritty;
+use serde_json as json;
 
 use std::fs::File;
 use std::io::{self, Read};

--- a/winpty/src/lib.rs
+++ b/winpty/src/lib.rs
@@ -12,4 +12,4 @@ extern crate winpty_sys;
 pub mod windows;
 
 #[cfg(windows)]
-pub use windows::*;
+pub use crate::windows::*;

--- a/winpty/src/windows.rs
+++ b/winpty/src/windows.rs
@@ -349,7 +349,7 @@ mod tests {
     use self::winapi::um::processthreadsapi::OpenProcess;
     use self::winapi::um::winnt::READ_CONTROL;
 
-    use {Config, ConfigFlags, SpawnConfig, SpawnFlags, Winpty};
+    use crate::{Config, ConfigFlags, SpawnConfig, SpawnFlags, Winpty};
 
     #[test]
     // Test that we can start a process in winpty


### PR DESCRIPTION
This updates Alacritty to Rust 2018 while fixing old workarounds for lack of NLLs. Almost all `// borrowck` commens have been resolved except for two instances of overlapping mutable borrows not quite covered by the initial NLL support.