### PR TITLE
Fix line metrics

### DIFF
--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -432,13 +432,9 @@ impl Font {
 
         // Strikeout and underline metrics
         // CoreText doesn't provide strikeout so we provide our own
-        let underline_position =
-            (self.ct_font.underline_position() - descent)
-            .round() as f32;
-        let underline_thickness = self.ct_font.underline_thickness()
-            .round()
-            .max(1.) as f32;
-        let strikeout_position = (line_height as f32 / 2. - descent as f32).round();
+        let underline_position = (self.ct_font.underline_position() - descent) as f32;
+        let underline_thickness = self.ct_font.underline_thickness().max(1.) as f32;
+        let strikeout_position = line_height as f32 / 2. - descent as f32;
         let strikeout_thickness = underline_thickness;
 
         Metrics {

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -430,17 +430,17 @@ impl Font {
         let leading = self.ct_font.leading() as f64;
         let line_height = (ascent + descent + leading + 0.5).floor();
 
-        // Strikeout and underline metrics
-        // CoreText doesn't provide strikeout so we provide our own
+        // Strikeout and underline metrics.
+        // CoreText doesn't provide strikeout so we provide our own.
         let underline_position = (self.ct_font.underline_position() - descent) as f32;
-        let underline_thickness = self.ct_font.underline_thickness().max(1.) as f32;
-        let strikeout_position = line_height as f32 / 2. - descent as f32;
+        let underline_thickness = self.ct_font.underline_thickness() as f32;
+        let strikeout_position = (line_height / 2. - descent) as f32;
         let strikeout_thickness = underline_thickness;
 
         Metrics {
             average_advance,
             line_height,
-            descent: -(self.ct_font.descent() as f32),
+            descent: -(descent as f32),
             underline_position,
             underline_thickness,
             strikeout_position,

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -97,15 +97,13 @@ impl ::Rasterize for FreeTypeRasterizer {
 
         // Get underline position and thickness in device pixels
         let x_scale = full.size_metrics.x_scale as f32 / 65536.0;
-        let mut underline_position =
-            f32::from(face.ft_face.underline_position()) * x_scale / 64.;
-        let mut underline_thickness =
-            (f32::from(face.ft_face.underline_thickness()) * x_scale / 64.).max(1.);
+        let mut underline_position = f32::from(face.ft_face.underline_position()) * x_scale / 64.;
+        let mut underline_thickness = f32::from(face.ft_face.underline_thickness()) * x_scale / 64.;
 
         // Fallback for bitmap fonts which do not provide underline metrics
         if underline_position == 0. {
             underline_thickness = (descent / 5.).round();
-            underline_position = descent / 2. + underline_thickness / 2.;
+            underline_position = descent / 2.;
         }
 
         // Get strikeout position and thickness in device pixels

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -97,22 +97,24 @@ impl ::Rasterize for FreeTypeRasterizer {
 
         // Get underline position and thickness in device pixels
         let x_scale = full.size_metrics.x_scale as f32 / 65536.0;
-        let underline_position =
-            (f32::from(face.ft_face.underline_position()) * x_scale / 64.).round();
-        let underline_thickness =
-            (f32::from(face.ft_face.underline_thickness()) * x_scale / 64.)
-            .round()
-            .max(1.);
+        let mut underline_position =
+            f32::from(face.ft_face.underline_position()) * x_scale / 64.;
+        let mut underline_thickness =
+            (f32::from(face.ft_face.underline_thickness()) * x_scale / 64.).max(1.);
+
+        // Fallback for bitmap fonts which do not provide underline metrics
+        if underline_position == 0. {
+            underline_thickness = (descent / 5.).round();
+            underline_position = descent / 2. + underline_thickness / 2.;
+        }
 
         // Get strikeout position and thickness in device pixels
         let (strikeout_position, strikeout_thickness) =
             match TrueTypeOS2Table::from_face(&mut face.ft_face.clone())
         {
             Some(os2) => {
-                let strikeout_position =
-                    (f32::from(os2.y_strikeout_position()) * x_scale / 64.).round();
-                let strikeout_thickness =
-                    (f32::from(os2.y_strikeout_size()) * x_scale / 64.).round();
+                let strikeout_position = f32::from(os2.y_strikeout_position()) * x_scale / 64.;
+                let strikeout_thickness = f32::from(os2.y_strikeout_size()) * x_scale / 64.;
                 (strikeout_position, strikeout_thickness)
             },
             _ => {

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -38,10 +38,10 @@ impl crate::Rasterize for RustTypeRasterizer {
         let average_advance = f64::from(hmetrics.advance_width);
         let descent = vmetrics.descent;
 
-        // Strikeout and underline metrics
-        // RustType doesn't support these, so we make up our own
+        // Strikeout and underline metrics.
+        // RustType doesn't support these, so we make up our own.
         let thickness = (descent / 5.).round();
-        let underline_position = descent / 2. + thickness / 2.;
+        let underline_position = descent / 2.;
         let strikeout_position = line_height as f32 / 2. - descent;
 
         Ok(Metrics {

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -42,7 +42,7 @@ impl crate::Rasterize for RustTypeRasterizer {
         // RustType doesn't support these, so we make up our own
         let thickness = (descent / 5.).round();
         let underline_position = descent / 2. + thickness / 2.;
-        let strikeout_position = (line_height as f32 / 2. - descent).round();
+        let strikeout_position = line_height as f32 / 2. - descent;
 
         Ok(Metrics {
             descent,

--- a/src/renderer/lines.rs
+++ b/src/renderer/lines.rs
@@ -126,7 +126,7 @@ fn create_rect(
     let cell_bottom = (start.line.0 as f32 + 1.) * size.cell_height;
     let baseline = cell_bottom + metrics.descent;
 
-    let mut y = baseline - position - height / 2.;
+    let mut y = baseline - position + height / 2.;
     let max_y = cell_bottom - height;
     if y > max_y {
         y = max_y;

--- a/src/renderer/lines.rs
+++ b/src/renderer/lines.rs
@@ -126,7 +126,7 @@ fn create_rect(
     let cell_bottom = (start.line.0 as f32 + 1.) * size.cell_height;
     let baseline = cell_bottom + metrics.descent;
 
-    let mut y = baseline - position + height / 2.;
+    let mut y = baseline - position - height / 2.;
     let max_y = cell_bottom - height;
     if y > max_y {
         y = max_y;
@@ -134,7 +134,7 @@ fn create_rect(
 
     let rect = Rect::new(
         start_x + size.padding_x,
-        y + size.padding_y,
+        y.round() + size.padding_y,
         width,
         height,
     );

--- a/src/renderer/lines.rs
+++ b/src/renderer/lines.rs
@@ -132,6 +132,10 @@ fn create_rect(
         y = max_y;
     }
 
+    if flag == Flags::UNDERLINE {
+        println!("UNDERLINE:\n    CELL BOTTOM: {}\n    BASELINE: {}\n    UL POS: {}\n    UL HEIGHT: {}\n    MAX Y: {}\n    Y: {}", cell_bottom, baseline, position, height, max_y, y);
+    }
+
     let rect = Rect::new(
         start_x + size.padding_x,
         y.round() + size.padding_y,

--- a/src/renderer/lines.rs
+++ b/src/renderer/lines.rs
@@ -117,11 +117,14 @@ fn create_rect(
     let end_x = (end.column.0 + 1) as f32 * size.cell_width;
     let width = end_x - start_x;
 
-    let (position, height) = match flag {
+    let (position, mut height) = match flag {
         Flags::UNDERLINE => (metrics.underline_position, metrics.underline_thickness),
         Flags::STRIKEOUT => (metrics.strikeout_position, metrics.strikeout_thickness),
         _ => unimplemented!("Invalid flag for cell line drawing specified"),
     };
+
+    // Make sure lines are always visible
+    height = height.max(1.);
 
     let cell_bottom = (start.line.0 as f32 + 1.) * size.cell_height;
     let baseline = cell_bottom + metrics.descent;
@@ -132,15 +135,11 @@ fn create_rect(
         y = max_y;
     }
 
-    if flag == Flags::UNDERLINE {
-        println!("UNDERLINE:\n    CELL BOTTOM: {}\n    BASELINE: {}\n    UL POS: {}\n    UL HEIGHT: {}\n    MAX Y: {}\n    Y: {}", cell_bottom, baseline, position, height, max_y, y);
-    }
-
     let rect = Rect::new(
         start_x + size.padding_x,
         y.round() + size.padding_y,
         width,
-        height,
+        height.round(),
     );
 
     (rect, start.fg)


### PR DESCRIPTION
The height of the line drawing for underline and strikethrough has been
incorrectly substracted from the Y position instead of adding it.
Leading to an incorrect Y position for underline and strikeout by
exactly the width of the line.

By simply adding half of the height instead of substracting it, the
position should be corrected and the distanace between the underline and
the baseline should be increased.