### PR TITLE
Add dynamic title support for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MSI installer for Windows is now available
 - New default key bindings Alt+Home, Alt+End, Alt+PageUp and Alt+PageDown
+- Dynamic title support on Windows
 
 ### Fixed
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -799,7 +799,7 @@ pub struct Term {
     message_buffer: MessageBuffer,
 
     /// Hint that Alacritty should be closed
-    should_exit: bool
+    should_exit: bool,
 }
 
 /// Terminal size info
@@ -1357,19 +1357,14 @@ impl ansi::Handler for Term {
     #[inline]
     fn set_title(&mut self, title: &str) {
         if self.dynamic_title {
-            let mut title = title.to_owned();
+            self.next_title = Some(title.to_owned());
 
             #[cfg(windows)]
             {
-                // Winpty - the title is missing Alacritty
-                // at the front, must prepend it to get equivalent
-                // behaviour between Conpty and Winpty
                 if !tty::is_conpty() {
-                    title = String::from("Alacritty") + &title;
+                    self.next_title = Some(format!("Alacritty{}", title));
                 }
             }
-
-            self.next_title = Some(title);
         }
     }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -786,6 +786,7 @@ pub struct Term {
     /// Default style for resetting the cursor
     default_cursor_style: CursorStyle,
 
+    /// Whether to permit updating the terminal title
     dynamic_title: bool,
 
     /// Number of spaces in one tab
@@ -798,7 +799,7 @@ pub struct Term {
     message_buffer: MessageBuffer,
 
     /// Hint that Alacritty should be closed
-    should_exit: bool,
+    should_exit: bool
 }
 
 /// Terminal size info
@@ -1356,7 +1357,19 @@ impl ansi::Handler for Term {
     #[inline]
     fn set_title(&mut self, title: &str) {
         if self.dynamic_title {
-            self.next_title = Some(title.to_owned());
+            let mut title = title.to_owned();
+
+            #[cfg(windows)]
+            {
+                // Winpty - the title is missing Alacritty
+                // at the front, must prepend it to get equivalent
+                // behaviour between Conpty and Winpty
+                if !tty::is_conpty() {
+                    title = String::from("Alacritty") + &title;
+                }
+            }
+
+            self.next_title = Some(title);
         }
     }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1361,8 +1361,14 @@ impl ansi::Handler for Term {
 
             #[cfg(windows)]
             {
-                if !tty::is_conpty() {
-                    self.next_title = Some(format!("Alacritty{}", title));
+                // cmd.exe in winpty: winpty incorrectly sets the title to ' ' instead of
+                // 'Alacritty' - thus we have to substitute this back to get equivalent
+                // behaviour as conpty.
+                //
+                // The starts_with check is necessary because other shells e.g. bash set a
+                // different title and don't need Alacritty prepended.
+                if !tty::is_conpty() && title.starts_with(' ') {
+                    self.next_title = Some(format!("Alacritty {}", title.trim()));
                 }
             }
         }

--- a/src/tty/windows/mod.rs
+++ b/src/tty/windows/mod.rs
@@ -34,6 +34,7 @@ mod winpty;
 
 /// Handle to the winpty agent or conpty process. Required so we know when it closes.
 static mut HANDLE: *mut c_void = 0usize as *mut c_void;
+static mut IS_CONPTY: bool = false;
 
 pub fn process_should_exit() -> bool {
     unsafe {
@@ -52,6 +53,10 @@ pub fn process_should_exit() -> bool {
             }
         }
     }
+}
+
+pub fn is_conpty() -> bool {
+    unsafe { IS_CONPTY }
 }
 
 #[derive(Clone)]
@@ -86,6 +91,7 @@ pub fn new<'a>(
 ) -> Pty<'a> {
     if let Some(pty) = conpty::new(config, options, size, window_id) {
         info!("Using Conpty agent");
+        unsafe { IS_CONPTY = true; }
         pty
     } else {
         info!("Using Winpty agent");

--- a/src/tty/windows/mod.rs
+++ b/src/tty/windows/mod.rs
@@ -14,6 +14,7 @@
 
 use std::io::{self, Read, Write};
 use std::os::raw::c_void;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use mio::{self, Evented, Poll, PollOpt, Ready, Token};
 use mio_anonymous_pipes::{EventedAnonRead, EventedAnonWrite};
@@ -34,7 +35,7 @@ mod winpty;
 
 /// Handle to the winpty agent or conpty process. Required so we know when it closes.
 static mut HANDLE: *mut c_void = 0usize as *mut c_void;
-static mut IS_CONPTY: bool = false;
+static IS_CONPTY: AtomicBool = AtomicBool::new(false);
 
 pub fn process_should_exit() -> bool {
     unsafe {
@@ -56,7 +57,7 @@ pub fn process_should_exit() -> bool {
 }
 
 pub fn is_conpty() -> bool {
-    unsafe { IS_CONPTY }
+    IS_CONPTY.load(Ordering::Relaxed)
 }
 
 #[derive(Clone)]
@@ -91,7 +92,7 @@ pub fn new<'a>(
 ) -> Pty<'a> {
     if let Some(pty) = conpty::new(config, options, size, window_id) {
         info!("Using Conpty agent");
-        unsafe { IS_CONPTY = true; }
+        IS_CONPTY.store(true, Ordering::Relaxed);
         pty
     } else {
         info!("Using Winpty agent");

--- a/src/window.rs
+++ b/src/window.rs
@@ -224,11 +224,8 @@ impl Window {
 
     /// Set the window title
     #[inline]
-    pub fn set_title(&self, _title: &str) {
-        // Because winpty doesn't know anything about OSC escapes this gets set to an empty
-        // string on windows
-        #[cfg(not(windows))]
-        self.window.set_title(_title);
+    pub fn set_title(&self, title: &str) {
+        self.window.set_title(title);
     }
 
     #[inline]


### PR DESCRIPTION
As discussed previously in #1708 I have successfully restored support for dynamic title for Windows, but only for the Conpty backend.

From what I can tell, winpty support would require us to fork the `winpty-agent.exe` binary. This would be incompatible with the current approach of downloading prebuilt versions of it. Perhaps worth closing #1708 PR and opening a new issue for winpty support to remember it for the future?

Fixes #1695.