### PR TITLE
Disable automatic graphics switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Clicking on non-alphabetical characters in front of URLs will no longer open them
 - Command keybindings on Windows will no longer open new cmd.exe console windows
+- On macOS, automatic graphics switching has been temporarily disabled due to a macos bug
 
 ### Fixed
 

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -29,7 +29,7 @@
   <key>NSMainNibFile</key>
   <string></string>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
-  <true/>
+  <false/>
   <key>CFBundleDisplayName</key>
   <string>Alacritty</string>
   <key>NSRequiresAquaSystemAppearance</key>


### PR DESCRIPTION
Temporarily disabled automatic graphics switching due to a bug in macOS
which leads to crashing.

See #2221.