### PR TITLE
Maximize window after mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes increase/decrease font-size keybindings on international keyboards
 - On Wayland, the `--title` flag will set the Window title now
 - Parsing issues with URLs starting in the first or ending in the last column
+- Fix not starting maximized on X11
 
 ## Version 0.2.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes increase/decrease font-size keybindings on international keyboards
 - On Wayland, the `--title` flag will set the Window title now
 - Parsing issues with URLs starting in the first or ending in the last column
-- Fix not starting maximized on X11
+- Fix `start_maximized` option on X11
 
 ## Version 0.2.9
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -138,6 +138,7 @@ impl Window {
         let window = create_gl_window(window_builder.clone(), &event_loop, false)
             .or_else(|_| create_gl_window(window_builder, &event_loop, true))?;
         window.show();
+        window.set_maximized(window_config.start_maximized());
 
         // Text cursor
         window.set_cursor(MouseCursor::Text);
@@ -263,7 +264,6 @@ impl Window {
             .with_title(title)
             .with_visibility(false)
             .with_transparency(true)
-            .with_maximized(window_config.start_maximized())
             .with_decorations(decorations)
             // X11
             .with_class(class.into(), DEFAULT_NAME.into())

--- a/src/window.rs
+++ b/src/window.rs
@@ -144,8 +144,8 @@ impl Window {
         // Maximize window after mapping in X11
         #[cfg(not(any(target_os = "macos", windows)))]
         {
-            if event_loop.is_x11() {
-                window.set_maximized(window_config.start_maximized());
+            if event_loop.is_x11() && window_config.start_maximized() {
+                window.set_maximized(true);
             }
         }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,6 +24,7 @@ use glutin::{
     MouseCursor, WindowBuilder, ContextTrait
 };
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
+#[cfg(not(any(target_os = "macos", windows)))]
 use glutin::os::unix::EventsLoopExt;
 
 use crate::cli::Options;

--- a/src/window.rs
+++ b/src/window.rs
@@ -138,6 +138,8 @@ impl Window {
         let window = create_gl_window(window_builder.clone(), &event_loop, false)
             .or_else(|_| create_gl_window(window_builder, &event_loop, true))?;
         window.show();
+
+        // Maximize window after mapping
         window.set_maximized(window_config.start_maximized());
 
         // Text cursor

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,7 +24,7 @@ use glutin::{
     MouseCursor, WindowBuilder, ContextTrait
 };
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
-use glutin::os::unix::WindowExt;
+use glutin::os::unix::EventsLoopExt;
 
 use crate::cli::Options;
 use crate::config::{Decorations, WindowConfig};
@@ -141,7 +141,7 @@ impl Window {
         window.show();
 
         // Maximize window after mapping in X11
-        if cfg!(not(any(target_os = "macos", windows))) && window.get_xlib_window().is_some() {
+        if cfg!(not(any(target_os = "macos", windows))) && event_loop.is_x11() {
             window.set_maximized(window_config.start_maximized());
         }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,6 +24,7 @@ use glutin::{
     MouseCursor, WindowBuilder, ContextTrait
 };
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
+use glutin::os::unix::WindowExt;
 
 use crate::cli::Options;
 use crate::config::{Decorations, WindowConfig};
@@ -139,8 +140,10 @@ impl Window {
             .or_else(|_| create_gl_window(window_builder, &event_loop, true))?;
         window.show();
 
-        // Maximize window after mapping
-        window.set_maximized(window_config.start_maximized());
+        // Maximize window after mapping in X11
+        if cfg!(not(any(target_os = "macos", windows))) && window.get_xlib_window().is_some() {
+            window.set_maximized(window_config.start_maximized());
+        }
 
         // Text cursor
         window.set_cursor(MouseCursor::Text);
@@ -267,6 +270,7 @@ impl Window {
             .with_visibility(false)
             .with_transparency(true)
             .with_decorations(decorations)
+            .with_maximized(window_config.start_maximized())
             // X11
             .with_class(class.into(), DEFAULT_NAME.into())
             // Wayland

--- a/src/window.rs
+++ b/src/window.rs
@@ -141,8 +141,11 @@ impl Window {
         window.show();
 
         // Maximize window after mapping in X11
-        if cfg!(not(any(target_os = "macos", windows))) && event_loop.is_x11() {
-            window.set_maximized(window_config.start_maximized());
+        #[cfg(not(any(target_os = "macos", windows)))]
+        {
+            if event_loop.is_x11() {
+                window.set_maximized(window_config.start_maximized());
+            }
         }
 
         // Text cursor


### PR DESCRIPTION
Because Alacritty's window starts out unmapped with `with_visibility(false)`, adding `with_maximized()` makes Winit try to maximize the window before it's mapped. Compliant window managers ignore the request, so when `show()` is called, it's not maximized. This pull request explicitly maximizes the window after it's mapped, and fixes #1902.