### PR TITLE
Debian needs pkg-config

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ libraries to build Alacritty. Here's an apt command that should install all of
 them. If something is still found to be missing, please open an issue.
 
 ```sh
-apt-get install cmake libfreetype6-dev libfontconfig1-dev xclip
+apt-get install cmake pkg-config libfreetype6-dev libfontconfig1-dev xclip
 ```
 
 #### Arch Linux


### PR DESCRIPTION
I just went through these instructions on my Debian 9.7 machine, and pkg-config wasn't already installed.