### PR TITLE
Fix alt screen bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic copying of selection to clipboard when mouse is released outside of Alacritty
 - Scrollback history live reload only working when shrinking lines
 - Crash when decreasing scrollback history in config while scrolled in history
+- Resetting the terminal while in the alt screen will no longer disable scrollback
+- Cursor jumping around when leaving alt screen while not in the alt screen
+- Text lingering around when resetting while scrolled up in the history
 
 ## Version 0.2.9
 

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -404,6 +404,22 @@ impl<T: Copy + Clone> Grid<T> {
             }
         }
     }
+
+    // Completely reset the grid state
+    pub fn reset(&mut self, template: &T) {
+        // Explicitly purge all lines from history
+        let shrinkage = self.raw.len() - self.lines.0;
+        self.raw.shrink_lines(shrinkage);
+        self.clear_history();
+
+        // Reset all visible lines
+        for row in 0..self.raw.len() {
+            self.raw[row].reset(template);
+        }
+
+        self.display_offset = 0;
+        self.selection = None;
+    }
 }
 
 #[allow(clippy::len_without_is_empty)]

--- a/src/grid/storage.rs
+++ b/src/grid/storage.rs
@@ -160,7 +160,7 @@ impl<T> Storage<T> {
     }
 
     // Shrink the number of lines in the buffer
-    fn shrink_lines(&mut self, shrinkage: usize) {
+    pub fn shrink_lines(&mut self, shrinkage: usize) {
         self.len -= shrinkage;
 
         // Free memory


### PR DESCRIPTION
This fixes two bugs with the alternate screen buffer.

When resetting while in the alt screen, Alacritty would not swap out
the grids leading to scrollback getting disabled. By swapping out the
grids again when resetting in the alternate screen buffer, scrollback is
now unaffected from a reset.

There was another issue with the cursor jumping around when leaving the
alt screen even though it was not active, this was fixed by skipping all
alt screen swap routines unless the current state matches the expected
state.

This fixes #2145.