### PR TITLE
 Fix regression in the URL launcher config 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Smoother scrolling for touchpads (also affects scrolling with some mice that send fractional scrolling values)
+- Improve scrolling accuracy with devices sending fractional updates (like touchpads)
 - `scrolling.multiplier` now affects normal scrolling with touchpads
 
 ### Fixed
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Excessive polling every 100ms with `live_config_reload` enabled
 - Unicode characters at the beginning of URLs are now properly ignored
 - Remove error message when reloading an empty config
+- Allow disabling URL launching by setting the value of `mouse.url.launcher` to `None`
 
 ## Version 0.2.7
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -291,6 +291,8 @@ mouse:
     # This program is executed when clicking on a text which is recognized as a URL.
     # The URL is always added to the command as the last parameter.
     #
+    # When set to `None`, URL launching will be disabled completely.
+    #
     # Default:
     #   - (macOS) open
     #   - (Linux) xdg-open

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -116,12 +116,38 @@ pub struct Mouse {
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct Url {
     // Program for opening links
-    #[serde(deserialize_with = "failure_default")]
+    #[serde(deserialize_with = "deserialize_launcher")]
     pub launcher: Option<CommandWrapper>,
 
     // Modifier used to open links
     #[serde(deserialize_with = "deserialize_modifiers")]
     pub modifiers: ModifiersState,
+}
+
+fn deserialize_launcher<'a, D>(deserializer: D) -> ::std::result::Result<Option<CommandWrapper>, D::Error>
+    where D: de::Deserializer<'a>
+{
+    // Deserialize to generic value
+    let val = match serde_yaml::Value::deserialize(deserializer) {
+        Ok(val) => val,
+        Err(err) => {
+            error!("Problem with config: {}; using default value", err);
+            return Ok(None);
+        },
+    };
+
+    // Accept `None` to disable the launcher
+    if val.as_str().filter(|v| v.to_lowercase() == "none").is_some() {
+        return Ok(None);
+    }
+
+    match <Option<CommandWrapper>>::deserialize(val) {
+        Ok(launcher) => Ok(launcher),
+        Err(err) => {
+            error!("Problem with config: {}; using default value", err);
+            Ok(None)
+        },
+    }
 }
 
 impl Default for Url {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,12 +127,14 @@ pub struct Url {
 fn deserialize_launcher<'a, D>(deserializer: D) -> ::std::result::Result<Option<CommandWrapper>, D::Error>
     where D: de::Deserializer<'a>
 {
+    let default = Url::default().launcher;
+
     // Deserialize to generic value
     let val = match serde_yaml::Value::deserialize(deserializer) {
         Ok(val) => val,
         Err(err) => {
-            error!("Problem with config: {}; using default value", err);
-            return Ok(None);
+            error!("Problem with config: {}; using {}", err, default.clone().unwrap().program());
+            return Ok(default);
         },
     };
 
@@ -144,8 +146,8 @@ fn deserialize_launcher<'a, D>(deserializer: D) -> ::std::result::Result<Option<
     match <Option<CommandWrapper>>::deserialize(val) {
         Ok(launcher) => Ok(launcher),
         Err(err) => {
-            error!("Problem with config: {}; using default value", err);
-            Ok(None)
+            error!("Problem with config: {}; using {}", err, default.clone().unwrap().program());
+            Ok(default)
         },
     }
 }


### PR DESCRIPTION
Due to the merging of configuration files on all platforms, it has been
made impossible to completely disable URL launching without still
executing some kind of program like `true`.

Setting the launcher to `None` in the config, will now disable it
completely.

This fixes #2058.