### PR TITLE
Set minimum macOS version to 10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URLs are only launched when left-clicking
 - Removal of extra characters (like `,`) at the end of URLs has been improved
 - Single quotes (`'`) are removed from URLs when there is no matching opening quote
+- Precompiled binaries now work with macOS versions before 10.13 (10.11 and above)
 
 ## Version 0.2.4
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ APP_DIR = $(RELEASE_DIR)/osx
 APP_BINARY = $(RELEASE_DIR)/$(TARGET)
 APP_BINARY_DIR  = $(APP_DIR)/$(APP_NAME)/Contents/MacOS
 
-export MACOSX_DEPLOYMENT_TARGET = $(shell defaults read loginwindow SystemVersionStampAsString)
-
 DMG_NAME = Alacritty.dmg
 DMG_DIR = $(RELEASE_DIR)/osx
 
@@ -24,10 +22,7 @@ help: ## Prints help for targets with comments
 
 binary: | $(TARGET) ## Build release binary with cargo
 $(TARGET):
-ifneq ( "${MACOSX_DEPLOYMENT_TARGET}" , "")
-	@echo MACOSX_DEPLOYMENT_TARGET=$${MACOSX_DEPLOYMENT_TARGET}
-endif
-	cargo build --release
+	MACOSX_DEPLOYMENT_TARGET="10.11" cargo build --release
 
 app: | $(APP_NAME) ## Clone Alacritty.app template and mount binary
 $(APP_NAME): $(TARGET) $(APP_TEMPLATE)


### PR DESCRIPTION
To make sure that CI builds produced by Travis work on all supported
versions of macOS and building Alacritty works on all supported
versions, the minimum macOS version has been set in the Makefile.

This sets the minimum macOS version to `10.11` as a reasonable
estimation based on other applications. If the exact version chosen
turns out to cause some issues, it can be changed in the future.

Fixes #1853.