### PR TITLE
Process Mouse Binding Actions Earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alt modifier is no longer sent separately from the modified key
 - Various Windows issues, like color support and performance, through the new ConPTY
 - Fixed rendering non default mouse cursors in terminal mouse mode (linux)
+- Fix the `Copy` `mouse_bindings` action ([#1963](https://github.com/jwilm/alacritty/issues/1963))
 
 ## Version 0.2.4
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -646,6 +646,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             MouseButton::Other(_) => None,
         };
 
+        self.process_mouse_bindings(modifiers, button);
+
         if let Some(prev_state) = prev_state {
             if prev_state != state {
                 match state {
@@ -658,8 +660,6 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         if let ElementState::Released = state {
             return;
         }
-
-        self.process_mouse_bindings(modifiers, button);
     }
 
     /// Process key input


### PR DESCRIPTION
As reported in #1963, mouse binding actions are being processed too late to allow copying the selection. This is the fix for this issue, assuming there's no other actions the depend on the opposite order.