### PR TITLE
Add ScrollLineUp and ScrollLineDown actions for scrolling line by line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to change the selection color
 - Text will reflow instead of truncating when resizing Alacritty
 - Underline text and change cursor when hovering over URLs with required modifiers pressed
+- Added ScrollLineUp and ScrollLineDown actions for scrolling line by line
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -438,6 +438,8 @@ alt_send_esc: true
 #   - ResetFontSize
 #   - ScrollPageUp
 #   - ScrollPageDown
+#   - ScrollLineUp
+#   - ScrollLineDown
 #   - ScrollToTop
 #   - ScrollToBottom
 #   - ClearHistory

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -868,8 +868,9 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
             fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(
                     "Paste, Copy, PasteSelection, IncreaseFontSize, DecreaseFontSize, \
-                     ResetFontSize, ScrollPageUp, ScrollPageDown, ScrollToTop, ScrollToBottom, \
-                     ClearHistory, Hide, ClearLogNotice, SpawnNewInstance, None or Quit",
+                     ResetFontSize, ScrollPageUp, ScrollPageDown, ScrollLineUp, ScrollLineDown, \
+                     ScrollToTop, ScrollToBottom, ClearHistory, Hide, ClearLogNotice, \
+                     SpawnNewInstance, None or Quit",
                 )
             }
 
@@ -886,6 +887,8 @@ impl<'a> de::Deserialize<'a> for ActionWrapper {
                     "ResetFontSize" => Action::ResetFontSize,
                     "ScrollPageUp" => Action::ScrollPageUp,
                     "ScrollPageDown" => Action::ScrollPageDown,
+                    "ScrollLineUp" => Action::ScrollLineUp,
+                    "ScrollLineDown" => Action::ScrollLineDown,
                     "ScrollToTop" => Action::ScrollToTop,
                     "ScrollToBottom" => Action::ScrollToBottom,
                     "ClearHistory" => Action::ClearHistory,

--- a/src/input.rs
+++ b/src/input.rs
@@ -220,6 +220,12 @@ pub enum Action {
     /// Scroll exactly one page down
     ScrollPageDown,
 
+    /// Scroll one line up
+    ScrollLineUp,
+
+    /// Scroll one line down
+    ScrollLineDown,
+
     /// Scroll all the way to the top
     ScrollToTop,
 
@@ -316,6 +322,12 @@ impl Action {
             },
             Action::ScrollPageDown => {
                 ctx.scroll(Scroll::PageDown);
+            },
+            Action::ScrollLineUp => {
+                ctx.scroll(Scroll::Lines(1));
+            },
+            Action::ScrollLineDown => {
+                ctx.scroll(Scroll::Lines(-1));
             },
             Action::ScrollToTop => {
                 ctx.scroll(Scroll::Top);


### PR DESCRIPTION
It was mentioned in #923 that there is currently no way to scroll line by line using the keyboard.  This PR adds two actions, `ScrollLineUp` and `ScrollLineDown`, which can be optionally bound to keyboard keys by the user.