### PR TITLE
Expand description; remove unnecessary comments

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,22 @@
-name: alacritty # you probably want to 'snapcraft register <name>'
+name: alacritty
 version: '0.2.4' # just for humans, typically '1.2+git' or '1.3.2'
-summary: Modern, GPU accelerated terminal emulator # 79 char long summary
+summary: Modern, GPU accelerated terminal emulator
 description: |
-  Modern, GPU accelerated terminal emulator
-grade: stable # must be 'stable' to release into candidate/stable channels
-confinement: classic # use 'strict' once you have the right plugs and slots
+  Alacritty is the fastest terminal emulator in existence. Using the GPU
+  for rendering enables optimizations that simply aren't possible in
+  other emulators.
+
+  Alacritty is focused on simplicity and performance. The performance
+  goal means it should be faster than any other terminal emulator
+  available. The simplicity goal means that it doesn't have features
+  such as tabs or splits (which can be better provided by a window
+  manager or terminal multiplexer) nor niceties like a GUI config editor.
+  
+  The software is considered to be at an alpha level of readiness—there 
+  are missing features and bugs to be fixed, but it is already used by 
+  many as a daily driver.
+grade: stable
+confinement: classic
 parts:
   alacritty:
     plugin: rust


### PR DESCRIPTION
This commit removes the boilerplate comments that come with the template `snapcraft.yaml`. It also expands the description to match the project's README.