### PR TITLE
Add action to create new instance of alacritty within the current working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crashes on Windows are now also reported with a popup in addition to stderr
 - Windows: New configuration field `enable_experimental_conpty_backend` which enables support
     for the Pseudoconsole API (ConPTY) added in Windows 10 October 2018 (1809) update
+- New key action `SpawnNewInstance` for launching another instance of Alacritty
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crashes on Windows are now also reported with a popup in addition to stderr
 - Windows: New configuration field `enable_experimental_conpty_backend` which enables support
     for the Pseudoconsole API (ConPTY) added in Windows 10 October 2018 (1809) update
-- New key action `SpawnNewInstance` for launching another instance of Alacritty
+- New mouse and key action `SpawnNewInstance` for launching another instance of Alacritty
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -374,6 +374,7 @@ live_config_reload: true
 #   - Hide
 #   - Quit
 #   - ClearLogNotice
+#   - SpawnNewInstance
 #
 # Values for `command`:
 #   The `command` field must be a map containing a `program` string and

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -319,7 +319,7 @@ live_config_reload: true
 # arguments (`command`).
 #
 # Example:
-#   `- { key: V, mods: Command, action: Paste }`
+#   `- { key: V, mods: Control|Shift, action: Paste }`
 #
 # Available fields:
 #   - key
@@ -391,10 +391,9 @@ live_config_reload: true
 key_bindings:
   - { key: V,        mods: Control|Shift,    action: Paste               }
   - { key: C,        mods: Control|Shift,    action: Copy                }
+  - { key: N,        mods: Control|Shift,    action: SpawnNewInstance    }
   - { key: Paste,                   action: Paste                        }
   - { key: Copy,                    action: Copy                         }
-  - { key: Q,        mods: Command, action: Quit                         }
-  - { key: W,        mods: Command, action: Quit                         }
   - { key: Insert,   mods: Shift,   action: PasteSelection               }
   - { key: Key0,     mods: Control, action: ResetFontSize                }
   - { key: Equals,   mods: Control, action: IncreaseFontSize             }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -391,7 +391,6 @@ live_config_reload: true
 key_bindings:
   - { key: V,        mods: Control|Shift,    action: Paste               }
   - { key: C,        mods: Control|Shift,    action: Copy                }
-  - { key: N,        mods: Control|Shift,    action: SpawnNewInstance    }
   - { key: Paste,                   action: Paste                        }
   - { key: Copy,                    action: Copy                         }
   - { key: Insert,   mods: Shift,   action: PasteSelection               }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -326,7 +326,7 @@ live_config_reload: true
 # arguments (`command`).
 #
 # Example:
-#   `- { key: V, mods: Command, action: Paste }`
+#   `- { key: V, mods: Control|Shift, action: Paste }`
 #
 # Available fields:
 #   - key
@@ -403,6 +403,7 @@ key_bindings:
   - { key: H,        mods: Command, action: Hide                         }
   - { key: Q,        mods: Command, action: Quit                         }
   - { key: W,        mods: Command, action: Quit                         }
+  - { key: N,        mods: Command, action: SpawnNewInstance             }
   - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }
   - { key: Home,                    chars: "\x1b[H",   mode: ~AppCursor  }
   - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -403,7 +403,6 @@ key_bindings:
   - { key: H,        mods: Command, action: Hide                         }
   - { key: Q,        mods: Command, action: Quit                         }
   - { key: W,        mods: Command, action: Quit                         }
-  - { key: N,        mods: Command, action: SpawnNewInstance             }
   - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }
   - { key: Home,                    chars: "\x1b[H",   mode: ~AppCursor  }
   - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }

--- a/alacritty_macos.yml
+++ b/alacritty_macos.yml
@@ -381,6 +381,7 @@ live_config_reload: true
 #   - Hide
 #   - Quit
 #   - ClearLogNotice
+#   - SpawnNewInstance
 #
 # Values for `command`:
 #   The `command` field must be a map containing a `program` string and

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -303,7 +303,7 @@ enable_experimental_conpty_backend: false
 # arguments (`command`).
 #
 # Example:
-#   `- { key: V, mods: Command, action: Paste }`
+#   `- { key: V, mods: Control|Shift, action: Paste }`
 #
 # Available fields:
 #   - key
@@ -375,8 +375,7 @@ enable_experimental_conpty_backend: false
 key_bindings:
   - { key: V,        mods: Control|Shift,    action: Paste               }
   - { key: C,        mods: Control|Shift,    action: Copy                }
