### PR TITLE
Set min osx deployment target to 10.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ APP_DIR = $(RELEASE_DIR)/osx
 APP_BINARY = $(RELEASE_DIR)/$(TARGET)
 APP_BINARY_DIR  = $(APP_DIR)/$(APP_NAME)/Contents/MacOS
 
-export MACOSX_DEPLOYMENT_TARGET = $(shell defaults read loginwindow SystemVersionStampAsString)
-
 DMG_NAME = Alacritty.dmg
 DMG_DIR = $(RELEASE_DIR)/osx
 
@@ -24,9 +22,6 @@ help: ## Prints help for targets with comments
 
 binary: | $(TARGET) ## Build release binary with cargo
 $(TARGET):
-ifneq ( "${MACOSX_DEPLOYMENT_TARGET}" , "")
-	@echo MACOSX_DEPLOYMENT_TARGET=$${MACOSX_DEPLOYMENT_TARGET}
-endif
 	cargo build --release
 
 app: | $(APP_NAME) ## Clone Alacritty.app template and mount binary

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -22,6 +22,7 @@ mkdir "./target/deploy"
 name="Alacritty-${TRAVIS_TAG}"
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    export MACOSX_DEPLOYMENT_TARGET=10.11
     make dmg
     mv "./target/release/osx/Alacritty.dmg" "./target/deploy/${name}.dmg"
 elif [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$ARCH" != "i386" ]; then


### PR DESCRIPTION
to get maximum coverage for pre-built binaries

closes #1853

in addition, `MACOSX_DEPLOYMENT_TARGET` can be overridden

BTW
I was able to reproduce the referenced issue by providing not existing version(`MACOSX_DEPLOYMENT_TARGET=10.14.3 make app`):
<img width="532" alt="screen shot 2018-12-25 at 00 40 49" src="https://user-images.githubusercontent.com/486807/50407071-1c93e000-07e1-11e9-85bd-4003244d246c.png">

