### PR TITLE
Fix tabs overwriting cells during movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent semantic and line selection from starting with the right or middle mouse button
 - Prevent Alacritty from crashing when started on a system without any free space
 - Resolve issue with high CPU usage after moving Alacritty between displays
+- Characters will no longer be deleted when using ncurses with the hard tab optimization
 
 ## Version 0.2.5
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1565,8 +1565,9 @@ impl ansi::Handler for Term {
             count -= 1;
 
             let cell = &mut self.grid[&self.cursor.point];
-            *cell = self.cursor.template;
-            cell.c = self.cursor.charsets[self.active_charset].map('\t');
+            if cell.c == ' ' {
+                cell.c = self.cursor.charsets[self.active_charset].map('\t');
+            }
 
             loop {
                 if (self.cursor.point.col + 1) == self.grid.num_cols() {


### PR DESCRIPTION
When compiling ncurses with the `--enable-hard-tabs` option, it will
make use of tabs to speed up cursor movement. These tabs can be set at
positions which will overwrite existing characters.

Since these are only for movement and not supposed to write anything to
the terminal, it is now checked that a cell does not contain any
character before writing a tab to it.

This fixes #1933.