### PR TITLE
Fix invalid working-directory ptr for ConPTY

### DIFF
--- a/src/tty/windows/conpty.rs
+++ b/src/tty/windows/conpty.rs
@@ -234,7 +234,7 @@ pub fn new<'a>(
             false as i32,
             EXTENDED_STARTUPINFO_PRESENT,
             ptr::null_mut(),
-            cwd.map_or_else(ptr::null, |s| s.as_ptr()),
+            cwd.as_ref().map_or_else(ptr::null, |s| s.as_ptr()),
             &mut startup_info_ex.StartupInfo as *mut STARTUPINFOW,
             &mut proc_info as *mut PROCESS_INFORMATION,
         ) > 0;


### PR DESCRIPTION
Hi, thought I'd make pr for this rather than an issue since it's such a small change.

Currently passing an argument with --working-directory and ConPTY enabled causes a panic:

`panicked at 'assertion failed: success', src\tty\windows\conpty.rs:243:9`

The results of `Error::last_os_error()` reveals a bit more:

`
{ code: 123, kind: Other, message: "The filename, directory name, or volume label syntax is incorrect." }
`
I believe the current code code: `cwd.map_or_else(ptr::null, |s| s.as_ptr())` returns a dangling pointer - looks like the value is moved and then immediately dropped IIUC.