-  - { key: Q,        mods: Command, action: Quit                         }
-  - { key: W,        mods: Command, action: Quit                         }
+  - { key: N,        mods: Control|Shift,    action: SpawnNewInstance    }
   - { key: Insert,   mods: Shift,   action: PasteSelection               }
   - { key: Key0,     mods: Control, action: ResetFontSize                }
   - { key: Equals,   mods: Control, action: IncreaseFontSize             }

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -358,6 +358,7 @@ enable_experimental_conpty_backend: false
 #   - Hide
 #   - Quit
 #   - ClearLogNotice
+#   - SpawnNewInstance
 #
 # Values for `command`:
 #   The `command` field must be a map containing a `program` string and

--- a/alacritty_windows.yml
+++ b/alacritty_windows.yml
@@ -375,7 +375,6 @@ enable_experimental_conpty_backend: false
 key_bindings:
   - { key: V,        mods: Control|Shift,    action: Paste               }
   - { key: C,        mods: Control|Shift,    action: Copy                }
-  - { key: N,        mods: Control|Shift,    action: SpawnNewInstance    }
   - { key: Insert,   mods: Shift,   action: PasteSelection               }
   - { key: Key0,     mods: Control, action: ResetFontSize                }
   - { key: Equals,   mods: Control, action: IncreaseFontSize             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -771,7 +771,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
             fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, \
                             ResetFontSize, ScrollPageUp, ScrollPageDown, ScrollToTop, \
-                            ScrollToBottom, ClearHistory, Hide, ClearLogNotice, NewInstanceSameDir or Quit")
+                            ScrollToBottom, ClearHistory, Hide, ClearLogNotice, SpawnNewInstance or Quit")
             }
 
             fn visit_str<E>(self, value: &str) -> ::std::result::Result<ActionWrapper, E>
@@ -792,7 +792,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
                     "Hide" => Action::Hide,
                     "Quit" => Action::Quit,
                     "ClearLogNotice" => Action::ClearLogNotice,
-                    "NewInstanceSameDir" => Action::NewInstanceSameDir,
+                    "SpawnNewInstance" => Action::SpawnNewInstance,
                     _ => return Err(E::invalid_value(Unexpected::Str(value), &self)),
                 }))
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -771,7 +771,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
             fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, \
                             ResetFontSize, ScrollPageUp, ScrollPageDown, ScrollToTop, \
-                            ScrollToBottom, ClearHistory, Hide, ClearLogNotice or Quit")
+                            ScrollToBottom, ClearHistory, Hide, ClearLogNotice, NewInstanceSameDir or Quit")
             }
 
             fn visit_str<E>(self, value: &str) -> ::std::result::Result<ActionWrapper, E>

--- a/src/config.rs
+++ b/src/config.rs
@@ -792,6 +792,7 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
                     "Hide" => Action::Hide,
                     "Quit" => Action::Quit,
                     "ClearLogNotice" => Action::ClearLogNotice,
+                    "NewInstanceSameDir" => Action::NewInstanceSameDir,
                     _ => return Err(E::invalid_value(Unexpected::Str(value), &self)),
                 }))
             }

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use std::io::Write;
 use std::sync::mpsc;
 use std::time::{Instant};
-use std::process;
 use std::process::Command;
 use std::env;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 //! Process window events
 use std::borrow::Cow;
-use std::fs::File;
+use std::fs::{self,File};
 use std::io::Write;
 use std::sync::mpsc;
 use std::time::{Instant};
@@ -183,34 +183,18 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     }
 
     fn new_instance_same_dir(&mut self) {
-        #[cfg(target_os = "linux")]
+        #[cfg(not(target_os = "windows"))]
         unsafe {
-            let current_working_dir = Command::new("pwdx")
-                .arg(tty::PID.to_string())
-                .output()
-                .expect("Failed to get shelll current working dir")
-                .stdout;
-            let current_working_dir = String::from_utf8(current_working_dir)
-                .expect("Failed to convert to string");
+        let current_working_dir =  fs::read_link(format!("/proc/{}/cwd", tty::PID))
+            .expect("Failed to get shell cwd");
+        let args:Vec<String> = env::args().collect();
 
-            let space_pos = current_working_dir
-                .find(" ")
-                .expect("Failed to find space");
-
-            let current_working_dir: String = current_working_dir
-                .chars()
-                .skip(space_pos + 1)
-                .take(current_working_dir.len() - space_pos + 1)
-                .collect(); 
-
-            let args:Vec<String> = env::args().collect();
-
-            Command::new(&args[0])
-                .arg("--working-directory")
-                .arg(&current_working_dir.trim())
-                .spawn()
-                .expect("");
-
+        Command::new(&args[0])
+            .arg("--working-directory")
+            .arg(&current_working_dir.into_os_string())
+            .spawn()
+            .expect("Failed to spawn new alacritty");
+            
         }
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -182,8 +182,8 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         self.terminal.clear_log();
     }
 
