### PR TITLE
Fix URLs getting incorrectly extended to next line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The AltGr key no longer sends escapes (like Alt)
 - Fixes increase/decrease font-size keybindings on international keyboards
 - On Wayland, the `--title` flag will set the Window title now
-- URLs getting incorrectly extended to the following line
+- Parsing issues with URLs starting in the first or ending in the last column
 
 ## Version 0.2.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The AltGr key no longer sends escapes (like Alt)
 - Fixes increase/decrease font-size keybindings on international keyboards
 - On Wayland, the `--title` flag will set the Window title now
+- URLs getting incorrectly extended to the following line
 
 ## Version 0.2.9
 


### PR DESCRIPTION
If a URL ends right at the end of the terminal, it would sometimes
incorrectly include the characters from the following line when
launching the URL.

Similar to the semantic search function, the URL parsing iterator will
now stop if it encounters a cell at the end of the line which does not
contain the `WRAPLINE` flag.

This fixes #1906.