### PR TITLE
Changed explicit script shebangs to use environment

### DIFF
--- a/scripts/24-bit-color.sh
+++ b/scripts/24-bit-color.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file was originally taken from iterm2 https://github.com/gnachman/iTerm2/blob/master/tests/24-bit-color.sh
 #
 #   This file echoes a bunch of 24-bit color codes

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for x in {0..8}; do
     for i in {30..37}; do

--- a/scripts/fg-bg.sh
+++ b/scripts/fg-bg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 printf "Fg=Black  Bg=Black           \e[30;40mTEST\e[m\n"
 printf "Fg=Black  Bg=White           \e[30;107mTEST\e[m\n"

--- a/scripts/spawn-alacritty-cwd
+++ b/scripts/spawn-alacritty-cwd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Spawn a new instance of Alacritty using the CWD of the currently focused
 # Alacritty process.


### PR DESCRIPTION
Changed shebangs from /bin/bash to /usr/bin/env bash. Some distributions do not have have bash in the standard path.