+    #[cfg(not(target_os = "windows"))]
     fn new_instance_same_dir(&mut self) {
-        #[cfg(not(target_os = "windows"))]
         unsafe {
         let current_working_dir =  fs::read_link(format!("/proc/{}/cwd", tty::PID))
             .expect("Failed to get shell cwd");
@@ -197,6 +197,13 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
             
         }
     }
+
+    #[cfg(target_os = "windows")]
+    fn new_instance_same_dir(&mut self) {
+        Command::new(&args[0])
+            .spawn()
+            .expect("Failed to spawn new alacritty");
+        }
 
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,8 @@
 //! Process window events
+#[cfg(unix)]
+use std::fs;
 use std::borrow::Cow;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::Write;
 use std::sync::mpsc;
 use std::time::{Instant};
@@ -12,6 +14,8 @@ use glutin::{self, ModifiersState, Event, ElementState};
 use copypasta::{Clipboard, Load, Store, Buffer as ClipboardBuffer};
 use glutin::dpi::PhysicalSize;
 
+#[cfg(unix)]
+use crate::tty;
 use crate::ansi::{Handler, ClearMode};
 use crate::grid::Scroll;
 use crate::config::{self, Config};
@@ -26,7 +30,6 @@ use crate::term::cell::Cell;
 use crate::util::{limit, start_daemon};
 use crate::util::fmt::Red;
 use crate::window::Window;
-use crate::tty;
 
 /// Byte sequences are sent to a `Notify` in response to some events
 pub trait Notify {
@@ -189,7 +192,7 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
                 .expect("shell working directory"),
         ];
         #[cfg(not(unix))]
