### PR TITLE
Fix double-triggering of mouse bindings

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -638,25 +638,19 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     }
 
     pub fn mouse_input(&mut self, state: ElementState, button: MouseButton, modifiers: ModifiersState) {
-        let prev_state = match button {
-            MouseButton::Left     => Some(mem::replace(&mut self.ctx.mouse_mut().left_button_state, state)),
-            MouseButton::Middle   => Some(mem::replace(&mut self.ctx.mouse_mut().middle_button_state, state)),
-            MouseButton::Right    => Some(mem::replace(&mut self.ctx.mouse_mut().right_button_state, state)),
-            // Can't properly report more than three buttons.
-            MouseButton::Other(_) => None,
-        };
-
-        if let ElementState::Pressed = state {
-            self.process_mouse_bindings(modifiers, button);
+        match button {
+            MouseButton::Left => self.ctx.mouse_mut().left_button_state = state,
+            MouseButton::Middle => self.ctx.mouse_mut().middle_button_state = state,
+            MouseButton::Right => self.ctx.mouse_mut().right_button_state = state,
+            _ => (),
         }
 
-        if let Some(prev_state) = prev_state {
-            if prev_state != state {
-                match state {
-                    ElementState::Pressed  => self.on_mouse_press(button, modifiers),
-                    ElementState::Released => self.on_mouse_release(button, modifiers),
-                };
-            }
+        match state {
+            ElementState::Pressed => {
+                self.process_mouse_bindings(modifiers, button);
+                self.on_mouse_press(button, modifiers);
+            },
+            ElementState::Released => self.on_mouse_release(button, modifiers),
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -646,7 +646,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             MouseButton::Other(_) => None,
         };
 
-        self.process_mouse_bindings(modifiers, button);
+        if let ElementState::Pressed = state {
+            self.process_mouse_bindings(modifiers, button);
+        }
 
         if let Some(prev_state) = prev_state {
             if prev_state != state {
@@ -655,10 +657,6 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                     ElementState::Released => self.on_mouse_release(button, modifiers),
                 };
             }
-        }
-
-        if let ElementState::Released = state {
-            return;
         }
     }
 


### PR DESCRIPTION
The 2d9afb9b395ea0cc71432613e0df104aefcf24c1 commit lead to mouse
actions being triggered on both press and release of mouse buttons.

This reverts the mouse binding behavior back to the previous state where
they are only triggered when the button is pressed, not when it's
released.