### PR TITLE
Fix recording of ref tests

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -336,6 +336,7 @@ impl<N: Notify> Processor<N> {
                         if ref_test {
                             // dump grid state
                             let mut grid = processor.ctx.terminal.grid().clone();
+                            grid.initialize_all(&::term::cell::Cell::default());
                             grid.truncate();
 
                             let serialized_grid = json::to_string(&grid)
@@ -344,6 +345,11 @@ impl<N: Notify> Processor<N> {
                             let serialized_size = json::to_string(processor.ctx.terminal.size_info())
                                 .expect("serialize size");
 
+                            let serialized_config = format!(
+                                "{{\"history_size\":{}}}",
+                                grid.history_size()
+                            );
+
                             File::create("./grid.json")
                                 .and_then(|mut f| f.write_all(serialized_grid.as_bytes()))
                                 .expect("write grid.json");
@@ -351,6 +357,10 @@ impl<N: Notify> Processor<N> {
                             File::create("./size.json")
                                 .and_then(|mut f| f.write_all(serialized_size.as_bytes()))
                                 .expect("write size.json");
+
+                            File::create("./config.json")
+                                .and_then(|mut f| f.write_all(serialized_config.as_bytes()))
+                                .expect("write config.json");
                         }
 
                         // FIXME should do a more graceful shutdown

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -435,6 +435,20 @@ impl<T> Grid<T> {
         self.raw.len()
     }
 
+    #[inline]
+    pub fn history_size(&self) -> usize {
+        self.raw.len().saturating_sub(*self.lines)
+    }
+
+    /// This is used only for initializing after loading ref-tests
+    pub fn initialize_all(&mut self, template: &T)
+    where
+        T: Copy
+    {
+        let history_size = self.raw.len().saturating_sub(*self.lines);
+        self.raw.initialize(self.max_scroll_limit - history_size, Row::new(self.cols, template));
+    }
+
     /// This is used only for truncating before saving ref-tests
     pub fn truncate(&mut self) {
         self.raw.truncate();

--- a/tests/ref.rs
+++ b/tests/ref.rs
@@ -99,12 +99,13 @@ fn ref_test(dir: &Path) {
 
     // Truncate invisible lines from the grid
     let mut term_grid = terminal.grid().clone();
+    term_grid.initialize_all(&Cell::default());
     term_grid.truncate();
 
     if grid != term_grid {
         for i in 0..grid.len() {
             for j in 0..grid.num_cols().0 {
-                let cell = terminal.grid()[i][Column(j)];
+                let cell = term_grid[i][Column(j)];
                 let original_cell = grid[i][Column(j)];
                 if original_cell != cell {
                     println!("[{i}][{j}] {original:?} => {now:?}",


### PR DESCRIPTION
Due to the lazy initialization of lines in the Alacritty history, the
recording of ref tests was broken. Because a WM would often resize the
ref test window after it was spawned, some additional lines were
initialized in the stored ref test.

To make sure lazy initialization does not play any role in the recording
and replaying of reftests, before recording and replaying the tests, the
complete grid is initialized and then truncated. This should make sure
that only the relevant lines are kept.