### PR TITLE
Add URL Highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New configuration field `window.position` allows specifying the starting position
 - Added the ability to change the selection color
 - Text will reflow instead of truncating when resizing Alacritty
-- Underline and change the mouse cursor when hovering over URLs
+- Underline text and change cursor when hovering over URLs with required modifiers pressed
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New configuration field `window.position` allows specifying the starting position
 - Added the ability to change the selection color
 - Text will reflow instead of truncating when resizing Alacritty
+- Underline and change the mouse cursor when hovering over URLs
+
+### Changed
+
+- Clicking on non-alphabetical characters in front of URLs will no longer open them
 
 ### Fixed
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -19,9 +19,9 @@ use std::str;
 
 use vte;
 use base64;
+use glutin::MouseCursor;
 use crate::index::{Column, Line, Contains};
 
-use crate::MouseCursor;
 use crate::term::color::Rgb;
 
 // Parse color arguments

--- a/src/event.rs
+++ b/src/event.rs
@@ -222,6 +222,13 @@ pub enum ClickState {
     TripleClick,
 }
 
+/// Temporary save state for restoring mouse cursor and underline after unhovering a URL.
+pub struct UrlHoverSaveState {
+    pub mouse_cursor: MouseCursor,
+    pub underlined: Vec<bool>,
+    pub start: Point<usize>,
+}
+
 /// State of the mouse
 pub struct Mouse {
     pub x: usize,
@@ -238,7 +245,7 @@ pub struct Mouse {
     pub lines_scrolled: f32,
     pub block_url_launcher: bool,
     pub last_button: MouseButton,
-    pub last_cursor: Option<MouseCursor>,
+    pub url_hover_save: Option<UrlHoverSaveState>,
 }
 
 impl Default for Mouse {
@@ -258,7 +265,7 @@ impl Default for Mouse {
             lines_scrolled: 0.0,
             block_url_launcher: false,
             last_button: MouseButton::Other(0),
-            last_cursor: None,
+            url_hover_save: None,
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,7 +10,7 @@ use std::env;
 
 use serde_json as json;
 use parking_lot::MutexGuard;
-use glutin::{self, ModifiersState, Event, ElementState, MouseButton};
+use glutin::{self, ModifiersState, Event, ElementState, MouseButton, MouseCursor};
 use copypasta::{Clipboard, Load, Store, Buffer as ClipboardBuffer};
 use glutin::dpi::PhysicalSize;
 
@@ -238,6 +238,7 @@ pub struct Mouse {
     pub lines_scrolled: f32,
     pub block_url_launcher: bool,
     pub last_button: MouseButton,
+    pub last_cursor: Option<MouseCursor>,
 }
 
 impl Default for Mouse {
@@ -257,6 +258,7 @@ impl Default for Mouse {
             lines_scrolled: 0.0,
             block_url_launcher: false,
             last_button: MouseButton::Other(0),
+            last_cursor: None,
         }
     }
 }

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -595,10 +595,8 @@ impl<T> Grid<T> {
 }
 
 pub struct GridIterator<'a, T> {
-    /// Immutable grid reference
-    grid: &'a Grid<T>,
-
     point_iter: PointIterator<usize>,
+    grid: &'a Grid<T>,
 }
 
 impl<'a, T> GridIterator<'a, T> {

--- a/src/grid/tests.rs
+++ b/src/grid/tests.rs
@@ -112,8 +112,8 @@ fn test_iter() {
 
     assert_eq!(None, iter.prev());
     assert_eq!(Some(&1), iter.next());
-    assert_eq!(Column(1), iter.cur.col);
-    assert_eq!(4, iter.cur.line);
+    assert_eq!(Column(1), iter.cur().col);
+    assert_eq!(4, iter.cur().line);
 
     assert_eq!(Some(&2), iter.next());
     assert_eq!(Some(&3), iter.next());
@@ -121,12 +121,12 @@ fn test_iter() {
 
     // test linewrapping
     assert_eq!(Some(&5), iter.next());
-    assert_eq!(Column(0), iter.cur.col);
-    assert_eq!(3, iter.cur.line);
+    assert_eq!(Column(0), iter.cur().col);
+    assert_eq!(3, iter.cur().line);
 
     assert_eq!(Some(&4), iter.prev());
-    assert_eq!(Column(4), iter.cur.col);
-    assert_eq!(4, iter.cur.line);
+    assert_eq!(Column(4), iter.cur().col);
+    assert_eq!(4, iter.cur().line);
 
 
     // test that iter ends at end of grid

--- a/src/index.rs
+++ b/src/index.rs
@@ -73,8 +73,8 @@ impl From<Point> for Point<usize> {
 }
 
 impl<T> Point<T>
-    where
-        T: Copy + Default + SubAssign<usize> + PartialEq,
+where
+    T: Copy + Default + SubAssign<usize> + PartialEq,
 {
     pub fn iter(&self, last_col: Column, last_line: T) -> PointIterator<T> {
         PointIterator {
@@ -92,8 +92,8 @@ pub struct PointIterator<T> {
 }
 
 impl<T> Iterator for PointIterator<T>
-    where
-        T: Copy + Default + SubAssign<usize> + PartialEq,
+where
+    T: Copy + Default + SubAssign<usize> + PartialEq,
 {
     type Item = Point<T>;
 
@@ -114,8 +114,8 @@ impl<T> Iterator for PointIterator<T>
 }
 
 impl<T> BidirectionalIterator for PointIterator<T>
-    where
-        T: Copy + Default + AddAssign<usize> + SubAssign<usize> + PartialEq,
+where
+    T: Copy + Default + AddAssign<usize> + SubAssign<usize> + PartialEq,
 {
     fn prev(&mut self) -> Option<Self::Item> {
         match self.cur {

--- a/src/input.rs
+++ b/src/input.rs
@@ -440,58 +440,57 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG | TermMode::MOUSE_REPORT_CLICK;
 
         // Only show URLs as launchable when all required modifiers are pressed
-        if self.mouse_config.url.modifiers.relaxed_eq(modifiers)
-            && (!self.ctx.terminal().mode().contains(TermMode::ALT_SCREEN) || modifiers.shift)
-        {
-            if let Some(Url { text, origin }) = self.ctx.terminal().url_search(point.into()) {
-                let mouse_cursor = if self.ctx.terminal().mode().intersects(mouse_mode) {
-                    MouseCursor::Default
-                } else {
-                    MouseCursor::Text
-                };
+        let url = if self.mouse_config.url.modifiers.relaxed_eq(modifiers)
+            && (!self.ctx.terminal().mode().contains(TermMode::ALT_SCREEN) || modifiers.shift) {
+                self.ctx.terminal().url_search(point.into())
+        } else {
+            None
+        };
 
-                let cols = self.ctx.size_info().cols().0;
-                let last_line = self.ctx.size_info().lines().0 - 1;
+        if let Some(Url { text, origin }) = url {
+            let mouse_cursor = if self.ctx.terminal().mode().intersects(mouse_mode) {
+                MouseCursor::Default
+            } else {
+                MouseCursor::Text
+            };
 
-                // Calculate the URL's start position
-                let col = (cols + point.col.0 - origin % cols) % cols;
-                let line = last_line - point.line.0 + (origin + cols - point.col.0 - 1) / cols;
-                let start = Point::new(line, Column(col));
+            let cols = self.ctx.size_info().cols().0;
+            let last_line = self.ctx.size_info().lines().0 - 1;
 
-                // Update URLs only on change, so they don't all get marked as underlined
-                if self.ctx.mouse().url_hover_save.as_ref().map(|hs| hs.start) == Some(start) {
-                    return;
-                }
+            // Calculate the URL's start position
+            let col = (cols + point.col.0 - origin % cols) % cols;
+            let line = last_line - point.line.0 + (origin + cols - point.col.0 - 1) / cols;
+            let start = Point::new(line, Column(col));
 
-                // Since the URL changed without reset, we need to clear the previous underline
-                if let Some(hover_save) = self.ctx.mouse_mut().url_hover_save.take() {
-                    self.reset_underline(&hover_save);
-                }
-
-                // Underline all cells and store their current underline state
-                let mut underlined = Vec::with_capacity(text.len());
-                let iter = once(start).chain(start.iter(Column(cols - 1), last_line));
-                for point in iter.take(text.len()) {
-                    let cell = &mut self.ctx.terminal_mut().grid_mut()[point.line][point.col];
-                    underlined.push(cell.flags.contains(Flags::UNDERLINE));
-                    cell.flags.insert(Flags::UNDERLINE);
-                }
-
-                // Save the higlight state for restoring it again
-                self.ctx.mouse_mut().url_hover_save = Some(UrlHoverSaveState {
-                    mouse_cursor,
-                    underlined,
-                    start,
-                });
-
-                self.ctx.terminal_mut().set_mouse_cursor(MouseCursor::Hand);
-                self.ctx.terminal_mut().dirty = true;
-
+            // Update URLs only on change, so they don't all get marked as underlined
+            if self.ctx.mouse().url_hover_save.as_ref().map(|hs| hs.start) == Some(start) {
                 return;
             }
-        }
 
-        if let Some(hover_save) = self.ctx.mouse_mut().url_hover_save.take() {
+            // Since the URL changed without reset, we need to clear the previous underline
+            if let Some(hover_save) = self.ctx.mouse_mut().url_hover_save.take() {
+                self.reset_underline(&hover_save);
+            }
+
+            // Underline all cells and store their current underline state
+            let mut underlined = Vec::with_capacity(text.len());
+            let iter = once(start).chain(start.iter(Column(cols - 1), last_line));
+            for point in iter.take(text.len()) {
+                let cell = &mut self.ctx.terminal_mut().grid_mut()[point.line][point.col];
+                underlined.push(cell.flags.contains(Flags::UNDERLINE));
+                cell.flags.insert(Flags::UNDERLINE);
+            }
+
+            // Save the higlight state for restoring it again
+            self.ctx.mouse_mut().url_hover_save = Some(UrlHoverSaveState {
+                mouse_cursor,
+                underlined,
+                start,
+            });
+
+            self.ctx.terminal_mut().set_mouse_cursor(MouseCursor::Hand);
+            self.ctx.terminal_mut().dirty = true;
+        } else if let Some(hover_save) = self.ctx.mouse_mut().url_hover_save.take() {
             self.ctx.terminal_mut().set_mouse_cursor(hover_save.mouse_cursor);
             self.ctx.terminal_mut().dirty = true;
             self.reset_underline(&hover_save);

--- a/src/input.rs
+++ b/src/input.rs
@@ -440,7 +440,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
         // Only show URLs as launchable when all required modifiers are pressed
         let url = if self.mouse_config.url.modifiers.relaxed_eq(modifiers)
-            && (!self.ctx.terminal().mode().contains(TermMode::ALT_SCREEN) || modifiers.shift) {
+            && (!self.ctx.terminal().mode().contains(TermMode::ALT_SCREEN) || modifiers.shift)
+        {
                 self.ctx.terminal().url_search(point.into())
         } else {
             None

--- a/src/input.rs
+++ b/src/input.rs
@@ -391,18 +391,17 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         let motion_mode = TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG;
         let report_mode = TermMode::MOUSE_REPORT_CLICK | motion_mode;
 
-        // Don't launch URLs if mouse has moved
-        if prev_line != self.ctx.mouse().line
+        let mouse_moved = prev_line != self.ctx.mouse().line
             || prev_col != self.ctx.mouse().column
-            || prev_side != cell_side
-        {
+            || prev_side != cell_side;
+
+        // Don't launch URLs if mouse has moved
+        if mouse_moved {
             self.ctx.mouse_mut().block_url_launcher = true;
         }
 
         // Only report motions when cell changed and mouse is not over the message bar
-        if self.message_at_point(Some(point)).is_some()
-            || (prev_line == self.ctx.mouse().line && prev_col == self.ctx.mouse().column)
-        {
+        if self.message_at_point(Some(point)).is_some() || !mouse_moved {
             return;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,6 @@ mod url;
 pub use crate::grid::Grid;
 pub use crate::term::Term;
 
-/// Facade around [winit's `MouseCursor`](glutin::MouseCursor)
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub enum MouseCursor {
-    Arrow,
-    Text,
-}
-
 pub mod gl {
     #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -433,6 +433,7 @@ impl Span {
 mod test {
     use crate::index::{Line, Column, Side, Point};
     use super::{Selection, Span, SpanType};
+    use crate::url::Url;
 
     struct Dimensions(Point);
     impl super::Dimensions for Dimensions {
@@ -453,7 +454,7 @@ mod test {
     impl super::Search for Dimensions {
         fn semantic_search_left(&self, point: Point<usize>) -> Point<usize> { point }
         fn semantic_search_right(&self, point: Point<usize>) -> Point<usize> { point }
-        fn url_search(&self, _: Point<usize>) -> Option<String> { None }
+        fn url_search(&self, _: Point<usize>) -> Option<Url> { None }
     }
 
     /// Test case of single cell selection

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -20,6 +20,7 @@ use std::time::{Duration, Instant};
 
 use arraydeque::ArrayDeque;
 use unicode_width::UnicodeWidthChar;
+use glutin::MouseCursor;
 
 use font::{self, Size};
 use crate::ansi::{self, Color, NamedColor, Attr, Handler, CharsetIndex, StandardCharset, CursorStyle};
@@ -30,7 +31,6 @@ use crate::grid::{
 use crate::index::{self, Point, Column, Line, IndexRange, Contains, Linear};
 use crate::selection::{self, Selection, Locations};
 use crate::config::{Config, VisualBellAnimation};
-use crate::MouseCursor;
 use copypasta::{Clipboard, Load, Store};
 use crate::input::FONT_SIZE_STEP;
 use crate::url::UrlParser;
@@ -2034,15 +2034,15 @@ impl ansi::Handler for Term {
             ansi::Mode::CursorKeys => self.mode.insert(mode::TermMode::APP_CURSOR),
             ansi::Mode::ReportMouseClicks => {
                 self.mode.insert(mode::TermMode::MOUSE_REPORT_CLICK);
-                self.set_mouse_cursor(MouseCursor::Arrow);
+                self.set_mouse_cursor(MouseCursor::Default);
             },
             ansi::Mode::ReportCellMouseMotion => {
                 self.mode.insert(mode::TermMode::MOUSE_DRAG);
-                self.set_mouse_cursor(MouseCursor::Arrow);
+                self.set_mouse_cursor(MouseCursor::Default);
             },
             ansi::Mode::ReportAllMouseMotion => {
                 self.mode.insert(mode::TermMode::MOUSE_MOTION);
-                self.set_mouse_cursor(MouseCursor::Arrow);
+                self.set_mouse_cursor(MouseCursor::Default);
             },
             ansi::Mode::ReportFocusInOut => self.mode.insert(mode::TermMode::FOCUS_IN_OUT),
             ansi::Mode::BracketedPaste => self.mode.insert(mode::TermMode::BRACKETED_PASTE),

--- a/src/url.rs
+++ b/src/url.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use url::Url;
+use url;
 
 // See https://tools.ietf.org/html/rfc3987#page-13
 const URL_SEPARATOR_CHARS: [char; 10] = ['<', '>', '"', ' ', '{', '}', '|', '\\', '^', '`'];
@@ -21,21 +21,35 @@ const URL_SCHEMES: [&str; 8] = [
     "http", "https", "mailto", "news", "file", "git", "ssh", "ftp",
 ];
 
-// Parser for streaming inside-out detection of URLs.
+/// URL text and origin of the original click position.
+#[derive(Debug, PartialEq)]
+pub struct Url {
+    pub text: String,
+    pub origin: usize,
+}
+
+/// Parser for streaming inside-out detection of URLs.
 pub struct UrlParser {
     state: String,
+    origin: usize,
 }
 
 impl UrlParser {
     pub fn new() -> Self {
         UrlParser {
             state: String::new(),
+            origin: 0,
         }
     }
 
     /// Advance the parser one character to the left.
     pub fn advance_left(&mut self, c: char) -> bool {
-        self.advance(c, 0)
+        if self.advance(c, 0) {
+            true
+        } else {
+            self.origin += 1;
+            false
+        }
     }
 
     /// Advance the parser one character to the right.
@@ -44,7 +58,7 @@ impl UrlParser {
     }
 
     /// Returns the URL if the parser has found any.
-    pub fn url(mut self) -> Option<String> {
+    pub fn url(mut self) -> Option<Url> {
         // Remove non-alphabetical characters before the scheme
         // https://tools.ietf.org/html/rfc3986#section-3.1
         if let Some(index) = self.state.find("://") {
@@ -57,6 +71,7 @@ impl UrlParser {
                 match c {
                     'a'...'z' | 'A'...'Z' => (),
                     _ => {
+                        self.origin = self.origin.saturating_sub(byte_index + 1);
                         self.state = self.state.split_off(byte_index + c.len_utf8());
                         break;
                     }
@@ -97,10 +112,13 @@ impl UrlParser {
         }
 
         // Check if string is valid url
-        match Url::parse(&self.state) {
+        match url::Url::parse(&self.state) {
             Ok(url) => {
-                if URL_SCHEMES.contains(&url.scheme()) {
-                    Some(self.state)
+                if URL_SCHEMES.contains(&url.scheme()) && self.origin > 0 {
+                    Some(Url {
+                        text: self.state,
+                        origin: self.origin - 1,
+                    })
                 } else {
                     None
                 }
@@ -155,12 +173,10 @@ mod tests {
         term
     }
 
-    fn url_test(input: &str, expected: &str, click_index: usize) {
+    fn url_test(input: &str, expected: &str) {
         let term = url_create_term(input);
-
-        let url = term.url_search(Point::new(0, Column(click_index)));
-
-        assert_eq!(url, Some(expected.into()));
+        let url = term.url_search(Point::new(0, Column(15)));
+        assert_eq!(url.map(|u| u.text), Some(expected.into()));
     }
 
     #[test]
@@ -168,72 +184,87 @@ mod tests {
         let term = url_create_term("no url here");
         let url = term.url_search(Point::new(0, Column(4)));
         assert_eq!(url, None);
+
+        let term = url_create_term(" https://example.org");
+        let url = term.url_search(Point::new(0, Column(0)));
+        assert_eq!(url, None);
+    }
+
+    #[test]
+    fn url_origin() {
+        let term = url_create_term(" test https://example.org ");
+        let url = term.url_search(Point::new(0, Column(10)));
+        assert_eq!(url.map(|u| u.origin), Some(4));
+
+        let term = url_create_term("https://example.org");
+        let url = term.url_search(Point::new(0, Column(0)));
+        assert_eq!(url.map(|u| u.origin), Some(0));
     }
 
     #[test]
     fn url_matching_chars() {
-        url_test("(https://example.org/test(ing))", "https://example.org/test(ing)", 5);
-        url_test("https://example.org/test(ing)", "https://example.org/test(ing)", 5);
-        url_test("((https://example.org))", "https://example.org", 5);
-        url_test(")https://example.org(", "https://example.org", 5);
-        url_test("https://example.org)", "https://example.org", 5);
-        url_test("https://example.org(", "https://example.org", 5);
-        url_test("(https://one.org/)(https://two.org/)", "https://one.org", 5);
+        url_test("(https://example.org/test(ing))", "https://example.org/test(ing)");
+        url_test("https://example.org/test(ing)", "https://example.org/test(ing)");
+        url_test("((https://example.org))", "https://example.org");
+        url_test(")https://example.org(", "https://example.org");
+        url_test("https://example.org)", "https://example.org");
+        url_test("https://example.org(", "https://example.org");
+        url_test("(https://one.org/)(https://two.org/)", "https://one.org");
 
-        url_test("https://[2001:db8:a0b:12f0::1]:80", "https://[2001:db8:a0b:12f0::1]:80", 5);
-        url_test("([(https://example.org/test(ing))])", "https://example.org/test(ing)", 5);
-        url_test("https://example.org/]()", "https://example.org", 5);
-        url_test("[https://example.org]", "https://example.org", 5);
+        url_test("https://[2001:db8:a0b:12f0::1]:80", "https://[2001:db8:a0b:12f0::1]:80");
+        url_test("([(https://example.org/test(ing))])", "https://example.org/test(ing)");
+        url_test("https://example.org/]()", "https://example.org");
+        url_test("[https://example.org]", "https://example.org");
 
-        url_test("'https://example.org/test'ing'''", "https://example.org/test'ing'", 5);
-        url_test("https://example.org/test'ing'", "https://example.org/test'ing'", 5);
-        url_test("'https://example.org'", "https://example.org", 5);
-        url_test("'https://example.org", "https://example.org", 5);
-        url_test("https://example.org'", "https://example.org", 5);
+        url_test("'https://example.org/test'ing'''", "https://example.org/test'ing'");
+        url_test("https://example.org/test'ing'", "https://example.org/test'ing'");
+        url_test("'https://example.org'", "https://example.org");
+        url_test("'https://example.org", "https://example.org");
+        url_test("https://example.org'", "https://example.org");
     }
 
     #[test]
     fn url_detect_end() {
-        url_test("https://example.org/test\u{00}ing", "https://example.org/test", 5);
-        url_test("https://example.org/test\u{1F}ing", "https://example.org/test", 5);
-        url_test("https://example.org/test\u{7F}ing", "https://example.org/test", 5);
-        url_test("https://example.org/test\u{9F}ing", "https://example.org/test", 5);
-        url_test("https://example.org/test\ting", "https://example.org/test", 5);
-        url_test("https://example.org/test ing", "https://example.org/test", 5);
+        url_test("https://example.org/test\u{00}ing", "https://example.org/test");
+        url_test("https://example.org/test\u{1F}ing", "https://example.org/test");
+        url_test("https://example.org/test\u{7F}ing", "https://example.org/test");
+        url_test("https://example.org/test\u{9F}ing", "https://example.org/test");
+        url_test("https://example.org/test\ting", "https://example.org/test");
+        url_test("https://example.org/test ing", "https://example.org/test");
     }
 
     #[test]
     fn url_remove_end_chars() {
-        url_test("https://example.org/test?ing", "https://example.org/test?ing", 5);
-        url_test("https://example.org.,;:)'!/?", "https://example.org", 5);
-        url_test("https://example.org'.", "https://example.org", 5);
+        url_test("https://example.org/test?ing", "https://example.org/test?ing");
+        url_test("https://example.org.,;:)'!/?", "https://example.org");
+        url_test("https://example.org'.", "https://example.org");
     }
 
     #[test]
     fn url_remove_start_chars() {
-        url_test("complicated:https://example.org", "https://example.org", 15);
-        url_test("test.https://example.org", "https://example.org", 10);
-        url_test(",https://example.org", "https://example.org", 5);
-        url_test("\u{2502}https://example.org", "https://example.org", 5);
+        url_test("complicated:https://example.org", "https://example.org");
+        url_test("test.https://example.org", "https://example.org");
+        url_test(",https://example.org", "https://example.org");
+        url_test("\u{2502}https://example.org", "https://example.org");
     }
 
     #[test]
     fn url_unicode() {
-        url_test("https://xn--example-2b07f.org", "https://xn--example-2b07f.org", 5);
-        url_test("https://example.org/\u{2008A}", "https://example.org/\u{2008A}", 5);
-        url_test("https://example.org/\u{f17c}", "https://example.org/\u{f17c}", 5);
-        url_test("https://üñîçøðé.com/ä", "https://üñîçøðé.com/ä", 5);
+        url_test("https://xn--example-2b07f.org", "https://xn--example-2b07f.org");
+        url_test("https://example.org/\u{2008A}", "https://example.org/\u{2008A}");
+        url_test("https://example.org/\u{f17c}", "https://example.org/\u{f17c}");
+        url_test("https://üñîçøðé.com/ä", "https://üñîçøðé.com/ä");
     }
 
     #[test]
     fn url_schemes() {
-        url_test("mailto://example.org", "mailto://example.org", 5);
-        url_test("https://example.org", "https://example.org", 5);
-        url_test("http://example.org", "http://example.org", 5);
-        url_test("news://example.org", "news://example.org", 5);
-        url_test("file://example.org", "file://example.org", 5);
-        url_test("git://example.org", "git://example.org", 5);
-        url_test("ssh://example.org", "ssh://example.org", 5);
-        url_test("ftp://example.org", "ftp://example.org", 5);
+        url_test("mailto://example.org", "mailto://example.org");
+        url_test("https://example.org", "https://example.org");
+        url_test("http://example.org", "http://example.org");
+        url_test("news://example.org", "news://example.org");
+        url_test("file://example.org", "file://example.org");
+        url_test("git://example.org", "git://example.org");
+        url_test("ssh://example.org", "ssh://example.org");
+        url_test("ftp://example.org", "ftp://example.org");
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -21,14 +21,12 @@ use glutin::Icon;
 use image::ImageFormat;
 use glutin::{
     self, ContextBuilder, ControlFlow, Event, EventsLoop,
-    MouseCursor as GlutinMouseCursor, WindowBuilder,
-    ContextTrait,
+    MouseCursor, WindowBuilder, ContextTrait
 };
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 
 use crate::cli::Options;
 use crate::config::{Decorations, WindowConfig};
-use crate::MouseCursor;
 
 #[cfg(windows)]
 static WINDOW_ICON: &'static [u8] = include_bytes!("../assets/windows/alacritty.ico");
@@ -142,7 +140,7 @@ impl Window {
         window.show();
 
         // Text cursor
-        window.set_cursor(GlutinMouseCursor::Text);
+        window.set_cursor(MouseCursor::Text);
 
         // Make the context current so OpenGL operations can run
         unsafe {
@@ -237,10 +235,7 @@ impl Window {
 
     #[inline]
     pub fn set_mouse_cursor(&self, cursor: MouseCursor) {
-        self.window.set_cursor(match cursor {
-            MouseCursor::Arrow => GlutinMouseCursor::Default,
-            MouseCursor::Text => GlutinMouseCursor::Text,
-        });
+        self.window.set_cursor(cursor);
     }
 
     /// Set mouse cursor visible


### PR DESCRIPTION
This PR adds URL highlighting to give better feedback to the user about
which text strings are recognized as an URL.

This includes changing the cursor to indicate that it is possible to
click URLs and underlining the URLs to show which cells are part of the
URL.

This fixes #1618.

Currently this is only an initial draft, there's still some things that need to be done:
 - [X] Change cursor when hovering over URLs
 - [x] Underline URLs
 - [x] Fix style/performance issues