### PR TITLE
Fix crash on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Crash when trying to start Alacritty on Windows
+
 ## Version 0.2.6
 
 ### Added

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -79,7 +79,7 @@ tabspaces: 8
 # Font configuration (changes require restart)
 font:
   # Normal (roman) font face
-  normal:
+  #normal:
     # Font family
     #
     # Default:
@@ -89,10 +89,10 @@ font:
     #family: monospace
 
     # The `style` can be specified to pick a specific face.
-    style: Regular
+    #style: Regular
 
   # Bold font face
-  bold:
+  #bold:
     # Font family
     #
     # If the bold family is not specified, it will fall back to the
@@ -100,10 +100,10 @@ font:
     #family: monospace
 
     # The `style` can be specified to pick a specific face.
-    style: Bold
+    #style: Bold
 
   # Italic font face
-  italic:
+  #italic:
     # Font family
     #
     # If the italic family is not specified, it will fall back to the
@@ -111,7 +111,7 @@ font:
     #family: monospace
 
     # The `style` can be specified to pick a specific face.
-    style: Italic
+    #style: Italic
 
   # Point size
   size: 11.0

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -61,7 +61,13 @@ impl crate::Rasterize for RustTypeRasterizer {
             .monospace();
 
         let fp = match desc.style {
-            Style::Specific(_) => unimplemented!(""),
+            Style::Specific(style) => {
+                match style.to_lowercase() {
+                    "italic" => fp.italic(),
+                    "bold" => fp.bold(),
+                    _ => fp,
+                }
+            },
             Style::Description { slant, weight } => {
                 let fp = match slant {
                     Slant::Normal => fp,

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -61,8 +61,8 @@ impl crate::Rasterize for RustTypeRasterizer {
             .monospace();
 
         let fp = match desc.style {
-            Style::Specific(style) => {
-                match style.to_lowercase() {
+            Style::Specific(ref style) => {
+                match style.to_lowercase().as_str() {
                     "italic" => fp.italic(),
                     "bold" => fp.bold(),
                     _ => fp,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2060,9 +2060,9 @@ impl Default for Font {
             #[cfg(target_os = "macos")]
             use_thin_strokes: true,
             size: default_font_size(),
-            normal: FontDescription::new_with_style("Regular"),
-            bold: SecondaryFontDescription::new_with_style("Bold"),
-            italic: SecondaryFontDescription::new_with_style("Italic"),
+            normal: Default::default(),
+            bold: Default::default(),
+            italic: Default::default(),
             scale_with_dpi: Default::default(),
             glyph_offset: Default::default(),
             offset: Default::default(),
@@ -2152,15 +2152,6 @@ impl Default for FontDescription {
     }
 }
 
-impl FontDescription {
-    fn new_with_style(style: &str) -> Self {
-        Self {
-            style: Some(style.into()),
-            ..Default::default()
-        }
-    }
-}
-
 /// Description of the italic and bold font
 #[serde(default)]
 #[derive(Debug, Default, Deserialize, Clone, PartialEq, Eq)]
@@ -2176,15 +2167,6 @@ impl SecondaryFontDescription {
         FontDescription {
             family: self.family.clone().unwrap_or_else(|| fallback.family.clone()),
             style: self.style.clone(),
-        }
-    }
-}
-
-impl SecondaryFontDescription {
-    fn new_with_style(style: &str) -> Self {
-        Self {
-            style: Some(style.into()),
-            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
The rusttype backend did not properly support manually specifying font
styles, but instead chose to panic when they are specified.

The rusttype implementation now provides a proper implementation for
handling `bold`, `italic` and `regular` font styles.

This fixes #2020.