### PR TITLE
Fix mouse events ignored by padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cursor jumping around when leaving alt screen while not in the alt screen
 - Text lingering around when resetting while scrolled up in the history
 - Terminfo support for extended capabilities
+- Mouse presses are no long ignored in padding except for event propagation
 
 ## Version 0.2.9
 
@@ -249,7 +250,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Empty lines in selections are now properly copied to the clipboard
 - Selection start point lagging behind initial cursor position
 - Rendering of selections which start above the visible area and end below it
-- Mouse press no longer ignored in padding width
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Empty lines in selections are now properly copied to the clipboard
 - Selection start point lagging behind initial cursor position
 - Rendering of selections which start above the visible area and end below it
+- Mouse press no longer ignored in padding width
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cursor jumping around when leaving alt screen while not in the alt screen
 - Text lingering around when resetting while scrolled up in the history
 - Terminfo support for extended capabilities
-- Mouse presses are no long ignored in padding except for event propagation
+- Allow mouse presses and beginning of mouse selection in padding
 
 ## Version 0.2.9
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -124,7 +124,11 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     }
 
     fn mouse_coords(&self) -> Option<Point> {
-        self.terminal.pixels_to_coords(self.mouse.x as usize, self.mouse.y as usize)
+        if self.mouse.x == usize::max_value() {
+            None
+        } else {
+            Some( self.size_info.pixels_to_coords(self.mouse.x as usize, self.mouse.y as usize) )
+        }
     }
 
     #[inline]
