### PR TITLE
Fix URL highlight crash

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -10,7 +10,7 @@ use std::env;
 
 use serde_json as json;
 use parking_lot::MutexGuard;
-use glutin::{self, ModifiersState, Event, ElementState, MouseButton, MouseCursor};
+use glutin::{self, ModifiersState, Event, ElementState, MouseButton};
 use copypasta::{Clipboard, Load, Store, Buffer as ClipboardBuffer};
 use glutin::dpi::PhysicalSize;
 
@@ -222,13 +222,6 @@ pub enum ClickState {
     TripleClick,
 }
 
-/// Temporary save state for restoring mouse cursor and underline after unhovering a URL.
-pub struct UrlHoverSaveState {
-    pub mouse_cursor: MouseCursor,
-    pub underlined: Vec<bool>,
-    pub start: Point<usize>,
-}
-
 /// State of the mouse
 pub struct Mouse {
     pub x: usize,
@@ -245,7 +238,6 @@ pub struct Mouse {
     pub lines_scrolled: f32,
     pub block_url_launcher: bool,
     pub last_button: MouseButton,
-    pub url_hover_save: Option<UrlHoverSaveState>,
 }
 
 impl Default for Mouse {
@@ -265,7 +257,6 @@ impl Default for Mouse {
             lines_scrolled: 0.0,
             block_url_launcher: false,
             last_button: MouseButton::Other(0),
-            url_hover_save: None,
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -463,14 +463,12 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             let start = Point::new(line, Column(col));
 
             // Update URLs only on change, so they don't all get marked as underlined
-            if self.ctx.terminal().url_hover_save.as_ref().map(|hs| hs.start) == Some(start) {
+            if self.ctx.terminal().url_highlight_start() == Some(start) {
                 return;
             }
 
             // Since the URL changed without reset, we need to clear the previous underline
-            if let Some(hover_save) = self.ctx.terminal_mut().url_hover_save.take() {
-                self.ctx.terminal_mut().reset_url_underline(&hover_save);
-            }
+            self.ctx.terminal_mut().reset_url_highlight();
 
             // Underline all cells and store their current underline state
             let mut underlined = Vec::with_capacity(len);
@@ -482,7 +480,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             }
 
             // Save the higlight state for restoring it again
-            self.ctx.terminal_mut().url_hover_save = Some(UrlHoverSaveState {
+            self.ctx.terminal_mut().set_url_highlight(UrlHoverSaveState {
                 mouse_cursor,
                 underlined,
                 start,
@@ -490,9 +488,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
             self.ctx.terminal_mut().set_mouse_cursor(MouseCursor::Hand);
             self.ctx.terminal_mut().dirty = true;
-        } else if let Some(hover_save) = self.ctx.terminal_mut().url_hover_save.take() {
-            self.ctx.terminal_mut().reset_url_highlight(&hover_save);
-            self.ctx.terminal_mut().dirty = true;
+        } else {
+            self.ctx.terminal_mut().reset_url_highlight();
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -440,7 +440,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
         // Only show URLs as launchable when all required modifiers are pressed
         let url = if self.mouse_config.url.modifiers.relaxed_eq(modifiers)
-            && (!self.ctx.terminal().mode().contains(TermMode::ALT_SCREEN) || modifiers.shift)
+            && (!self.ctx.terminal().mode().intersects(mouse_mode) || modifiers.shift)
         {
                 self.ctx.terminal().url_search(point.into())
         } else {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1212,6 +1212,8 @@ impl Term {
             return;
         }
 
+        self.reset_url_highlight();
+
         let old_cols = self.grid.num_cols();
         let old_lines = self.grid.num_lines();
         let mut num_cols = size.cols();
@@ -1227,8 +1229,6 @@ impl Term {
             debug!("Term::resize dimensions unchanged");
             return;
         }
-
-        self.reset_url_highlight();
 
         self.grid.selection = None;
         self.alt_grid.selection = None;


### PR DESCRIPTION
The URL highlight stores the state of the last URL highlight with the
position of the URL start position. However when resizing, it's possible
that the indices of this point change which will cause a crash if the
old positions are not within the grid anymore.

This has been resolved by resetting the URL highlight state whenever the
terminal is resized.

This fixes #2194.