### PR TITLE
Fix URL parsing with double-width characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes increase/decrease font-size keybindings on international keyboards
 - On Wayland, the `--title` flag will set the Window title now
 - Parsing issues with URLs starting in the first or ending in the last column
+- URLs stopping at double-width characters
 
 ## Version 0.2.9
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -447,7 +447,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             None
         };
 
-        if let Some(Url { text, origin }) = url {
+        if let Some(Url { origin, len, .. }) = url {
             let mouse_cursor = if self.ctx.terminal().mode().intersects(mouse_mode) {
                 MouseCursor::Default
             } else {
@@ -473,9 +473,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             }
 
             // Underline all cells and store their current underline state
-            let mut underlined = Vec::with_capacity(text.len());
+            let mut underlined = Vec::with_capacity(len);
             let iter = once(start).chain(start.iter(Column(cols - 1), last_line));
-            for point in iter.take(text.len()) {
+            for point in iter.take(len) {
                 let cell = &mut self.ctx.terminal_mut().grid_mut()[point.line][point.col];
                 underlined.push(cell.flags.contains(Flags::UNDERLINE));
                 cell.flags.insert(Flags::UNDERLINE);

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -120,14 +120,14 @@ impl Search for Term {
         let mut url_parser = UrlParser::new();
         while let Some(cell) = iterb.prev() {
             if (iterb.cur().col == last_col && !cell.flags.contains(cell::Flags::WRAPLINE))
-                || url_parser.advance_left(cell.c)
+                || url_parser.advance_left(cell)
             {
                 break;
             }
         }
 
         while let Some(cell) = iterf.next() {
-            if url_parser.advance_right(cell.c)
+            if url_parser.advance_right(cell)
                 || (iterf.cur().col == last_col && !cell.flags.contains(cell::Flags::WRAPLINE))
             {
                 break;

--- a/src/url.rs
+++ b/src/url.rs
@@ -251,17 +251,17 @@ mod tests {
 
     #[test]
     fn url_len() {
-        // let term = url_create_term(" test https://example.org ");
-        // let url = term.url_search(Point::new(0, Column(10)));
-        // assert_eq!(url.map(|u| u.len), Some(19));
+        let term = url_create_term(" test https://example.org ");
+        let url = term.url_search(Point::new(0, Column(10)));
+        assert_eq!(url.map(|u| u.len), Some(19));
 
-        // let term = url_create_term("https://全.org");
-        // let url = term.url_search(Point::new(0, Column(0)));
-        // assert_eq!(url.map(|u| u.len), Some(14));
+        let term = url_create_term("https://全.org");
+        let url = term.url_search(Point::new(0, Column(0)));
+        assert_eq!(url.map(|u| u.len), Some(14));
 
-        // let term = url_create_term("https://全.org");
-        // let url = term.url_search(Point::new(0, Column(10)));
-        // assert_eq!(url.map(|u| u.len), Some(14));
+        let term = url_create_term("https://全.org");
+        let url = term.url_search(Point::new(0, Column(10)));
+        assert_eq!(url.map(|u| u.len), Some(14));
 
         let term = url_create_term("https://全.org");
         let url = term.url_search(Point::new(0, Column(9)));
@@ -293,11 +293,11 @@ mod tests {
     #[test]
     fn url_detect_end() {
         url_test("https://example.org/test\u{00}ing", "https://example.org/test");
-        // url_test("https://example.org/test\u{1F}ing", "https://example.org/test");
-        // url_test("https://example.org/test\u{7F}ing", "https://example.org/test");
-        // url_test("https://example.org/test\u{9F}ing", "https://example.org/test");
-        // url_test("https://example.org/test\ting", "https://example.org/test");
-        // url_test("https://example.org/test ing", "https://example.org/test");
+        url_test("https://example.org/test\u{1F}ing", "https://example.org/test");
+        url_test("https://example.org/test\u{7F}ing", "https://example.org/test");
+        url_test("https://example.org/test\u{9F}ing", "https://example.org/test");
+        url_test("https://example.org/test\ting", "https://example.org/test");
+        url_test("https://example.org/test ing", "https://example.org/test");
     }
 
     #[test]


### PR DESCRIPTION
Since double-width characters are followed by an empty cell containing
only the `WIDE_CELL_SPACER` flag, the URL parser would stop once
encountering the cell after a double-width character.

By skipping cells that contain the `WIDE_CELL_SPACER` flag and
incrementing the URL length by unicode width of the character instead of
cell count, this can be resolved for both URL launching and URL
highlighting.

Fixes #2158.