### PR TITLE
 Change shift+pgup/pgdown to scroll history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error/Warning bar doesn't overwrite the terminal anymore
 - Full error/warning messages are displayed
 - Config error messages are automatically removed when the config is fixed
+- Scroll history on Shift+PgUp/PgDown when scrollback history is available
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -444,122 +444,124 @@ alt_send_esc: true
 #   - AppKeypad
 key_bindings:
   # (Windows/Linux only)
-  #- { key: V,        mods: Control|Shift,    action: Paste               }
-  #- { key: C,        mods: Control|Shift,    action: Copy                }
-  #- { key: Insert,   mods: Shift,   action: PasteSelection               }
-  #- { key: Key0,     mods: Control, action: ResetFontSize                }
-  #- { key: Equals,   mods: Control, action: IncreaseFontSize             }
-  #- { key: Subtract, mods: Control, action: DecreaseFontSize             }
+  #- { key: V,        mods: Control|Shift, action: Paste            }
+  #- { key: C,        mods: Control|Shift, action: Copy             }
+  #- { key: Insert,   mods: Shift,         action: PasteSelection   }
+  #- { key: Key0,     mods: Control,       action: ResetFontSize    }
+  #- { key: Equals,   mods: Control,       action: IncreaseFontSize }
+  #- { key: Subtract, mods: Control,       action: DecreaseFontSize }
 
   # (macOS only)
-  #- { key: Key0,     mods: Command, action: ResetFontSize                }
-  #- { key: Equals,   mods: Command, action: IncreaseFontSize             }
-  #- { key: Minus,    mods: Command, action: DecreaseFontSize             }
-  #- { key: K,        mods: Command, action: ClearHistory                 }
-  #- { key: K,        mods: Command, chars: "\x0c"                        }
-  #- { key: V,        mods: Command, action: Paste                        }
-  #- { key: C,        mods: Command, action: Copy                         }
-  #- { key: H,        mods: Command, action: Hide                         }
-  #- { key: Q,        mods: Command, action: Quit                         }
-  #- { key: W,        mods: Command, action: Quit                         }
+  #- { key: Key0,   mods: Command, action: ResetFontSize    }
+  #- { key: Equals, mods: Command, action: IncreaseFontSize }
+  #- { key: Minus,  mods: Command, action: DecreaseFontSize }
+  #- { key: K,      mods: Command, action: ClearHistory     }
+  #- { key: K,      mods: Command, chars: "\x0c"            }
+  #- { key: V,      mods: Command, action: Paste            }
+  #- { key: C,      mods: Command, action: Copy             }
+  #- { key: H,      mods: Command, action: Hide             }
+  #- { key: Q,      mods: Command, action: Quit             }
+  #- { key: W,      mods: Command, action: Quit             }
 
