### PR TITLE
Use /compat/linux/proc in SpawnNewInstance on FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terminfo support for extended capabilities
 - Allow mouse presses and beginning of mouse selection in padding
 - Windows: Conpty backend could close immediately on startup in certain situations
+- FreeBSD: SpawnNewInstance will now open new instances in the shell's current working directory as long as linprocfs(5) is mounted on `/compat/linux/proc`
 
 ## Version 0.2.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terminfo support for extended capabilities
 - Allow mouse presses and beginning of mouse selection in padding
 - Windows: Conpty backend could close immediately on startup in certain situations
-- FreeBSD: SpawnNewInstance will now open new instances in the shell's current working directory as long as linprocfs(5) is mounted on `/compat/linux/proc`
+- FreeBSD: SpawnNewInstance will now open new instances in the shell's current
+    working directory as long as linprocfs(5) is mounted on `/compat/linux/proc`
 
 ## Version 0.2.9
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -172,7 +172,11 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
 
         #[cfg(unix)]
         let args = {
-            if let Ok(path) = fs::read_link(format!("/proc/{}/cwd", unsafe { tty::PID })) {
+            #[cfg(not(target_os = "freebsd"))]
+            let proc_prefix = "";
+            #[cfg(target_os = "freebsd")]
+            let proc_prefix = "/compat/linux";
+            if let Ok(path) = fs::read_link(format!("{}/proc/{}/cwd", proc_prefix, unsafe { tty::PID })) {
                 vec!["--working-directory".into(), path]
             } else {
                 Vec::new()


### PR DESCRIPTION
This fixes opening a new instance in the shell's current working
directory.  The code currently assumes that there is a Linux
compatible procfs mounted on /proc which is not the case on FreeBSD.
However linprocfs(5) is often mounted on /compat/linux/proc so we
can use that here for the time being.

A proper solution would look up the kern.proc.cwd.<pid> sysctl
instead, but that is not currently easily doable due to missing
KERN_PROC_CWD and struct kinfo_file definitions in the libc crate.