### PR TITLE
Make start_daemon behaviour on Windows consistent with Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Command keybindings on Windows will no longer open new cmd.exe console windows
+
 ### Added
 
 - MSI installer for Windows is now available
@@ -22,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Text lingering around when resetting while scrolled up in the history
 - Terminfo support for extended capabilities
 - Allow mouse presses and beginning of mouse selection in padding
+- Windows: Conpty backend could close immediately on startup in certain situations
 
 ## Version 0.2.9
 

--- a/src/tty/windows/conpty.rs
+++ b/src/tty/windows/conpty.rs
@@ -34,7 +34,7 @@ use winapi::um::processthreadsapi::{
     CreateProcessW, InitializeProcThreadAttributeList, UpdateProcThreadAttribute,
     PROCESS_INFORMATION, STARTUPINFOW,
 };
-use winapi::um::winbase::{EXTENDED_STARTUPINFO_PRESENT, STARTUPINFOEXW};
+use winapi::um::winbase::{EXTENDED_STARTUPINFO_PRESENT, STARTF_USESTDHANDLES, STARTUPINFOEXW};
 use winapi::um::wincon::COORD;
 
 use crate::cli::Options;
@@ -149,6 +149,10 @@ pub fn new<'a>(
     let mut startup_info_ex: STARTUPINFOEXW = Default::default();
     startup_info_ex.StartupInfo.cb = mem::size_of::<STARTUPINFOEXW>() as u32;
 
+    // Setting this flag but leaving all the handles as default (null) ensures the
+    // pty process does not inherit any handles from this Alacritty process.
+    startup_info_ex.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+
     // Create the appropriately sized thread attribute list.
     unsafe {
         success =
@@ -226,7 +230,7 @@ pub fn new<'a>(
             cmdline as LPWSTR,
             ptr::null_mut(),
             ptr::null_mut(),
-            true as i32,
+            false as i32,
             EXTENDED_STARTUPINFO_PRESENT,
             ptr::null_mut(),
             cwd_ptr,

--- a/src/util.rs
+++ b/src/util.rs
@@ -109,16 +109,10 @@ pub fn start_daemon<I, S>(program: &str, args: I) -> io::Result<()>
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
 {
-    // As per issue 2128 the decision was made to make this call as
-    // similar to the Unix behaviour as possible.
-    //
     // Setting all the I/O handles to null and setting the
     // CREATE_NEW_PROCESS_GROUP and CREATE_NO_WINDOW has the effect
     // that console applications will run without opening a new
     // console window.
-    //
-    // If visible output is desirable the DETACHED_PROCESS flag could
-    // be used instead of CREATE_NO_WINDOW.
     Command::new(program)
         .args(args)
         .stdin(Stdio::null())

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,11 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use std::{cmp, io};
+use std::ffi::OsStr;
+use std::process::Command;
+
 #[cfg(not(windows))]
 use std::os::unix::process::CommandExt;
-use std::process::Command;
-use std::ffi::OsStr;
-use std::{cmp, io};
+
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+#[cfg(windows)]
+use std::process::Stdio;
+#[cfg(windows)]
+use winapi::um::winbase::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
 
 /// Threading utilities
 pub mod thread {
@@ -100,7 +109,24 @@ pub fn start_daemon<I, S>(program: &str, args: I) -> io::Result<()>
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
 {
-    Command::new(program).args(args).spawn().map(|_| ())
+    // As per issue 2128 the decision was made to make this call as
+    // similar to the Unix behaviour as possible.
+    //
+    // Setting all the I/O handles to null and setting the
+    // CREATE_NEW_PROCESS_GROUP and CREATE_NO_WINDOW has the effect
+    // that console applications will run without opening a new
+    // console window.
+    //
+    // If visible output is desirable the DETACHED_PROCESS flag could
+    // be used instead of CREATE_NO_WINDOW.
+    Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW)
+        .spawn()
+        .map(|_| ())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #2128.

As agreed in that thread, I have modified the `start_daemon` function on Windows to make behaviour as close to Unix as possible.

At the same time I have also fixed a crash where new Alacritty windows opened with `SpawnNewInstance` keybind would close instantly with the ConPTY backend. This was due to invalid stdio handles being passed to the conpty child process.

If you think this all looks reasonable I'll create a ChangeLog entry and add it to the PR.