### PR TITLE
Fix off-by-one error in erase_chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Line's last character will no longer escape erasing
+- Resolved off-by-one issue with erasing characters in the last column
 
 ## Version 0.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Line's last character will no longer escape erasing
+
 ## Version 0.2.7
 
 ### Fixed

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1702,7 +1702,7 @@ impl ansi::Handler for Term {
     fn erase_chars(&mut self, count: Column) {
         trace!("Erasing chars: count={}, col={}", count, self.cursor.point.col);
         let start = self.cursor.point.col;
-        let end = min(start + count, self.grid.num_cols() - 1);
+        let end = min(start + count, self.grid.num_cols());
 
         let row = &mut self.grid[self.cursor.point.line];
         let template = self.cursor.template; // Cleared cells have current background color set


### PR DESCRIPTION
I had an issue with last characters on the line remaining on the screen even after line they belonged to moved up or down. Easy repro: open any text file with long lines (alacritty.yml for example around line 100) in an editor of your choice, and then move around so the editor scrolls up or down. Last char of the line will not be erased.

Here is the example:
<img width="487" alt="alacritty_bug" src="https://user-images.githubusercontent.com/3798402/51405719-00206480-1b4f-11e9-9580-7068747d2b5f.png">

It looked like off-by-one kind of error from the start, so it was just a matter of seeing what kind of events are happening when bug is present.

According to rust docs, slicing with [..N] doesn't include N-th element, so we don't have to subtract 1 from num_cols().

On a side note, for some reason the issue doesn't manifest itself with winpty on Windows, only with conpty.