### PR TITLE
config and term: introduce explicit selection color.

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -177,6 +177,14 @@ colors:
   #  text: '0x000000'
   #  cursor: '0xffffff'
 
+  # Selection colors
+  #
+  # Colors which should be used to draw selections. If either are unset, the
+  # selection will be the inverse of the cell color.
+  #selection:
+  #  text: '0xff0000'
+  #  cursor: '0x00ff00'
+
   # Normal colors
   normal:
     black:   '0x000000'

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1281,6 +1281,8 @@ pub struct Colors {
     pub primary: PrimaryColors,
     #[serde(deserialize_with = "failure_default")]
     pub cursor: CursorColors,
+    #[serde(deserialize_with = "failure_default")]
+    pub selection: CursorColors,
     #[serde(deserialize_with = "deserialize_normal_colors")]
     pub normal: AnsiColors,
     #[serde(deserialize_with = "deserialize_bright_colors")]
@@ -1296,6 +1298,7 @@ impl Default for Colors {
         Colors {
             primary: Default::default(),
             cursor: Default::default(),
+            selection: Default::default(),
             normal: default_normal_colors(),
             bright: default_bright_colors(),
             dim: Default::default(),

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -458,7 +458,13 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
             let mut bg_rgb = self.compute_bg_rgb(cell.bg);
 
             let bg_alpha = if selected ^ cell.inverse() {
-                mem::swap(&mut fg_rgb, &mut bg_rgb);
+                let colors = self.config.colors().selection;
+		        if colors.text.is_none() || colors.cursor.is_none() {
+			        mem::swap(&mut fg_rgb, &mut bg_rgb);
+		        } else {
+                    fg_rgb = self.config.colors().selection.text.unwrap();
+                    bg_rgb = self.config.colors().selection.cursor.unwrap();
+                }
                 self.compute_bg_alpha(cell.fg)
             } else {
                 self.compute_bg_alpha(cell.bg)


### PR DESCRIPTION
This commit introduces a new feature for Alacritty wherein the user may
request explicit text and background colors for selection ranges.  If
no color is specified, the behavior falls back on the Alacritty factory
original of using the inverted fore- and background colors for the
current context.

This had been something I was pining for in the last two years of using
Alacritty.  Looked into how hard it would be to implement and seemed
easy enough.  Please let me know what your feedback is.

![Screenshot_20190310_125724](https://user-images.githubusercontent.com/46149/54084709-72821980-4334-11e9-9391-6e4bda62eeec.png)
