### PR TITLE
Fix selection with right and middle mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Replaced `Command` with `Super` in the Linux and Windows config documentation
+- Prevent semantic and line selection from starting with the right or middle mouse button
 
 ## Version 0.2.5
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,7 +10,7 @@ use std::env;
 
 use serde_json as json;
 use parking_lot::MutexGuard;
-use glutin::{self, ModifiersState, Event, ElementState};
+use glutin::{self, ModifiersState, Event, ElementState, MouseButton};
 use copypasta::{Clipboard, Load, Store, Buffer as ClipboardBuffer};
 use glutin::dpi::PhysicalSize;
 
@@ -245,6 +245,7 @@ pub struct Mouse {
     pub cell_side: Side,
     pub lines_scrolled: f32,
     pub block_url_launcher: bool,
+    pub last_button: MouseButton,
 }
 
 impl Default for Mouse {
@@ -263,6 +264,7 @@ impl Default for Mouse {
             cell_side: Side::Left,
             lines_scrolled: 0.0,
             block_url_launcher: false,
+            last_button: MouseButton::Other(0),
         }
     }
 }


### PR DESCRIPTION
Since there was no check for the button state for semantic and line
selection, it was possible to trigger selection using the middle and
right mouse button. This has been resolved by explicitly checking for
the pressed button before starting these selections.

To further ensure that double and triple clicks are only triggered when
the same button is pressed multiple times, the last pressed button is
stored.

This fixes #1915.