@@ -238,8 +242,8 @@ pub struct Mouse {
 impl Default for Mouse {
     fn default() -> Mouse {
         Mouse {
-            x: 0,
-            y: 0,
+            x: usize::max_value(),
+            y: usize::max_value(),
             last_click_timestamp: Instant::now(),
             left_button_state: ElementState::Released,
             middle_button_state: ElementState::Released,
@@ -404,6 +408,9 @@ impl<N: Notify> Processor<N> {
                             processor.mouse_input(state, button, modifiers);
                             processor.ctx.terminal.dirty = true;
                         }
+                    },
+                    CursorLeft { .. } => {
+                        processor.mouse_left();
                     },
                     CursorMoved { position: lpos, modifiers, .. } => {
                         let (x, y) = lpos.to_physical(processor.ctx.size_info.dpr).into();

--- a/src/event.rs
+++ b/src/event.rs
@@ -62,14 +62,15 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         self.terminal.scroll_display(scroll);
 
         if let ElementState::Pressed = self.mouse().left_button_state {
-            let (x, y) = (self.mouse().x, self.mouse().y);
-            let size_info = self.size_info();
-            let point = size_info.pixels_to_coords(x, y);
-            let cell_side = self.mouse().cell_side;
-            self.update_selection(Point {
-                line: point.line,
-                col: point.col
-            }, cell_side);
+            if let Some((x,y)) = self.mouse().position {
+                let size_info = self.size_info();
+                let point = size_info.pixels_to_coords(x, y);
+                let cell_side = self.mouse().cell_side;
+                self.update_selection(Point {
+                    line: point.line,
+                    col: point.col
+                }, cell_side);
+            }
         }
     }
 
@@ -124,10 +125,10 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
     }
 
     fn mouse_coords(&self) -> Option<Point> {
-        if self.mouse.x == usize::max_value() {
-            None
+        if let Some((x,y)) = self.mouse.position {
+            Some( self.size_info.pixels_to_coords(x as usize, y as usize) )
         } else {
-            Some( self.size_info.pixels_to_coords(self.mouse.x as usize, self.mouse.y as usize) )
+            None
         }
     }
 
@@ -223,8 +224,7 @@ pub enum ClickState {
 
 /// State of the mouse
 pub struct Mouse {
-    pub x: usize,
-    pub y: usize,
+    pub position: Option< (usize, usize ) >,
     pub left_button_state: ElementState,
     pub middle_button_state: ElementState,
     pub right_button_state: ElementState,
@@ -242,8 +242,7 @@ pub struct Mouse {
 impl Default for Mouse {
     fn default() -> Mouse {
         Mouse {
-            x: usize::max_value(),
-            y: usize::max_value(),
+            position: None,
             last_click_timestamp: Instant::now(),
             left_button_state: ElementState::Released,
             middle_button_state: ElementState::Released,

--- a/src/input.rs
+++ b/src/input.rs
@@ -370,6 +370,11 @@ impl From<&'static str> for Action {
 
 impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     #[inline]
+    pub fn mouse_left(&mut self) {
+        self.ctx.mouse_mut().x = usize::max_value();
+        self.ctx.mouse_mut().y = usize::max_value();
+    }
+
     pub fn mouse_moved(&mut self, x: usize, y: usize, modifiers: ModifiersState) {
         self.ctx.mouse_mut().x = x;
         self.ctx.mouse_mut().y = y;
@@ -961,7 +966,11 @@ mod tests {
         }
 
         fn mouse_coords(&self) -> Option<Point> {
-            self.terminal.pixels_to_coords(self.mouse.x as usize, self.mouse.y as usize)
+            if self.mouse.x == usize::max_value() {
+                None
+            } else {
+                Some( self.ctx.size_info.pixels_to_coords(self.mouse.x as usize, self.mouse.y as usize) )
+            }
         }
 
         #[inline]

--- a/src/input.rs
+++ b/src/input.rs
@@ -375,9 +375,12 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     }
 
     pub fn mouse_moved(&mut self, x: usize, y: usize, modifiers: ModifiersState) {
-        self.ctx.mouse_mut().position = Some( (x,y) );
-
         let size_info = self.ctx.size_info();
+        if size_info.contains_point(x,y) {
+            self.ctx.mouse_mut().position = Some( (x,y) );
+        } else {
+            self.ctx.mouse_mut().position = None
+        }
         let point = size_info.pixels_to_coords(x, y);
 
         let cell_side = self.get_mouse_side(x);
@@ -414,6 +417,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         } else if self.ctx.terminal().mode().intersects(motion_mode)
             // Only report motion when changing cells
             && (prev_line != self.ctx.mouse().line || prev_col != self.ctx.mouse().column)
+            && self.mouse().position.is_some()
         {
             if self.ctx.mouse().left_button_state == ElementState::Pressed {
                 self.mouse_report(32, ElementState::Pressed, modifiers);

--- a/src/input.rs
+++ b/src/input.rs
@@ -417,7 +417,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         } else if self.ctx.terminal().mode().intersects(motion_mode)
             // Only report motion when changing cells
             && (prev_line != self.ctx.mouse().line || prev_col != self.ctx.mouse().column)
-            && self.mouse().position.is_some()
+            && self.ctx.mouse().position.is_some()
         {
             if self.ctx.mouse().left_button_state == ElementState::Pressed {
                 self.mouse_report(32, ElementState::Pressed, modifiers);

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -838,11 +838,16 @@ impl SizeInfo {
         Column(((self.width - 2. * self.padding_x) / self.cell_width) as usize)
     }
 
-    pub fn contains_point(&self, x: usize, y:usize) -> bool {
-        x < self.width as usize
-            && x >= 0 as usize
+    pub fn contains_point(&self, x: usize, y: usize, include_padding: bool) -> bool {
+        if include_padding {
+            x < self.width as usize
             && y < self.height as usize
-            && y >= 0 as usize
+        } else {
+            x < (self.width - self.padding_x) as usize
+                && x >= self.padding_x as usize
+                && y < (self.height - self.padding_y) as usize
+                && y >= self.padding_y as usize
+        }
     }
 
     pub fn pixels_to_coords(&self, x: usize, y: usize) -> Point {
@@ -1097,6 +1102,21 @@ impl Term {
 
     pub(crate) fn visible_to_buffer(&self, point: Point) -> Point<usize> {
         self.grid.visible_to_buffer(point)
+    }
+
+    /// Convert the given pixel values to a grid coordinate
+    ///
+    /// The mouse coordinates are expected to be relative to the top left. The
+    /// line and column returned are also relative to the top left.
+    ///
+    /// Returns None if the coordinates are outside the window,
+    /// padding pixels are considered inside the window
+    pub fn pixels_to_coords(&self, x: usize, y: usize) -> Option<Point> {
+        if self.size_info.contains_point(x, y, true) {
+            Some(self.size_info.pixels_to_coords(x, y))
+        } else {
+            None
+        }
     }
 
     /// Access to the raw grid data structure

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -839,10 +839,10 @@ impl SizeInfo {
     }
 
     pub fn contains_point(&self, x: usize, y:usize) -> bool {
-        x < (self.width - self.padding_x) as usize
-            && x >= self.padding_x as usize
-            && y < (self.height - self.padding_y) as usize
-            && y >= self.padding_y as usize
+        x < self.width as usize
+            && x >= 0 as usize
+            && y < self.height as usize
+            && y >= 0 as usize
     }
 
     pub fn pixels_to_coords(&self, x: usize, y: usize) -> Point {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -840,8 +840,7 @@ impl SizeInfo {
 
     pub fn contains_point(&self, x: usize, y: usize, include_padding: bool) -> bool {
         if include_padding {
-            x < self.width as usize
-            && y < self.height as usize
+            x < self.width as usize && y < self.height as usize
         } else {
             x < (self.width - self.padding_x) as usize
                 && x >= self.padding_x as usize

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1099,20 +1099,6 @@ impl Term {
         self.grid.visible_to_buffer(point)
     }
 
-    /// Convert the given pixel values to a grid coordinate
-    ///
-    /// The mouse coordinates are expected to be relative to the top left. The
-    /// line and column returned are also relative to the top left.
-    ///
-    /// Returns None if the coordinates are outside the screen
-    pub fn pixels_to_coords(&self, x: usize, y: usize) -> Option<Point> {
-        if self.size_info.contains_point(x, y) {
-            Some(self.size_info.pixels_to_coords(x, y))
-        } else {
-            None
-        }
-    }
-
     /// Access to the raw grid data structure
     ///
     /// This is a bit of a hack; when the window is closed, the event processor


### PR DESCRIPTION
SizeInfo ctx with padding was being used to determine if the last mouse location was valid, however the padding doesn't need to be applied to mouse locations. Mouse x,y is updated by CursorMoved events which only send events if the mouse is inside of the alacritty window bounds.

Instead, use usize::max_value() as a marker for invalid mouse positions and set to that value on CursorLeft events to ensure that mouse_coords() returns None when the mouse position is invalid. This should allow any mouse location inside the alacritty window to return a proper row/col coord.

This fixes #2109