### PR TITLE
Fix lingering window after child process exit on unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows: Conpty backend could close immediately on startup in certain situations
 - FreeBSD: SpawnNewInstance will now open new instances in the shell's current
     working directory as long as linprocfs(5) is mounted on `/compat/linux/proc`
+- Fix lingering Alacritty window after child process has exited
 
 ## Version 0.2.9
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminfo 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -114,6 +115,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "argon2rs"
@@ -1278,6 +1284,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-uds"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2080,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2764,7 @@ dependencies = [
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c57ff1a5b00753647aebbbcf4ea67fa1e711a65ea7a30eb90dbf07de2485aee"
+"checksum arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1025aeae2b664ca0ea726a89d574fe8f4e77dd712d443236ad1de00379450cf6"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arraydeque 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e300327073b806ffc81fccb228b2d4131ac7ef1b1a015f7b0c399c7f886cacc6"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
@@ -2864,6 +2892,7 @@ dependencies = [
 "checksum mio-anonymous-pipes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8c274c3c52dcd1d78c5d7ed841eca1e9ea2db8353f3b8ec25789cc62c471aaf"
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+"checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum named_pipe 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ed10a5ac4f5f7e5d75552b12c1d5d542debca81e573279dd1e4c19fde6efa6d"
@@ -2950,6 +2979,7 @@ dependencies = [
 "checksum servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9"
 "checksum servo-fontconfig-sys 4.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b46d201addcfbd25c1798ad1281d98c40743824e0b0f1e611bd3d5d0d31a7b8d"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+"checksum signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "97a47ae722318beceb0294e6f3d601205a1e6abaa4437d9d33e3a212233e3021"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "88aea073965ab29f6edb5493faf96ad662fb18aa9eeb186a3b7057951605ed15"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ url = "1.7.1"
 time = "0.1.40"
 crossbeam-channel = "0.3.8"
 
+[target.'cfg(unix)'.dependencies]
+nix = "0.12"
+
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
 x11-dl = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ crossbeam-channel = "0.3.8"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.12"
+signal-hook = { version = "0.1", features = ["mio-support"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
 x11-dl = "2"

--- a/src/event.rs
+++ b/src/event.rs
@@ -176,7 +176,8 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
             let proc_prefix = "";
             #[cfg(target_os = "freebsd")]
             let proc_prefix = "/compat/linux";
-            if let Ok(path) = fs::read_link(format!("{}/proc/{}/cwd", proc_prefix, unsafe { tty::PID })) {
+            let link_path = format!("{}/proc/{}/cwd", proc_prefix, tty::child_pid());
+            if let Ok(path) = fs::read_link(link_path) {
                 vec!["--working-directory".into(), path]
             } else {
                 Vec::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,7 @@ fn run(
         }
 
         // Begin shutdown if the flag was raised
-        if terminal_lock.should_exit() {
+        if terminal_lock.should_exit() || tty::process_should_exit() {
             break;
         }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -34,6 +34,8 @@ use crate::url::UrlParser;
 use crate::message_bar::MessageBuffer;
 use crate::term::color::Rgb;
 use crate::term::cell::{LineLength, Cell};
+
+#[cfg(windows)]
 use crate::tty;
 
 pub mod cell;

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1336,7 +1336,7 @@ impl Term {
 
     #[inline]
     pub fn should_exit(&self) -> bool {
-        tty::process_should_exit() || self.should_exit
+        self.should_exit
     }
 }
 

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -40,7 +40,7 @@ pub trait EventedReadWrite {
     fn register(
         &mut self,
         _: &mio::Poll,
-        _: &mut dyn Iterator<Item = &usize>,
+        _: &mut dyn Iterator<Item = mio::Token>,
         _: mio::Ready,
         _: mio::PollOpt,
     ) -> io::Result<()>;

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -53,6 +53,29 @@ pub trait EventedReadWrite {
     fn write_token(&self) -> mio::Token;
 }
 
+/// Events concerning TTY child processes
+#[derive(PartialEq)]
+pub enum ChildEvent {
+    /// Indicates the child has exited
+    Exited
+}
+
+/// A pseudoterminal (or PTY)
+///
+/// This is a refinement of EventedReadWrite that also provides a channel through which we can be
+/// notified if the PTY child process does something we care about (other than writing to the TTY).
+/// In particular, this allows for race-free child exit notification on UNIX (cf. `SIGCHLD`).
+pub trait EventedPty : EventedReadWrite {
+    #[cfg(unix)]
+    fn child_event_token(&self) -> mio::Token;
+
+    /// Tries to retrieve an event
+    ///
+    /// Returns `Some(event)` on success, or `None` if there are no events to retrieve.
+    #[cfg(unix)]
+    fn next_child_event(&mut self) -> Option<ChildEvent>;
+}
+
 // Setup environment variables
 pub fn setup_env(config: &Config) {
     // Default to 'alacritty' terminfo if it is available, otherwise

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -327,11 +327,11 @@ impl EventedReadWrite for Pty {
     fn register(
         &mut self,
         poll: &mio::Poll,
-        token: &mut dyn Iterator<Item = &usize>,
+        token: &mut dyn Iterator<Item = mio::Token>,
         interest: mio::Ready,
         poll_opts: mio::PollOpt,
     ) -> io::Result<()> {
-        self.token = (*token.next().unwrap()).into();
+        self.token = token.next().unwrap();
         poll.register(
             &EventedFd(&self.fd.as_raw_fd()),
             self.token,

--- a/src/tty/windows/mod.rs
+++ b/src/tty/windows/mod.rs
@@ -28,7 +28,7 @@ use crate::cli::Options;
 use crate::config::Config;
 use crate::display::OnResize;
 use crate::term::SizeInfo;
-use crate::tty::EventedReadWrite;
+use crate::tty::{EventedReadWrite, EventedPty};
 
 mod conpty;
 mod winpty;
@@ -232,12 +232,12 @@ impl<'a> EventedReadWrite for Pty<'a> {
     fn register(
         &mut self,
         poll: &mio::Poll,
-        token: &mut dyn Iterator<Item = &usize>,
+        token: &mut dyn Iterator<Item = mio::Token>,
         interest: mio::Ready,
         poll_opts: mio::PollOpt,
     ) -> io::Result<()> {
-        self.read_token = (*token.next().unwrap()).into();
-        self.write_token = (*token.next().unwrap()).into();
+        self.read_token = token.next().unwrap();
+        self.write_token = token.next().unwrap();
 
         if interest.is_readable() {
             poll.register(
@@ -339,3 +339,5 @@ impl<'a> EventedReadWrite for Pty<'a> {
         self.write_token
     }
 }
+
+impl<'a> EventedPty for Pty<'a> { }


### PR DESCRIPTION
This is a crack at handing `SIGCHLD` (and conceivably others) safely and correctly, taking a different approach to #1367 by using the well-known "self-pipe trick". This should allay concerns about non- _async-signal-safe_ functions in signal handlers.

The signal handler writes received `SIG*` numbers into a pipe, which wakes up the existing I/O event loop. The loop then delegates handling back to the `Pty`, which reads the pipe, and reacts appropriately.

I'm not 100% certain on the finer points of this design, though, so I'd appreciate some feedback.

- Fixes #915
- Fixes #1276
- Fixes #1313