-        let args = [];
+        let args: [&str; 0] = [];
 
         match (start_daemon(&alacritty, &args), args.get(1)) {
             (Ok(_), Some(dir)) => println!("Started new Alacritty process in {:?}", dir),

--- a/src/event.rs
+++ b/src/event.rs
@@ -194,11 +194,9 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         #[cfg(not(unix))]
         let args: [&str; 0] = [];
 
-        match (start_daemon(&alacritty, &args), args.get(1)) {
-            (Ok(_), Some(dir)) => println!("Started new Alacritty process in {:?}", dir),
-            (Ok(_), _) => println!("Started new Alacritty process"),
-            (Err(_), Some(dir)) => println!("Unable to start new Alacritty process in {:?}", dir),
-            (Err(_), _) => println!("Unable to start new Alacritty process"),
+        match start_daemon(&alacritty, &args) {
+            Ok(_) => debug!("Started new Alacritty process: {} {:?}", alacritty, args),
+            Err(_) => warn!("Unable to start new Alacritty process: {} {:?}", alacritty, args),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,17 +1,16 @@
 //! Process window events
 use std::borrow::Cow;
-use std::fs::{self,File};
+use std::fs::{self, File};
 use std::io::Write;
 use std::sync::mpsc;
 use std::time::{Instant};
 use std::env;
 
-use crate::tty;
-
 use serde_json as json;
 use parking_lot::MutexGuard;
 use glutin::{self, ModifiersState, Event, ElementState};
 use copypasta::{Clipboard, Load, Store, Buffer as ClipboardBuffer};
+use glutin::dpi::PhysicalSize;
 
 use crate::ansi::{Handler, ClearMode};
 use crate::grid::Scroll;
@@ -27,7 +26,7 @@ use crate::term::cell::Cell;
 use crate::util::{limit, start_daemon};
 use crate::util::fmt::Red;
 use crate::window::Window;
-use glutin::dpi::PhysicalSize;
+use crate::tty;
 
 /// Byte sequences are sent to a `Notify` in response to some events
 pub trait Notify {

--- a/src/event.rs
+++ b/src/event.rs
@@ -183,6 +183,7 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     }
 
     fn new_instance_same_dir(&mut self) {
+       if cfg!(target_os = "linux"){
         unsafe {
         let current_working_dir = Command::new("pwdx")
             .arg(tty::PID.to_string())
@@ -211,6 +212,7 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
             .expect("");
             
         }
+       }
     }
 
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -183,36 +183,35 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     }
 
     fn new_instance_same_dir(&mut self) {
-       if cfg!(target_os = "linux"){
+        #[cfg(target_os = "linux")]
         unsafe {
-        let current_working_dir = Command::new("pwdx")
-            .arg(tty::PID.to_string())
-            .output()
-            .expect("Failed to get shelll current working dir")
-            .stdout;
-        let current_working_dir = String::from_utf8(current_working_dir)
-            .expect("Failed to convert to string");
-        
-        let space_pos = current_working_dir
-            .find(" ")
-            .expect("Failed to find space");
+            let current_working_dir = Command::new("pwdx")
+                .arg(tty::PID.to_string())
+                .output()
+                .expect("Failed to get shelll current working dir")
+                .stdout;
+            let current_working_dir = String::from_utf8(current_working_dir)
+                .expect("Failed to convert to string");
 
-        let current_working_dir: String = current_working_dir
-            .chars()
-            .skip(space_pos + 1)
-            .take(current_working_dir.len() - space_pos + 1)
-            .collect(); 
+            let space_pos = current_working_dir
+                .find(" ")
+                .expect("Failed to find space");
 
-        let args:Vec<String> = env::args().collect();
+            let current_working_dir: String = current_working_dir
+                .chars()
+                .skip(space_pos + 1)
+                .take(current_working_dir.len() - space_pos + 1)
+                .collect(); 
 
-        Command::new(&args[0])
-            .arg("--working-directory")
-            .arg(&current_working_dir.trim())
-            .spawn()
-            .expect("");
-            
+            let args:Vec<String> = env::args().collect();
+
+            Command::new(&args[0])
+                .arg("--working-directory")
+                .arg(&current_working_dir.trim())
+                .spawn()
+                .expect("");
+
         }
-       }
     }
 
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -200,6 +200,7 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
 
     #[cfg(target_os = "windows")]
     fn new_instance_same_dir(&mut self) {
+        let args:Vec<String> = env::args().collect();
         Command::new(&args[0])
             .spawn()
             .expect("Failed to spawn new alacritty");

--- a/src/event.rs
+++ b/src/event.rs
@@ -182,7 +182,7 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         self.terminal.clear_log();
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(unix)]
     fn new_instance_same_dir(&mut self) {
         unsafe {
         let current_working_dir =  fs::read_link(format!("/proc/{}/cwd", tty::PID))
@@ -198,16 +198,14 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         }
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     fn new_instance_same_dir(&mut self) {
         let args:Vec<String> = env::args().collect();
         Command::new(&args[0])
             .spawn()
             .expect("Failed to spawn new alacritty");
-        }
-
+    }
 }
-
 /// The ActionContext can't really have direct access to the Window
 /// with the current design. Event handlers that want to change the
 /// window must set these flags instead. The processor will trigger

--- a/src/input.rs
+++ b/src/input.rs
@@ -872,6 +872,7 @@ mod tests {
         fn hide_window(&mut self) {
         }
         fn clear_log(&mut self) {}
+        fn new_instance_same_dir(&mut self) {}
     }
 
     macro_rules! test_clickstate {

--- a/src/input.rs
+++ b/src/input.rs
@@ -204,7 +204,7 @@ pub enum Action {
     /// Clears warning and error notices.
     ClearLogNotice,
 
-    /// Create new instance of alacritty with the current directory
+    /// Spawn a new instance of Alacritty.
     SpawnNewInstance,
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -75,7 +75,7 @@ pub trait ActionContext {
     fn hide_window(&mut self);
     fn url(&self, _: Point<usize>) -> Option<String>;
     fn clear_log(&mut self);
-    fn new_instance_same_dir(&mut self);
+    fn spawn_new_instance(&mut self);
 }
 
 /// Describes a state and action to take in that state
@@ -203,8 +203,9 @@ pub enum Action {
 
     /// Clears warning and error notices.
     ClearLogNotice,
+
     /// Create new instance of alacritty with the current directory
-    NewInstanceSameDir,
+    SpawnNewInstance,
 }
 
 impl Action {
@@ -283,8 +284,8 @@ impl Action {
             Action::ClearLogNotice => {
                 ctx.clear_log();
             },
-            Action::NewInstanceSameDir => {
-                ctx.new_instance_same_dir();
+            Action::SpawnNewInstance => {
+                ctx.spawn_new_instance();
             },
         }
     }
@@ -799,9 +800,17 @@ mod tests {
     }
 
     impl <'a>super::ActionContext for ActionContext<'a> {
-        fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, _val: B) {
-            // STUBBED
-        }
+        fn write_to_pty<B: Into<Cow<'static, [u8]>>>(&mut self, _val: B) {}
+        fn update_selection(&mut self, _point: Point, _side: Side) {}
+        fn simple_selection(&mut self, _point: Point, _side: Side) {}
+        fn copy_selection(&self, _buffer: ClipboardBuffer) {}
+        fn clear_selection(&mut self) {}
+        fn change_font_size(&mut self, _delta: f32) {}
+        fn reset_font_size(&mut self) {}
+        fn clear_history(&mut self) {}
+        fn clear_log(&mut self) {}
+        fn hide_window(&mut self) {}
+        fn spawn_new_instance(&mut self) {}
 
         fn terminal_mode(&self) -> TermMode {
             *self.terminal.mode()
@@ -810,14 +819,6 @@ mod tests {
         fn size_info(&self) -> SizeInfo {
             *self.size_info
         }
-
-        fn copy_selection(&self, _buffer: ClipboardBuffer) {
-            // STUBBED
-        }
-
-        fn clear_selection(&mut self) {}
-        fn update_selection(&mut self, _point: Point, _side: Side) {}
-        fn simple_selection(&mut self, _point: Point, _side: Side) {}
 
         fn semantic_selection(&mut self, _point: Point) {
             // set something that we can check for here
@@ -857,22 +858,14 @@ mod tests {
         fn received_count(&mut self) -> &mut usize {
             &mut self.received_count
         }
+
         fn suppress_chars(&mut self) -> &mut bool {
             &mut self.suppress_chars
         }
+
         fn last_modifiers(&mut self) -> &mut ModifiersState {
             &mut self.last_modifiers
         }
-        fn change_font_size(&mut self, _delta: f32) {
-        }
-        fn reset_font_size(&mut self) {
-        }
-        fn clear_history(&mut self) {
-        }
-        fn hide_window(&mut self) {
-        }
-        fn clear_log(&mut self) {}
-        fn new_instance_same_dir(&mut self) {}
     }
 
     macro_rules! test_clickstate {

--- a/src/input.rs
+++ b/src/input.rs
@@ -75,6 +75,7 @@ pub trait ActionContext {
     fn hide_window(&mut self);
     fn url(&self, _: Point<usize>) -> Option<String>;
     fn clear_log(&mut self);
+    fn new_instance_same_dir(&mut self);
 }
 
 /// Describes a state and action to take in that state
@@ -202,6 +203,8 @@ pub enum Action {
 
     /// Clears warning and error notices.
     ClearLogNotice,
+    /// Create new instance of alacritty with the current directory
+    NewInstanceSameDir,
 }
 
 impl Action {
@@ -279,7 +282,10 @@ impl Action {
             },
             Action::ClearLogNotice => {
                 ctx.clear_log();
-            }
+            },
+            Action::NewInstanceSameDir => {
+                ctx.new_instance_same_dir();
+            },
         }
     }
 

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -38,7 +38,7 @@ use std::os::unix::io::AsRawFd;
 /// Process ID of child process
 ///
 /// Necessary to put this in static storage for `sigchld` to have access
-static mut PID: pid_t = 0;
+pub static mut PID: pid_t = 0;
 
 /// Exit flag
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,6 +14,7 @@
 #[cfg(not(windows))]
 use std::os::unix::process::CommandExt;
 use std::process::Command;
+use std::ffi::OsStr;
 use std::{cmp, io};
 
 /// Threading utilities
@@ -77,7 +78,11 @@ pub mod fmt {
 }
 
 #[cfg(not(windows))]
-pub fn start_daemon(program: &str, args: &[String]) -> io::Result<()> {
+pub fn start_daemon<I, S>(program: &str, args: I) -> io::Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+{
     Command::new(program)
         .args(args)
         .before_exec(|| unsafe {
@@ -90,7 +95,11 @@ pub fn start_daemon(program: &str, args: &[String]) -> io::Result<()> {
 }
 
 #[cfg(windows)]
-pub fn start_daemon(program: &str, args: &[String]) -> io::Result<()> {
+pub fn start_daemon<I, S>(program: &str, args: I) -> io::Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+{
     Command::new(program).args(args).spawn().map(|_| ())
 }
 


### PR DESCRIPTION
Other terminals allow you to spawn a new instance of the terminal with the same working directory. This pull request adds this feature.

Tested on: 
- Linux Xorg
- Linux Wayland ( Sway )

Notes:
- It will probably crash on windows and mac.
- I changed the shell PID variable on tty::unix::PID to public. Don't know if that is allowed. 
- I didn't write any tests 😅. 

This fixes https://github.com/jwilm/alacritty/issues/808.
