### PR TITLE
Add Control+Back, Control+Delete bindings to default config

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -481,9 +481,11 @@ key_bindings:
   - { key: PageDown,                chars: "\x1b[6~"                         }
   - { key: Tab,      mods: Shift,   chars: "\x1b[Z"                          }
   - { key: Back,                    chars: "\x7f"                            }
+  - { key: Back,     mods: Control, chars: "\x17"                            }
   - { key: Back,     mods: Alt,     chars: "\x1b\x7f"                        }
   - { key: Insert,                  chars: "\x1b[2~"                         }
   - { key: Delete,                  chars: "\x1b[3~"                         }
+  - { key: Delete,   mods: Control, chars: "\x1bD"                           }
   - { key: Left,     mods: Shift,   chars: "\x1b[1;2D"                       }
   - { key: Left,     mods: Control, chars: "\x1b[1;5D"                       }
   - { key: Left,     mods: Alt,     chars: "\x1b[1;3D"                       }

--- a/src/config/bindings.rs
+++ b/src/config/bindings.rs
@@ -82,9 +82,11 @@ pub fn default_key_bindings() -> Vec<KeyBinding> {
         Key::PageDown; Action::Esc("\x1b[6~".into());
         Key::Tab, [shift: true]; Action::Esc("\x1b[Z".into());
         Key::Back; Action::Esc("\x7f".into());
+        Key::Back, [ctrl: true]; Action::Esc("\x17".into());
         Key::Back, [alt: true]; Action::Esc("\x1b\x7f".into());
         Key::Insert; Action::Esc("\x1b[2~".into());
         Key::Delete; Action::Esc("\x1b[3~".into());
+        Key::Delete, [ctrl: true]; Action::Esc("\x1bD".into());
         Key::Left, [shift: true]; Action::Esc("\x1b[1;2D".into());
         Key::Left, [ctrl: true]; Action::Esc("\x1b[1;5D".into());
         Key::Left, [alt: true]; Action::Esc("\x1b[1;3D".into());


### PR DESCRIPTION
Bound to delete-to-word-begin, delete-to-word-end as for example in VS Code.