-  - { key: Paste,                   action: Paste                        }
-  - { key: Copy,                    action: Copy                         }
-  - { key: L,        mods: Control, action: ClearLogNotice               }
-  - { key: L,        mods: Control, chars: "\x0c"                        }
-  - { key: Home,                    chars: "\x1bOH",   mode: AppCursor   }
-  - { key: Home,                    chars: "\x1b[H",   mode: ~AppCursor  }
-  - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }
-  - { key: End,                     chars: "\x1b[F",   mode: ~AppCursor  }
-  - { key: PageUp,   mods: Shift,   action: ScrollPageUp                 }
-  - { key: PageUp,   mods: Control, chars: "\x1b[5;5~"                   }
-  - { key: PageUp,                  chars: "\x1b[5~"                     }
-  - { key: PageDown, mods: Shift,   action: ScrollPageDown               }
-  - { key: PageDown, mods: Control, chars: "\x1b[6;5~"                   }
-  - { key: PageDown,                chars: "\x1b[6~"                     }
-  - { key: Tab,      mods: Shift,   chars: "\x1b[Z"                      }
-  - { key: Back,                    chars: "\x7f"                        }
-  - { key: Back,     mods: Alt,     chars: "\x1b\x7f"                    }
-  - { key: Insert,                  chars: "\x1b[2~"                     }
-  - { key: Delete,                  chars: "\x1b[3~"                     }
-  - { key: Left,     mods: Shift,   chars: "\x1b[1;2D"                   }
-  - { key: Left,     mods: Control, chars: "\x1b[1;5D"                   }
-  - { key: Left,     mods: Alt,     chars: "\x1b[1;3D"                   }
-  - { key: Left,                    chars: "\x1b[D",   mode: ~AppCursor  }
-  - { key: Left,                    chars: "\x1bOD",   mode: AppCursor   }
-  - { key: Right,    mods: Shift,   chars: "\x1b[1;2C"                   }
-  - { key: Right,    mods: Control, chars: "\x1b[1;5C"                   }
-  - { key: Right,    mods: Alt,     chars: "\x1b[1;3C"                   }
-  - { key: Right,                   chars: "\x1b[C",   mode: ~AppCursor  }
-  - { key: Right,                   chars: "\x1bOC",   mode: AppCursor   }
-  - { key: Up,       mods: Shift,   chars: "\x1b[1;2A"                   }
-  - { key: Up,       mods: Control, chars: "\x1b[1;5A"                   }
-  - { key: Up,       mods: Alt,     chars: "\x1b[1;3A"                   }
-  - { key: Up,                      chars: "\x1b[A",   mode: ~AppCursor  }
-  - { key: Up,                      chars: "\x1bOA",   mode: AppCursor   }
-  - { key: Down,     mods: Shift,   chars: "\x1b[1;2B"                   }
-  - { key: Down,     mods: Control, chars: "\x1b[1;5B"                   }
-  - { key: Down,     mods: Alt,     chars: "\x1b[1;3B"                   }
-  - { key: Down,                    chars: "\x1b[B",   mode: ~AppCursor  }
-  - { key: Down,                    chars: "\x1bOB",   mode: AppCursor   }
-  - { key: F1,                      chars: "\x1bOP"                      }
-  - { key: F2,                      chars: "\x1bOQ"                      }
-  - { key: F3,                      chars: "\x1bOR"                      }
-  - { key: F4,                      chars: "\x1bOS"                      }
-  - { key: F5,                      chars: "\x1b[15~"                    }
-  - { key: F6,                      chars: "\x1b[17~"                    }
-  - { key: F7,                      chars: "\x1b[18~"                    }
-  - { key: F8,                      chars: "\x1b[19~"                    }
-  - { key: F9,                      chars: "\x1b[20~"                    }
-  - { key: F10,                     chars: "\x1b[21~"                    }
-  - { key: F11,                     chars: "\x1b[23~"                    }
-  - { key: F12,                     chars: "\x1b[24~"                    }
-  - { key: F1,       mods: Shift,   chars: "\x1b[1;2P"                   }
-  - { key: F2,       mods: Shift,   chars: "\x1b[1;2Q"                   }
-  - { key: F3,       mods: Shift,   chars: "\x1b[1;2R"                   }
-  - { key: F4,       mods: Shift,   chars: "\x1b[1;2S"                   }
-  - { key: F5,       mods: Shift,   chars: "\x1b[15;2~"                  }
-  - { key: F6,       mods: Shift,   chars: "\x1b[17;2~"                  }
-  - { key: F7,       mods: Shift,   chars: "\x1b[18;2~"                  }
-  - { key: F8,       mods: Shift,   chars: "\x1b[19;2~"                  }
-  - { key: F9,       mods: Shift,   chars: "\x1b[20;2~"                  }
-  - { key: F10,      mods: Shift,   chars: "\x1b[21;2~"                  }
-  - { key: F11,      mods: Shift,   chars: "\x1b[23;2~"                  }
-  - { key: F12,      mods: Shift,   chars: "\x1b[24;2~"                  }
-  - { key: F1,       mods: Control, chars: "\x1b[1;5P"                   }
-  - { key: F2,       mods: Control, chars: "\x1b[1;5Q"                   }
-  - { key: F3,       mods: Control, chars: "\x1b[1;5R"                   }
-  - { key: F4,       mods: Control, chars: "\x1b[1;5S"                   }
-  - { key: F5,       mods: Control, chars: "\x1b[15;5~"                  }
-  - { key: F6,       mods: Control, chars: "\x1b[17;5~"                  }
-  - { key: F7,       mods: Control, chars: "\x1b[18;5~"                  }
-  - { key: F8,       mods: Control, chars: "\x1b[19;5~"                  }
-  - { key: F9,       mods: Control, chars: "\x1b[20;5~"                  }
-  - { key: F10,      mods: Control, chars: "\x1b[21;5~"                  }
-  - { key: F11,      mods: Control, chars: "\x1b[23;5~"                  }
-  - { key: F12,      mods: Control, chars: "\x1b[24;5~"                  }
-  - { key: F1,       mods: Alt,     chars: "\x1b[1;6P"                   }
-  - { key: F2,       mods: Alt,     chars: "\x1b[1;6Q"                   }
-  - { key: F3,       mods: Alt,     chars: "\x1b[1;6R"                   }
-  - { key: F4,       mods: Alt,     chars: "\x1b[1;6S"                   }
-  - { key: F5,       mods: Alt,     chars: "\x1b[15;6~"                  }
-  - { key: F6,       mods: Alt,     chars: "\x1b[17;6~"                  }
-  - { key: F7,       mods: Alt,     chars: "\x1b[18;6~"                  }
-  - { key: F8,       mods: Alt,     chars: "\x1b[19;6~"                  }
-  - { key: F9,       mods: Alt,     chars: "\x1b[20;6~"                  }
-  - { key: F10,      mods: Alt,     chars: "\x1b[21;6~"                  }
-  - { key: F11,      mods: Alt,     chars: "\x1b[23;6~"                  }
-  - { key: F12,      mods: Alt,     chars: "\x1b[24;6~"                  }
-  - { key: F1,       mods: Super,   chars: "\x1b[1;3P"                   }
-  - { key: F2,       mods: Super,   chars: "\x1b[1;3Q"                   }
-  - { key: F3,       mods: Super,   chars: "\x1b[1;3R"                   }
-  - { key: F4,       mods: Super,   chars: "\x1b[1;3S"                   }
-  - { key: F5,       mods: Super,   chars: "\x1b[15;3~"                  }
-  - { key: F6,       mods: Super,   chars: "\x1b[17;3~"                  }
-  - { key: F7,       mods: Super,   chars: "\x1b[18;3~"                  }
-  - { key: F8,       mods: Super,   chars: "\x1b[19;3~"                  }
-  - { key: F9,       mods: Super,   chars: "\x1b[20;3~"                  }
-  - { key: F10,      mods: Super,   chars: "\x1b[21;3~"                  }
-  - { key: F11,      mods: Super,   chars: "\x1b[23;3~"                  }
-  - { key: F12,      mods: Super,   chars: "\x1b[24;3~"                  }
-  - { key: NumpadEnter,             chars: "\n"                          }
+  - { key: Paste,                   action: Paste                            }
+  - { key: Copy,                    action: Copy                             }
+  - { key: L,        mods: Control, action: ClearLogNotice                   }
+  - { key: L,        mods: Control, chars: "\x0c"                            }
+  - { key: Home,                    chars: "\x1bOH",        mode: AppCursor  }
+  - { key: Home,                    chars: "\x1b[H",        mode: ~AppCursor }
+  - { key: End,                     chars: "\x1bOF",        mode: AppCursor  }
+  - { key: End,                     chars: "\x1b[F",        mode: ~AppCursor }
+  - { key: PageUp,   mods: Shift,   action: ScrollPageUp,   mode: ~Alt       }
+  - { key: PageUp,   mods: Shift,   chars: "\x1b[5;2~",     mode: Alt        }
+  - { key: PageUp,   mods: Control, chars: "\x1b[5;5~"                       }
+  - { key: PageUp,                  chars: "\x1b[5~"                         }
+  - { key: PageDown, mods: Shift,   action: ScrollPageDown, mode: ~Alt       }
+  - { key: PageDown, mods: Shift,   chars: "\x1b[6;2~",     mode: Alt        }
+  - { key: PageDown, mods: Control, chars: "\x1b[6;5~"                       }
+  - { key: PageDown,                chars: "\x1b[6~"                         }
+  - { key: Tab,      mods: Shift,   chars: "\x1b[Z"                          }
+  - { key: Back,                    chars: "\x7f"                            }
+  - { key: Back,     mods: Alt,     chars: "\x1b\x7f"                        }
+  - { key: Insert,                  chars: "\x1b[2~"                         }
+  - { key: Delete,                  chars: "\x1b[3~"                         }
+  - { key: Left,     mods: Shift,   chars: "\x1b[1;2D"                       }
+  - { key: Left,     mods: Control, chars: "\x1b[1;5D"                       }
+  - { key: Left,     mods: Alt,     chars: "\x1b[1;3D"                       }
+  - { key: Left,                    chars: "\x1b[D",        mode: ~AppCursor }
+  - { key: Left,                    chars: "\x1bOD",        mode: AppCursor  }
+  - { key: Right,    mods: Shift,   chars: "\x1b[1;2C"                       }
+  - { key: Right,    mods: Control, chars: "\x1b[1;5C"                       }
+  - { key: Right,    mods: Alt,     chars: "\x1b[1;3C"                       }
+  - { key: Right,                   chars: "\x1b[C",        mode: ~AppCursor }
+  - { key: Right,                   chars: "\x1bOC",        mode: AppCursor  }
+  - { key: Up,       mods: Shift,   chars: "\x1b[1;2A"                       }
+  - { key: Up,       mods: Control, chars: "\x1b[1;5A"                       }
+  - { key: Up,       mods: Alt,     chars: "\x1b[1;3A"                       }
+  - { key: Up,                      chars: "\x1b[A",        mode: ~AppCursor }
+  - { key: Up,                      chars: "\x1bOA",        mode: AppCursor  }
+  - { key: Down,     mods: Shift,   chars: "\x1b[1;2B"                       }
+  - { key: Down,     mods: Control, chars: "\x1b[1;5B"                       }
+  - { key: Down,     mods: Alt,     chars: "\x1b[1;3B"                       }
+  - { key: Down,                    chars: "\x1b[B",        mode: ~AppCursor }
+  - { key: Down,                    chars: "\x1bOB",        mode: AppCursor  }
+  - { key: F1,                      chars: "\x1bOP"                          }
+  - { key: F2,                      chars: "\x1bOQ"                          }
+  - { key: F3,                      chars: "\x1bOR"                          }
+  - { key: F4,                      chars: "\x1bOS"                          }
+  - { key: F5,                      chars: "\x1b[15~"                        }
+  - { key: F6,                      chars: "\x1b[17~"                        }
+  - { key: F7,                      chars: "\x1b[18~"                        }
+  - { key: F8,                      chars: "\x1b[19~"                        }
+  - { key: F9,                      chars: "\x1b[20~"                        }
+  - { key: F10,                     chars: "\x1b[21~"                        }
+  - { key: F11,                     chars: "\x1b[23~"                        }
+  - { key: F12,                     chars: "\x1b[24~"                        }
+  - { key: F1,       mods: Shift,   chars: "\x1b[1;2P"                       }
+  - { key: F2,       mods: Shift,   chars: "\x1b[1;2Q"                       }
+  - { key: F3,       mods: Shift,   chars: "\x1b[1;2R"                       }
+  - { key: F4,       mods: Shift,   chars: "\x1b[1;2S"                       }
+  - { key: F5,       mods: Shift,   chars: "\x1b[15;2~"                      }
+  - { key: F6,       mods: Shift,   chars: "\x1b[17;2~"                      }
+  - { key: F7,       mods: Shift,   chars: "\x1b[18;2~"                      }
+  - { key: F8,       mods: Shift,   chars: "\x1b[19;2~"                      }
+  - { key: F9,       mods: Shift,   chars: "\x1b[20;2~"                      }
+  - { key: F10,      mods: Shift,   chars: "\x1b[21;2~"                      }
+  - { key: F11,      mods: Shift,   chars: "\x1b[23;2~"                      }
+  - { key: F12,      mods: Shift,   chars: "\x1b[24;2~"                      }
+  - { key: F1,       mods: Control, chars: "\x1b[1;5P"                       }
+  - { key: F2,       mods: Control, chars: "\x1b[1;5Q"                       }
+  - { key: F3,       mods: Control, chars: "\x1b[1;5R"                       }
+  - { key: F4,       mods: Control, chars: "\x1b[1;5S"                       }
+  - { key: F5,       mods: Control, chars: "\x1b[15;5~"                      }
+  - { key: F6,       mods: Control, chars: "\x1b[17;5~"                      }
+  - { key: F7,       mods: Control, chars: "\x1b[18;5~"                      }
+  - { key: F8,       mods: Control, chars: "\x1b[19;5~"                      }
+  - { key: F9,       mods: Control, chars: "\x1b[20;5~"                      }
+  - { key: F10,      mods: Control, chars: "\x1b[21;5~"                      }
+  - { key: F11,      mods: Control, chars: "\x1b[23;5~"                      }
+  - { key: F12,      mods: Control, chars: "\x1b[24;5~"                      }
+  - { key: F1,       mods: Alt,     chars: "\x1b[1;6P"                       }
+  - { key: F2,       mods: Alt,     chars: "\x1b[1;6Q"                       }
+  - { key: F3,       mods: Alt,     chars: "\x1b[1;6R"                       }
+  - { key: F4,       mods: Alt,     chars: "\x1b[1;6S"                       }
+  - { key: F5,       mods: Alt,     chars: "\x1b[15;6~"                      }
+  - { key: F6,       mods: Alt,     chars: "\x1b[17;6~"                      }
+  - { key: F7,       mods: Alt,     chars: "\x1b[18;6~"                      }
+  - { key: F8,       mods: Alt,     chars: "\x1b[19;6~"                      }
+  - { key: F9,       mods: Alt,     chars: "\x1b[20;6~"                      }
+  - { key: F10,      mods: Alt,     chars: "\x1b[21;6~"                      }
+  - { key: F11,      mods: Alt,     chars: "\x1b[23;6~"                      }
+  - { key: F12,      mods: Alt,     chars: "\x1b[24;6~"                      }
+  - { key: F1,       mods: Super,   chars: "\x1b[1;3P"                       }
+  - { key: F2,       mods: Super,   chars: "\x1b[1;3Q"                       }
+  - { key: F3,       mods: Super,   chars: "\x1b[1;3R"                       }
+  - { key: F4,       mods: Super,   chars: "\x1b[1;3S"                       }
+  - { key: F5,       mods: Super,   chars: "\x1b[15;3~"                      }
+  - { key: F6,       mods: Super,   chars: "\x1b[17;3~"                      }
+  - { key: F7,       mods: Super,   chars: "\x1b[18;3~"                      }
+  - { key: F8,       mods: Super,   chars: "\x1b[19;3~"                      }
+  - { key: F9,       mods: Super,   chars: "\x1b[20;3~"                      }
+  - { key: F10,      mods: Super,   chars: "\x1b[21;3~"                      }
+  - { key: F11,      mods: Super,   chars: "\x1b[23;3~"                      }
+  - { key: F12,      mods: Super,   chars: "\x1b[24;3~"                      }
+  - { key: NumpadEnter,             chars: "\n"                              }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -471,10 +471,10 @@ key_bindings:
   - { key: Home,                    chars: "\x1b[H",   mode: ~AppCursor  }
   - { key: End,                     chars: "\x1bOF",   mode: AppCursor   }
   - { key: End,                     chars: "\x1b[F",   mode: ~AppCursor  }
