### PR TITLE
Fix reloading with empty config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved off-by-one issue with erasing characters in the last column
 - Excessive polling every 100ms with `live_config_reload` enabled
 - Unicode characters at the beginning of URLs are now properly ignored
+- Remove error message when reloading an empty config
 
 ## Version 0.2.7
 


### PR DESCRIPTION
When loading an empty configuration file, Alacritty only prints an info
message and then proceeds to load the default config. However when
reloading the configuration file it would throw a hard error.

This has been fixed and a hard error is now only thrown when an error is
returned during reload which isn't the empty file error.