### PR TITLE
Change mouse mode cursor to the default cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tabs are no longer replaced by spaces when copying them to the clipboard
 - Alt modifier is no longer sent separately from the modified key
 - Various Windows issues, like color support and performance, through the new ConPTY
+- Fixed rendering non default mouse cursors in terminal mouse mode (linux)
 
 ## Version 0.2.4
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -249,7 +249,7 @@ impl Window {
     #[inline]
     pub fn set_mouse_cursor(&self, cursor: MouseCursor) {
         self.window.set_cursor(match cursor {
-            MouseCursor::Arrow => GlutinMouseCursor::Arrow,
+            MouseCursor::Arrow => GlutinMouseCursor::Default,
             MouseCursor::Text => GlutinMouseCursor::Text,
         });
     }


### PR DESCRIPTION
On my linux machine, the `Arrow` cursor is this very rarely used Xorg cursor:
![arrow](https://user-images.githubusercontent.com/312503/50563480-80586480-0d1d-11e9-82da-b89b862b56ce.png)

However, changing the cursor to `Default` gives me the default mouse cursor I'm used to:
![default](https://user-images.githubusercontent.com/312503/50563502-a0882380-0d1d-11e9-8099-9f65dd987226.png)

@zacps, @dm1try and @sodiumjoe could you guys check to that this doesn't mess it up on Windows/Mac?