### PR TITLE
Feature/mac os fullscreen

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -136,9 +136,14 @@ impl Window {
 
         let title = options.title.as_ref().map_or(DEFAULT_NAME, |t| t);
         let class = options.class.as_ref().map_or(DEFAULT_NAME, |c| c);
-        let window_builder = Window::get_platform_window(title, class, window_config, &event_loop);
+        let window_builder = Window::get_platform_window(title, class, window_config);
         let window = create_gl_window(window_builder.clone(), &event_loop, false)
             .or_else(|_| create_gl_window(window_builder, &event_loop, true))?;
+
+        if window_config.start_maximized() {
+            window.set_fullscreen(Some(event_loop.get_primary_monitor()));
+        }
+
         window.show();
 
         // Text cursor
@@ -251,8 +256,7 @@ impl Window {
     pub fn get_platform_window(
         title: &str,
         class: &str,
-        window_config: &WindowConfig,
-        event_loop: &EventsLoop
+        window_config: &WindowConfig
     ) -> WindowBuilder {
         use glutin::os::unix::WindowBuilderExt;
 
@@ -277,8 +281,7 @@ impl Window {
     pub fn get_platform_window(
         title: &str,
         _class: &str,
-        window_config: &WindowConfig,
-        event_loop: &EventsLoop
+        window_config: &WindowConfig
     ) -> WindowBuilder {
         let icon = Icon::from_bytes_with_format(WINDOW_ICON, ImageFormat::ICO).unwrap();
 
@@ -300,21 +303,15 @@ impl Window {
     pub fn get_platform_window(
         title: &str,
         _class: &str,
-        window_config: &WindowConfig,
-        event_loop: &EventsLoop
+        window_config: &WindowConfig
     ) -> WindowBuilder {
         use glutin::os::macos::WindowBuilderExt;
-
-        let monitor = Some(event_loop.get_primary_monitor());
 
         let window = WindowBuilder::new()
             .with_title(title)
             .with_visibility(false)
-            .with_transparency(true);
-
-        if window_config.start_maximized() {
-            return window.with_fullscreen(monitor)
-        }
+            .with_transparency(true)
+            .with_maximized(window_config.start_maximized());
 
         match window_config.decorations() {
             Decorations::Full => window,

--- a/src/window.rs
+++ b/src/window.rs
@@ -136,7 +136,7 @@ impl Window {
 
         let title = options.title.as_ref().map_or(DEFAULT_NAME, |t| t);
         let class = options.class.as_ref().map_or(DEFAULT_NAME, |c| c);
-        let window_builder = Window::get_platform_window(title, class, window_config);
+        let window_builder = Window::get_platform_window(title, class, window_config, &event_loop);
         let window = create_gl_window(window_builder.clone(), &event_loop, false)
             .or_else(|_| create_gl_window(window_builder, &event_loop, true))?;
         window.show();
@@ -251,7 +251,8 @@ impl Window {
     pub fn get_platform_window(
         title: &str,
         class: &str,
-        window_config: &WindowConfig
+        window_config: &WindowConfig,
+        event_loop: &EventsLoop
     ) -> WindowBuilder {
         use glutin::os::unix::WindowBuilderExt;
 
@@ -276,7 +277,8 @@ impl Window {
     pub fn get_platform_window(
         title: &str,
         _class: &str,
-        window_config: &WindowConfig
+        window_config: &WindowConfig,
+        event_loop: &EventsLoop
     ) -> WindowBuilder {
         let icon = Icon::from_bytes_with_format(WINDOW_ICON, ImageFormat::ICO).unwrap();
 
@@ -298,15 +300,21 @@ impl Window {
     pub fn get_platform_window(
         title: &str,
         _class: &str,
-        window_config: &WindowConfig
+        window_config: &WindowConfig,
+        event_loop: &EventsLoop
     ) -> WindowBuilder {
         use glutin::os::macos::WindowBuilderExt;
+
+        let monitor = Some(event_loop.get_primary_monitor());
 
         let window = WindowBuilder::new()
             .with_title(title)
             .with_visibility(false)
-            .with_transparency(true)
-            .with_maximized(window_config.start_maximized());
+            .with_transparency(true);
+
+        if window_config.start_maximized() {
+            return window.with_fullscreen(monitor)
+        }
 
         match window_config.decorations() {
             Decorations::Full => window,


### PR DESCRIPTION
Judging by the latest comments on #34 seems I'm not the only one irritated by the fact that Alacritty does not start in _fullscreen_ mode. 

This changes the `start_maximized` config behaviour to start the app in full-screen on the current primary monitor (macos : where the mouse is located and spotlight bar is displayed).

I guess an additional configuration can be added for this. For now, I rather keep this simple.

I've tested this on latest macOs Mojave version and it works as expected.

Can't test how this change behaves on Windows but I will update this PR once tested.