### PR TITLE
Adds keybinding for 'de' layout keyboards #2010

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for alternate keyboard layouts on macOS
 - Slow startup time on some X11 systems
 - The AltGr key no longer sends escapes (like Alt)
-- Fixes increase font-size keybinding on German keyboards
+- Fixes increase/decrease font-size keybindings on international keyboards
 
 ## Version 0.2.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for alternate keyboard layouts on macOS
 - Slow startup time on some X11 systems
 - The AltGr key no longer sends escapes (like Alt)
+- Fixes increase font-size keybinding on German keyboards
 
 ## Version 0.2.9
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -466,11 +466,13 @@ key_bindings:
   #- { key: Insert,   mods: Shift,         action: PasteSelection   }
   #- { key: Key0,     mods: Control,       action: ResetFontSize    }
   #- { key: Equals,   mods: Control,       action: IncreaseFontSize }
+  #- { key: Add,      mods: Control,       action: IncreaseFontSize }
   #- { key: Subtract, mods: Control,       action: DecreaseFontSize }
 
   # (macOS only)
   #- { key: Key0,   mods: Command, action: ResetFontSize    }
   #- { key: Equals, mods: Command, action: IncreaseFontSize }
+  #- { key: Add,    mods: Control, action: IncreaseFontSize }
   #- { key: Minus,  mods: Command, action: DecreaseFontSize }
   #- { key: K,      mods: Command, action: ClearHistory     }
   #- { key: K,      mods: Command, chars: "\x0c"            }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -468,6 +468,7 @@ key_bindings:
   #- { key: Equals,   mods: Control,       action: IncreaseFontSize }
   #- { key: Add,      mods: Control,       action: IncreaseFontSize }
   #- { key: Subtract, mods: Control,       action: DecreaseFontSize }
+  #- { key: Minus,    mods: Control,       action: DecreaseFontSize }
 
   # (macOS only)
   #- { key: Key0,   mods: Command, action: ResetFontSize    }

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -472,7 +472,7 @@ key_bindings:
   # (macOS only)
   #- { key: Key0,   mods: Command, action: ResetFontSize    }
   #- { key: Equals, mods: Command, action: IncreaseFontSize }
-  #- { key: Add,    mods: Control, action: IncreaseFontSize }
+  #- { key: Add,    mods: Command, action: IncreaseFontSize }
   #- { key: Minus,  mods: Command, action: DecreaseFontSize }
   #- { key: K,      mods: Command, action: ClearHistory     }
   #- { key: K,      mods: Command, chars: "\x0c"            }

--- a/src/config/bindings.rs
+++ b/src/config/bindings.rs
@@ -186,6 +186,7 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         Key::Insert, [shift: true]; Action::PasteSelection;
         Key::Key0, [ctrl: true]; Action::ResetFontSize;
         Key::Equals, [ctrl: true]; Action::IncreaseFontSize;
+        Key::Add, [ctrl: true]; Action::IncreaseFontSize;
         Key::Subtract, [ctrl: true]; Action::DecreaseFontSize;
     )
 }
@@ -196,6 +197,7 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         KeyBinding;
         Key::Key0, [logo: true]; Action::ResetFontSize;
         Key::Equals, [logo: true]; Action::IncreaseFontSize;
+        Key::Add, [ctrl: true]; Action::IncreaseFontSize;
         Key::Minus, [logo: true]; Action::DecreaseFontSize;
         Key::K, [logo: true]; Action::ClearHistory;
         Key::K, [logo: true]; Action::Esc("\x0c".into());

--- a/src/config/bindings.rs
+++ b/src/config/bindings.rs
@@ -188,6 +188,7 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         Key::Equals, [ctrl: true]; Action::IncreaseFontSize;
         Key::Add, [ctrl: true]; Action::IncreaseFontSize;
         Key::Subtract, [ctrl: true]; Action::DecreaseFontSize;
+        Key::Minus, [ctrl: true]; Action::DecreaseFontSize;
     )
 }
 

--- a/src/config/bindings.rs
+++ b/src/config/bindings.rs
@@ -197,7 +197,7 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         KeyBinding;
         Key::Key0, [logo: true]; Action::ResetFontSize;
         Key::Equals, [logo: true]; Action::IncreaseFontSize;
-        Key::Add, [ctrl: true]; Action::IncreaseFontSize;
+        Key::Add, [logo: true]; Action::IncreaseFontSize;
         Key::Minus, [logo: true]; Action::DecreaseFontSize;
         Key::K, [logo: true]; Action::ClearHistory;
         Key::K, [logo: true]; Action::Esc("\x0c".into());


### PR DESCRIPTION
This closes #2010  by implementing the suggestion made by @chrisduerr to include the IncreaseFontSize keybinding for the 'Add' key by default.

I tested this on MacOS and Arch Linux, and it seems to work. All of the cargo tests pass as well.

Also, I realize there's not a lot going on in this PR, but it's my first 'real' one so any suggestions or critiques about the code or the message would be most welcome! Thanks :) 