### PR TITLE
Update --class docs

### DIFF
--- a/alacritty.man
+++ b/alacritty.man
@@ -40,7 +40,7 @@ Prints version information
 .SH "OPTIONS"
 .TP
 \fB\-\-class\fR <class>
-Defines the window class on X11 [default: Alacritty]
+Defines the window class on Linux [default: Alacritty]
 .TP
 \fB\-e\fR, \fB\-\-command\fR <command>...
 Command and args to execute (must be last argument)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,7 +100,7 @@ impl Options {
             .arg(Arg::with_name("class")
                  .long("class")
                  .takes_value(true)
-                 .help(&format!("Defines window class on X11 [default: {}]", DEFAULT_NAME)))
+                 .help(&format!("Defines window class on Linux [default: {}]", DEFAULT_NAME)))
             .arg(Arg::with_name("q")
                 .short("q")
                 .multiple(true)


### PR DESCRIPTION
Since the `--class` flag has been changed to take effect on Wayland too,
the documentation has been updated to reflect that.

The original change was made in #2077.