### PR TITLE
Rework URL highlighting 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing issues with URLs starting in the first or ending in the last column
 - URLs stopping at double-width characters
 - Fix `start_maximized` option on X11
+- Error when parsing URLs ending with Unicode outside of the ascii range
 
 ## Version 0.2.9
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -432,6 +432,7 @@ impl<N: Notify> Processor<N> {
                             processor.ctx.terminal.dirty = true;
                             processor.ctx.terminal.next_is_urgent = Some(false);
                         } else {
+                            processor.ctx.terminal.reset_url_highlight();
                             processor.ctx.terminal.dirty = true;
                             *hide_mouse = false;
                         }

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -15,7 +15,7 @@
 //! A specialized 2d grid implementation optimized for use in a terminal.
 
 use std::cmp::{min, max, Ordering};
-use std::ops::{Deref, Range, Index, IndexMut, RangeTo, RangeFrom, RangeFull};
+use std::ops::{Deref, Range, Index, IndexMut, RangeTo, RangeFrom, RangeFull, RangeInclusive};
 
 use crate::index::{self, Point, Line, Column, IndexRange};
 use crate::selection::Selection;
@@ -105,16 +105,9 @@ pub struct Grid<T> {
     #[serde(default)]
     max_scroll_limit: usize,
 
-    /// Underline URL on hover
+    /// Range for URL hover highlights
     #[serde(default)]
-    pub url_highlight: Option<UrlHighlight>,
-}
-
-/// Temporary save state for restoring mouse cursor and underline after unhovering a URL.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct UrlHighlight {
-    pub start: Point<usize>,
-    pub end: Point<usize>,
+    pub url_highlight: Option<RangeInclusive<index::Linear>>,
 }
 
 #[derive(Copy, Clone)]

