### PR TITLE
Add -x flag to tic command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -226,7 +226,7 @@ To choose a default terminal app, use Debian's `update-alternatives`.
 
 ```sh
 update-alternatives --config x-terminal-emulator
-``` 
+```
 
 ## Manual Page
 
@@ -303,5 +303,5 @@ instead.
 To install alacritty's terminfo entry globally:
 
 ```sh
-sudo tic -e alacritty,alacritty-direct alacritty.info
+sudo tic -xe alacritty,alacritty-direct alacritty.info
 ```


### PR DESCRIPTION
Fixes #1876 

Adding `-x` flag fixes the issue. With this flag, unknown terminfo capabilities are treated as user-defined.
