### PR TITLE
Chocolatey on Windows is now a supported method of installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Once the cask is installed, it is recommended to setup the [manual page](INSTALL
 
 ### Windows
 
+#### Via [Chocolatey](https://chocolatey.org)
+
+```batch
+choco install alacritty
+```
+
 #### Via [Scoop](https://scoop.sh)
 
 ```batch


### PR DESCRIPTION
The Alacritty package on Chocolatey is now fully maintained and is up to date with the current version of this software as of writing this. This PR is to make aware that Alacritty can be installed from Chocolatey as an alternative installation method.

Package: https://chocolatey.org/packages/alacritty/