--- a/src/grid/tests.rs
+++ b/src/grid/tests.rs
@@ -112,8 +112,8 @@ fn test_iter() {
 
     assert_eq!(None, iter.prev());
     assert_eq!(Some(&1), iter.next());
-    assert_eq!(Column(1), iter.cur().col);
-    assert_eq!(4, iter.cur().line);
+    assert_eq!(Column(1), iter.cur.col);
+    assert_eq!(4, iter.cur.line);
 
     assert_eq!(Some(&2), iter.next());
     assert_eq!(Some(&3), iter.next());
@@ -121,12 +121,12 @@ fn test_iter() {
 
     // test linewrapping
     assert_eq!(Some(&5), iter.next());
-    assert_eq!(Column(0), iter.cur().col);
-    assert_eq!(3, iter.cur().line);
+    assert_eq!(Column(0), iter.cur.col);
+    assert_eq!(3, iter.cur.line);
 
     assert_eq!(Some(&4), iter.prev());
-    assert_eq!(Column(4), iter.cur().col);
-    assert_eq!(4, iter.cur().line);
+    assert_eq!(Column(4), iter.cur.col);
+    assert_eq!(4, iter.cur.line);
 
 
     // test that iter ends at end of grid

--- a/src/index.rs
+++ b/src/index.rs
@@ -19,8 +19,6 @@ use std::cmp::{Ord, Ordering};
 use std::fmt;
 use std::ops::{self, Deref, Range, RangeInclusive, Add, Sub, AddAssign, SubAssign};
 
-use crate::grid::BidirectionalIterator;
-
 /// The side of a cell
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Side {
@@ -72,67 +70,6 @@ impl From<Point> for Point<usize> {
     }
 }
 
-impl<T> Point<T>
-where
-    T: Copy + Default + SubAssign<usize> + PartialEq,
-{
-    pub fn iter(&self, last_col: Column, last_line: T) -> PointIterator<T> {
-        PointIterator {
-            cur: *self,
-            last_col,
-            last_line,
-        }
-    }
-}
-
-pub struct PointIterator<T> {
-    pub cur: Point<T>,
-    last_col: Column,
-    last_line: T,
-}
-
-impl<T> Iterator for PointIterator<T>
-where
-    T: Copy + Default + SubAssign<usize> + PartialEq,
-{
-    type Item = Point<T>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.cur {
-            Point { line, col } if line == Default::default() && col == self.last_col => None,
-            Point { col, .. } if col == self.last_col => {
-                self.cur.line -= 1;
-                self.cur.col = Column(0);
-                Some(self.cur)
-            },
-            _ => {
-                self.cur.col += Column(1);
-                Some(self.cur)
-            }
-        }
-    }
-}
-
-impl<T> BidirectionalIterator for PointIterator<T>
-where
-    T: Copy + Default + AddAssign<usize> + SubAssign<usize> + PartialEq,
-{
-    fn prev(&mut self) -> Option<Self::Item> {
-        match self.cur {
-            Point { line, col: Column(0) } if line == self.last_line => None,
-            Point { col: Column(0), .. } => {
-                self.cur.line += 1;
-                self.cur.col = self.last_col;
-                Some(self.cur)
-            },
-            _ => {
-                self.cur.col -= Column(1);
-                Some(self.cur)
-            }
-        }
-    }
-}
-
 /// A line
 ///
 /// Newtype to avoid passing values incorrectly
@@ -162,6 +99,16 @@ impl fmt::Display for Column {
 /// Newtype to avoid passing values incorrectly
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Linear(pub usize);
+
+impl Linear {
+    pub fn new(columns: Column, column: Column, line: Line) -> Self {
+        Linear(line.0 * columns.0 + column.0)
+    }
+
+    pub fn from_point(columns: Column, point: Point<usize>) -> Self {
+        Linear(point.line * columns.0 + point.col.0)
+    }
+}
 
 impl fmt::Display for Linear {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/input.rs
+++ b/src/input.rs
@@ -24,6 +24,7 @@ use std::time::Instant;
 use std::iter::once;
 
 use copypasta::{Clipboard, Load, Buffer as ClipboardBuffer};
+use unicode_width::UnicodeWidthStr;
 use glutin::{
     ElementState, KeyboardInput, ModifiersState, MouseButton, MouseCursor, MouseScrollDelta,
     TouchPhase,
@@ -448,7 +449,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             None
         };
 
-        if let Some(Url { origin, len, .. }) = url {
+        if let Some(Url { origin, text }) = url {
             let mouse_cursor = if self.ctx.terminal().mode().intersects(mouse_mode) {
                 MouseCursor::Default
             } else {
@@ -470,6 +471,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
             // Since the URL changed without reset, we need to clear the previous underline
             self.ctx.terminal_mut().reset_url_highlight();
+
+            let len = text.width();
 
             // Underline all cells and store their current underline state
             let mut underlined = Vec::with_capacity(len);

--- a/src/input.rs
+++ b/src/input.rs
@@ -21,6 +21,7 @@
 use std::borrow::Cow;
 use std::mem;
 use std::time::Instant;
+use std::ops::RangeInclusive;
 
 use copypasta::{Clipboard, Load, Buffer as ClipboardBuffer};
 use unicode_width::UnicodeWidthStr;
@@ -30,9 +31,9 @@ use glutin::{
 };
 
 use crate::config::{self, Key};
-use crate::grid::{Scroll, UrlHighlight};
+use crate::grid::Scroll;
 use crate::event::{ClickState, Mouse};
-use crate::index::{Line, Column, Side, Point};
+use crate::index::{Line, Column, Side, Point, Linear};
 use crate::term::{Term, SizeInfo, Search};
 use crate::term::mode::TermMode;
 use crate::util::fmt::Red;
@@ -467,10 +468,10 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             let end_line = point.line.0 + (point.col.0 + len - origin) / cols;
             let end = Point::new(end_line, Column(end_col));
 
-            self.ctx.terminal_mut().set_url_highlight(UrlHighlight {
-                start,
-                end,
-            });
+            let start = Linear::from_point(Column(cols), start);
+            let end = Linear::from_point(Column(cols), end);
+
+            self.ctx.terminal_mut().set_url_highlight(RangeInclusive::new(start, end));
             self.ctx.terminal_mut().set_mouse_cursor(MouseCursor::Hand);
             self.ctx.terminal_mut().dirty = true;
         } else {

--- a/src/input.rs
+++ b/src/input.rs
@@ -21,7 +21,6 @@
 use std::borrow::Cow;
 use std::mem;
 use std::time::Instant;
-use std::iter::once;
 
 use copypasta::{Clipboard, Load, Buffer as ClipboardBuffer};
 use unicode_width::UnicodeWidthStr;
@@ -31,12 +30,11 @@ use glutin::{
 };
 
 use crate::config::{self, Key};
-use crate::grid::Scroll;
+use crate::grid::{Scroll, UrlHighlight};
 use crate::event::{ClickState, Mouse};
 use crate::index::{Line, Column, Side, Point};
-use crate::term::{Term, SizeInfo, Search, UrlHoverSaveState};
+use crate::term::{Term, SizeInfo, Search};
 use crate::term::mode::TermMode;
-use crate::term::cell::Flags;
 use crate::util::fmt::Red;
 use crate::util::start_daemon;
 use crate::message_bar::{self, Message};
@@ -450,46 +448,29 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         };
 
         if let Some(Url { origin, text }) = url {
-            let mouse_cursor = if self.ctx.terminal().mode().intersects(mouse_mode) {
-                MouseCursor::Default
-            } else {
-                MouseCursor::Text
-            };
-
             let cols = self.ctx.size_info().cols().0;
-            let last_line = self.ctx.size_info().lines().0 - 1;
 
             // Calculate the URL's start position
-            let col = (cols + point.col.0 - origin % cols) % cols;
-            let line = last_line - point.line.0 + (origin + cols - point.col.0 - 1) / cols;
-            let start = Point::new(line, Column(col));
+            let lines_before = (origin + cols - point.col.0 - 1) / cols;
+            let (start_col, start_line) = if lines_before > point.line.0 {
+                (0, 0)
+            } else {
+                let start_col = (cols + point.col.0 - origin % cols) % cols;
+                let start_line = point.line.0 - lines_before;
+                (start_col, start_line)
+            };
+            let start = Point::new(start_line, Column(start_col));
 
-            // Update URLs only on change, so they don't all get marked as underlined
-            if self.ctx.terminal().url_highlight_start() == Some(start) {
-                return;
-            }
-
-            // Since the URL changed without reset, we need to clear the previous underline
-            self.ctx.terminal_mut().reset_url_highlight();
-
+            // Calculate the URL's end position
             let len = text.width();
+            let end_col = (point.col.0 + len - origin) % cols - 1;
+            let end_line = point.line.0 + (point.col.0 + len - origin) / cols;
+            let end = Point::new(end_line, Column(end_col));
 
-            // Underline all cells and store their current underline state
-            let mut underlined = Vec::with_capacity(len);
-            let iter = once(start).chain(start.iter(Column(cols - 1), last_line));
-            for point in iter.take(len) {
-                let cell = &mut self.ctx.terminal_mut().grid_mut()[point.line][point.col];
-                underlined.push(cell.flags.contains(Flags::UNDERLINE));
-                cell.flags.insert(Flags::UNDERLINE);
-            }
-
-            // Save the higlight state for restoring it again
-            self.ctx.terminal_mut().set_url_highlight(UrlHoverSaveState {
-                mouse_cursor,
-                underlined,
+            self.ctx.terminal_mut().set_url_highlight(UrlHighlight {
                 start,
+                end,
             });
-
             self.ctx.terminal_mut().set_mouse_cursor(MouseCursor::Hand);
             self.ctx.terminal_mut().dirty = true;
         } else {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -26,7 +26,7 @@ use font::{self, Size};
 use crate::ansi::{self, Color, NamedColor, Attr, Handler, CharsetIndex, StandardCharset, CursorStyle};
 use crate::grid::{
     BidirectionalIterator, DisplayIter, Grid, GridCell, IndexRegion, Indexed, Scroll,
-    ViewportPosition, UrlHighlight
+    ViewportPosition
 };
 use crate::index::{self, Point, Column, Line, IndexRange, Contains, Linear};
 use crate::selection::{self, Selection, Locations};
@@ -163,7 +163,7 @@ pub struct RenderableCellsIter<'a> {
     config: &'a Config,
     colors: &'a color::List,
     selection: Option<RangeInclusive<index::Linear>>,
-    url_highlight: Option<RangeInclusive<index::Linear>>,
+    url_highlight: &'a Option<RangeInclusive<index::Linear>>,
     cursor_cells: ArrayDeque<[Indexed<Cell>; 3]>,
 }
 
@@ -231,16 +231,6 @@ impl<'a> RenderableCellsIter<'a> {
             }
         }
 
-        let url_highlight = match grid.url_highlight {
-            Some(ref hl) => {
-                let cols = grid.num_cols();
-                let start = Linear::from_point(cols, hl.start);
-                let end = Linear::from_point(cols, hl.end);
-                Some(RangeInclusive::new(start, end))
-            },
-            None => None,
-        };
-
         RenderableCellsIter {
             cursor: &term.cursor.point,
             cursor_offset,
@@ -248,7 +238,7 @@ impl<'a> RenderableCellsIter<'a> {
             inner,
             mode: term.mode,
             selection: selection_range,
-            url_highlight,
+            url_highlight: &grid.url_highlight,
             config,
             colors: &term.colors,
             cursor_cells: ArrayDeque::new(),
@@ -1389,7 +1379,7 @@ impl Term {
     }
 
     #[inline]
-    pub fn set_url_highlight(&mut self, hl: UrlHighlight) {
+    pub fn set_url_highlight(&mut self, hl: RangeInclusive<index::Linear>) {
         self.grid.url_highlight = Some(hl);
     }
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -66,11 +66,7 @@ impl UrlParser {
             return false;
         }
 
-        if self.advance(cell.c, self.state.len()) {
-            true
-        } else {
-            false
-        }
+        self.advance(cell.c, self.state.len())
     }
 
     /// Returns the URL if the parser has found any.

--- a/src/url.rs
+++ b/src/url.rs
@@ -94,7 +94,7 @@ impl UrlParser {
         // Remove non-matching parenthesis and brackets
         let mut open_parens_count: isize = 0;
         let mut open_bracks_count: isize = 0;
-        for (i, c) in self.state.chars().enumerate() {
+        for (i, c) in self.state.char_indices() {
             match c {
                 '(' => open_parens_count += 1,
                 ')' if open_parens_count > 0 => open_parens_count -= 1,
@@ -266,6 +266,8 @@ mod tests {
         url_test("'https://example.org'", "https://example.org");
         url_test("'https://example.org", "https://example.org");
         url_test("https://example.org'", "https://example.org");
+
+        url_test("(https://example.org/test全)", "https://example.org/test全");
     }
 
     #[test]

--- a/src/url.rs
+++ b/src/url.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use url;
+use unicode_width::UnicodeWidthChar;
 
 use crate::term::cell::{Cell, Flags};
 
@@ -28,14 +29,12 @@ const URL_SCHEMES: [&str; 8] = [
 pub struct Url {
     pub text: String,
     pub origin: usize,
-    pub len: usize,
 }
 
 /// Parser for streaming inside-out detection of URLs.
 pub struct UrlParser {
     state: String,
     origin: usize,
-    len: usize,
 }
 
 impl UrlParser {
@@ -43,7 +42,6 @@ impl UrlParser {
         UrlParser {
             state: String::new(),
             origin: 0,
-            len: 0,
         }
     }
 
@@ -51,7 +49,6 @@ impl UrlParser {
     pub fn advance_left(&mut self, cell: &Cell) -> bool {
         if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
             self.origin += 1;
-            self.len += 1;
             return false;
         }
 
@@ -59,7 +56,6 @@ impl UrlParser {
             true
         } else {
             self.origin += 1;
-            self.len += 1;
             false
         }
     }
@@ -67,14 +63,12 @@ impl UrlParser {
     /// Advance the parser one character to the right.
     pub fn advance_right(&mut self, cell: &Cell) -> bool {
         if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
-            self.len += 1;
             return false;
         }
 
         if self.advance(cell.c, self.state.len()) {
             true
         } else {
-            self.len += 1;
             false
         }
     }
@@ -93,7 +87,7 @@ impl UrlParser {
                 match c {
                     'a'...'z' | 'A'...'Z' => (),
                     _ => {
-                        self.origin = self.origin.saturating_sub(byte_index + 1);
+                        self.origin = self.origin.saturating_sub(byte_index + c.width().unwrap_or(1));
                         self.state = self.state.split_off(byte_index + c.len_utf8());
                         break;
                     }
@@ -140,7 +134,6 @@ impl UrlParser {
                     Some(Url {
                         origin: self.origin - 1,
                         text: self.state,
-                        len: self.len,
                     })
                 } else {
                     None
@@ -247,25 +240,14 @@ mod tests {
         let term = url_create_term("https://全.org");
         let url = term.url_search(Point::new(0, Column(9)));
         assert_eq!(url.map(|u| u.origin), Some(9));
-    }
 
-    #[test]
-    fn url_len() {
-        let term = url_create_term(" test https://example.org ");
-        let url = term.url_search(Point::new(0, Column(10)));
-        assert_eq!(url.map(|u| u.len), Some(19));
-
-        let term = url_create_term("https://全.org");
-        let url = term.url_search(Point::new(0, Column(0)));
-        assert_eq!(url.map(|u| u.len), Some(14));
-
-        let term = url_create_term("https://全.org");
-        let url = term.url_search(Point::new(0, Column(10)));
-        assert_eq!(url.map(|u| u.len), Some(14));
-
-        let term = url_create_term("https://全.org");
+        let term = url_create_term("test@https://example.org");
         let url = term.url_search(Point::new(0, Column(9)));
-        assert_eq!(url.map(|u| u.len), Some(14));
+        assert_eq!(url.map(|u| u.origin), Some(4));
+
+        let term = url_create_term("test全https://example.org");
+        let url = term.url_search(Point::new(0, Column(9)));
+        assert_eq!(url.map(|u| u.origin), Some(3));
     }
 
     #[test]


### PR DESCRIPTION
This completely reworks URL highlighting to fix two issues which were
caused by the original approach.

The primary issues that were not straight-forward to resolve with the
previous implementation were about handling the URL highlighted content
moving while the highlight is active.

This lead to issues with highlighting with scrolling and when the
display offset was not 0.

The new approach sticks closely to prior art done for the selection,
where the selection is tracked on the grid and updated whenever the
buffer is rotated.

This fixes #2225.
This fixes #2231.