-  - { key: PageUp,   mods: Shift,   chars: "\x1b[5;2~"                   }
+  - { key: PageUp,   mods: Shift,   action: ScrollPageUp                 }
   - { key: PageUp,   mods: Control, chars: "\x1b[5;5~"                   }
   - { key: PageUp,                  chars: "\x1b[5~"                     }
-  - { key: PageDown, mods: Shift,   chars: "\x1b[6;2~"                   }
+  - { key: PageDown, mods: Shift,   action: ScrollPageDown               }
   - { key: PageDown, mods: Control, chars: "\x1b[6;5~"                   }
   - { key: PageDown,                chars: "\x1b[6~"                     }
   - { key: Tab,      mods: Shift,   chars: "\x1b[Z"                      }

--- a/src/config/bindings.rs
+++ b/src/config/bindings.rs
@@ -72,10 +72,12 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         Key::Home, ~TermMode::APP_CURSOR; Action::Esc("\x1b[H".into());
         Key::End, +TermMode::APP_CURSOR; Action::Esc("\x1bOF".into());
         Key::End, ~TermMode::APP_CURSOR; Action::Esc("\x1b[F".into());
-        Key::PageUp, [shift: true]; Action::ScrollPageUp;
+        Key::PageUp, [shift: true], ~TermMode::ALT_SCREEN; Action::ScrollPageUp;
+        Key::PageUp, [shift: true], +TermMode::ALT_SCREEN; Action::Esc("\x1b[5;2~".into());
         Key::PageUp, [ctrl: true]; Action::Esc("\x1b[5;5~".into());
         Key::PageUp; Action::Esc("\x1b[5~".into());
