### PR TITLE
Send alt key with actual key in one flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix color issue in ncurses programs by updating terminfo pairs from 0x10000 to 0x7FFF
 - Fix panic after quitting Alacritty on macOS
 - Tabs are no longer replaced by spaces when copying them to the clipboard
+- Alt modifier is no longer sent separately from the modified key
 
 ## Version 0.2.4
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -687,14 +687,14 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             self.ctx.clear_selection();
 
             let utf8_len = c.len_utf8();
-            if *self.ctx.received_count() == 0 && self.ctx.last_modifiers().alt && utf8_len == 1 {
-                self.ctx.write_to_pty(b"\x1b".to_vec());
-            }
-
             let mut bytes = Vec::with_capacity(utf8_len);
             unsafe {
                 bytes.set_len(utf8_len);
                 c.encode_utf8(&mut bytes[..]);
+            }
+
+            if *self.ctx.received_count() == 0 && self.ctx.last_modifiers().alt && utf8_len == 1 {
+                bytes.insert(0, b'\x1b');
             }
 
             self.ctx.write_to_pty(bytes);


### PR DESCRIPTION
The delay between the alt key and the actual received key might cause
certain key sequences to be missed, ex. when tmux has its escape-time
set to 0.