### PR TITLE
Fix scrollback live reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix panic which could occur when quitting Alacritty on Windows if using the Conpty backend
 - Automatic copying of selection to clipboard when mouse is released outside of Alacritty
+- Scrollback history live reload only working when shrinking lines
+- Crash when decreasing scrollback history in config while scrolled in history
 
 ## Version 0.2.9
 

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -163,7 +163,9 @@ impl<T: Copy + Clone> Grid<T> {
     pub fn update_history(&mut self, history_size: usize, template: &T)
     {
         self.raw.update_history(history_size, Row::new(self.cols, &template));
+        self.max_scroll_limit = history_size;
         self.scroll_limit = min(self.scroll_limit, history_size);
+        self.display_offset = min(self.display_offset, self.scroll_limit);
     }
 
     pub fn scroll_display(&mut self, scroll: Scroll) {


### PR DESCRIPTION
This fixes two issues with live reloading the `scrolling.history`
property.

It is now possible to increase the scrollback history without restarting
Alacritty.

When decreasing the scrollback history while scrolled beyond the new
history limit, Alacritty will reset the viewport position to the new
limit instead of crashing.

This fixes #2147.