### PR TITLE
Windows: Remove undefined assertion on return value of ClosePseudoConsole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix panic which could occur when quitting Alacritty on Windows if using the Conpty backend
+
 ## Version 0.2.9
 
 ### Changed


### PR DESCRIPTION
Windows: ClosePseudoConsole has no return value, but `impl Drop for ConPty` was mistakenly trying to assert the return value was "OK".

When I wrote the ConPty implementation I'd been working from this document: https://github.com/MicrosoftDocs/Console-Docs/blob/master/docs/closepseudoconsole.md, and as you will see there the documentation states the function has **no return value**.

If you check the history of that file you'll see the docs used to state that it had an HRESULT return type. I wrote the assertion based on that erroneous doc.

I've removed the usage of the return value.