### PR TITLE
remove misleading comment

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -734,8 +734,6 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     }
 
     /// Process key input
-    ///
-    /// If a keybinding was run, returns true. Otherwise returns false.
     pub fn process_key(&mut self, input: KeyboardInput) {
         match input.state {
             ElementState::Pressed => {


### PR DESCRIPTION
The function signature clearly does not have a bool return type - this seems to be copied from process_key_bindings and accidentally left in.