### PR TITLE
Ignore result on deregistering pty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix color issue in ncurses programs by updating terminfo pairs from 0x10000 to 0x7FFF
+- Fix panic on releasing event loop
 
 ## Version 0.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix color issue in ncurses programs by updating terminfo pairs from 0x10000 to 0x7FFF
-- Fix panic on releasing event loop
+- Fix panic after quitting Alacritty on macOS
 
 ## Version 0.2.4
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -426,7 +426,7 @@ impl<T> EventLoop<T>
             // The evented instances are not dropped here so deregister them explicitly
             // TODO: Is this still necessary?
             let _ = self.poll.deregister(&self.rx);
-            self.pty.deregister(&self.poll).unwrap();
+            let _ = self.pty.deregister(&self.poll);
 
             (self, state)
         })


### PR DESCRIPTION
to prevent the panic on `unwrap` if fd is not found
closes #1897