-        Key::PageDown, [shift: true]; Action::ScrollPageDown;
+        Key::PageDown, [shift: true], ~TermMode::ALT_SCREEN; Action::ScrollPageDown;
+        Key::PageDown, [shift: true], +TermMode::ALT_SCREEN; Action::Esc("\x1b[6;2~".into());
         Key::PageDown, [ctrl: true]; Action::Esc("\x1b[6;5~".into());
         Key::PageDown; Action::Esc("\x1b[6~".into());
         Key::Tab, [shift: true]; Action::Esc("\x1b[Z".into());

--- a/src/config/bindings.rs
+++ b/src/config/bindings.rs
@@ -72,10 +72,10 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         Key::Home, ~TermMode::APP_CURSOR; Action::Esc("\x1b[H".into());
         Key::End, +TermMode::APP_CURSOR; Action::Esc("\x1bOF".into());
         Key::End, ~TermMode::APP_CURSOR; Action::Esc("\x1b[F".into());
-        Key::PageUp, [shift: true]; Action::Esc("\x1b[5;2~".into());
+        Key::PageUp, [shift: true]; Action::ScrollPageUp;
         Key::PageUp, [ctrl: true]; Action::Esc("\x1b[5;5~".into());
         Key::PageUp; Action::Esc("\x1b[5~".into());
