### PR TITLE
Remove selections when clearing screen partially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix IME position on HiDPI displays
 - URLs not opening while terminal is scrolled
 - Reliably remove log file when Alacritty is closed and persistent logging is disabled
+- Remove selections when clearing the screen partially (scrolling horizontally in less)
 
 ### Removed
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1866,6 +1866,9 @@ impl ansi::Handler for Term {
         let mut template = self.cursor.template;
         template.flags ^= template.flags;
 
+        // Remove active selections
+        self.grid.selection = None;
+
         match mode {
             ansi::ClearMode::Below => {
                 for cell in &mut self.grid[self.cursor.point.line][self.cursor.point.col..] {
@@ -1891,9 +1894,7 @@ impl ansi::Handler for Term {
                 }
             },
             // If scrollback is implemented, this should clear it
-            ansi::ClearMode::Saved => {
-                self.grid.clear_history();
-            }
+            ansi::ClearMode::Saved => self.grid.clear_history(),
         }
     }
 


### PR DESCRIPTION
Automatically remove all selections when part of the screen is cleared.
This fixes issues in applications like `less -S` where a selection would
stay around after scrolling horizontally.

XTerm and URxvt both choose to always remove the selection, even if it's
outside of the cleared area, however VTE only clears the selection if
any part of it is inside the cleared area.

To keep things simple, Alacritty has adopted the behavior of XTerm and
URxvt to always clear selections.

This fixes #1644.