### PR TITLE
 Move clippy tests to stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ os:
 
 rust:
   - stable
+  - beta
   - nightly
 
 matrix:
@@ -22,6 +23,18 @@ matrix:
       os: linux
       rust: stable
       env: ARCH=i386
+    - name: "Clippy Linux"
+      os: linux
+      env: CLIPPY=true
+      rust: stable
+    - name: "Clippy OSX"
+      os: osx
+      env: CLIPPY=true
+      rust: stable
+    - name: "Clippy Windows"
+      os: windows
+      env: CLIPPY=true
+      rust: stable
   allow_failures:
     - rust: nightly
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Add clippy for linting with nightly builds
-if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-    rustup component add clippy-preview
+if [ "$CLIPPY" == "true" ]; then
+    rustup component add clippy
 fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,7 +5,7 @@ error=false
 
 # Run clippy checks
 if [ "$CLIPPY" == "true" ]; then
-    cargo clippy --all-features --all-targets
+    cargo clippy --all-targets
     exit
 fi
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,9 +3,10 @@
 # Check if any command failed
 error=false
 
-# Run clippy on nightly builds
-if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-    cargo clippy --all-features --all-targets || error=true
+# Run clippy checks
+if [ "$CLIPPY" == "true" ]; then
+    cargo clippy --all-features --all-targets
+    exit
 fi
 
 # Run test in release mode if a tag is present, to produce an optimized binary

--- a/src/config/bindings.rs
+++ b/src/config/bindings.rs
@@ -47,7 +47,6 @@ macro_rules! bindings {
                 mode: _mode,
                 notmode: _notmode,
                 action: $action,
-                ..Default::default()
             });
         )*
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -137,7 +137,7 @@ impl log::Log for Logger {
                         record.file().unwrap_or("?"),
                         record.line()
                               .map(|l| l.to_string())
-                              .unwrap_or("?".to_string()),
+                              .unwrap_or_else(|| "?".into()),
                         record.args())
             } else {
                 format!("[{}] [{}] {}\n",

--- a/src/tty/windows/mod.rs
+++ b/src/tty/windows/mod.rs
@@ -208,7 +208,7 @@ impl Write for EventedWritablePipe {
 impl<'a> OnResize for PtyHandle<'a> {
     fn on_resize(&mut self, sizeinfo: &SizeInfo) {
         match self {
-            PtyHandle::Winpty(w) => w.winpty_mut().on_resize(sizeinfo),
+            PtyHandle::Winpty(w) => w.resize(sizeinfo),
             PtyHandle::Conpty(c) => {
                 let mut handle = c.clone();
                 handle.on_resize(sizeinfo)

--- a/src/tty/windows/winpty.rs
+++ b/src/tty/windows/winpty.rs
@@ -55,14 +55,16 @@ impl<'a> Agent<'a> {
 
     /// Get immutable access to Winpty.
     pub fn winpty(&self) -> &Winpty<'a> {
-        unsafe {&*self.winpty}
+        unsafe { &*self.winpty }
     }
 
-    /// Get mutable access to Winpty.
-    /// Can offer internal mutability like this because Winpty uses
-    /// a mutex internally.
-    pub fn winpty_mut(&self) -> &mut Winpty<'a> {
-        unsafe {&mut *self.winpty}
+    pub fn resize(&self, size: &SizeInfo) {
+        /// Get mutable access to Winpty.
+        /// Can offer internal mutability like this because Winpty uses
+        /// a mutex internally.
+        unsafe {
+            (&mut *self.winpty).on_resize(size);
+        }
     }
 }
 

--- a/src/tty/windows/winpty.rs
+++ b/src/tty/windows/winpty.rs
@@ -59,9 +59,7 @@ impl<'a> Agent<'a> {
     }
 
     pub fn resize(&self, size: &SizeInfo) {
-        /// Get mutable access to Winpty.
-        /// Can offer internal mutability like this because Winpty uses
-        /// a mutex internally.
+        // This is safe since Winpty uses a mutex internally.
         unsafe {
             (&mut *self.winpty).on_resize(size);
         }


### PR DESCRIPTION
The clippy tests had to be run on nightly previously since it wasn't
available with the stable compiler yet, however this had the potential
to fail a lot since not all nightly builds offer clippy.

Since clippy is now available for stable rust, moving clippy to a stable
build should make sure that the failure rate of the CI job is cut down
to a minimum.

This fixes #2007.