-        Key::PageDown, [shift: true]; Action::Esc("\x1b[6;2~".into());
+        Key::PageDown, [shift: true]; Action::ScrollPageDown;
         Key::PageDown, [ctrl: true]; Action::Esc("\x1b[6;5~".into());
         Key::PageDown; Action::Esc("\x1b[6~".into());
         Key::Tab, [shift: true]; Action::Esc("\x1b[Z".into());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -937,6 +937,8 @@ impl<'a> de::Deserialize<'a> for ModeWrapper {
                         "~AppCursor" => res.not_mode |= mode::TermMode::APP_CURSOR,
                         "AppKeypad" => res.mode |= mode::TermMode::APP_KEYPAD,
                         "~AppKeypad" => res.not_mode |= mode::TermMode::APP_KEYPAD,
+                        "~Alt" => res.not_mode |= mode::TermMode::ALT_SCREEN,
+                        "Alt" => res.mode |= mode::TermMode::ALT_SCREEN,
                         _ => error!("Unknown mode {:?}", modifier),
                     }
                 }


### PR DESCRIPTION
The default shift+pgup/pgdown buttons were sending the escape sequences
specified by the official standard, however most terminal emulators like
XTerm, URxvt and VTE make an exception for this special case and instead
scroll the native history buffer.

Both XTerm and URxvt do never send the escapes for Shift+PgUp/PgDown,
however VTE does send them in the alternate screen.

Since Alacritty already supports keybindings based on terminal mode and
the binding to scroll the history is useless when in the alternate
screen buffer, Alacritty is now following VTEs behavior here, allowing
applications in the alt screen (like vim) to handle this escape.

Fixes #1989.