### PR TITLE
Improve errors for missing shell file on Windows 

### DIFF
--- a/src/tty/windows/conpty.rs
+++ b/src/tty/windows/conpty.rs
@@ -15,11 +15,11 @@
 use super::{Pty, HANDLE};
 
 use std::i16;
+use std::io::Error;
 use std::mem;
 use std::os::windows::io::IntoRawHandle;
 use std::ptr;
 use std::sync::Arc;
-use std::io::Error;
 
 use dunce::canonicalize;
 use mio_anonymous_pipes::{EventedAnonRead, EventedAnonWrite};

--- a/src/tty/windows/conpty.rs
+++ b/src/tty/windows/conpty.rs
@@ -218,7 +218,7 @@ pub fn new<'a>(
 
     let mut proc_info: PROCESS_INFORMATION = Default::default();
     unsafe {
-        success = CreateProcessW(
+        let process_found = CreateProcessW(
             ptr::null(),
             cmdline.as_ptr() as LPWSTR,
             ptr::null_mut(),
@@ -231,7 +231,9 @@ pub fn new<'a>(
             &mut proc_info as *mut PROCESS_INFORMATION,
         ) > 0;
 
-        assert!(success);
+        if (!process_found) {
+            panic!("Unable to spawn shell: File can not be found in PATH");
+        }
     }
 
     // Store handle to console

--- a/src/tty/windows/conpty.rs
+++ b/src/tty/windows/conpty.rs
@@ -19,6 +19,7 @@ use std::mem;
 use std::os::windows::io::IntoRawHandle;
 use std::ptr;
 use std::sync::Arc;
+use std::io::Error;
 
 use dunce::canonicalize;
 use mio_anonymous_pipes::{EventedAnonRead, EventedAnonWrite};
@@ -155,11 +156,13 @@ pub fn new<'a>(
 
     // Create the appropriately sized thread attribute list.
     unsafe {
-        success =
+        let failure =
             InitializeProcThreadAttributeList(ptr::null_mut(), 1, 0, &mut size as PSIZE_T) > 0;
 
         // This call was expected to return false.
-        assert!(!success);
+        if (!failure) {
+            panic_shell_spawn();
+        }
     }
 
     let mut attr_list: Box<[BYTE]> = vec![0; size].into_boxed_slice();
@@ -183,7 +186,9 @@ pub fn new<'a>(
             &mut size as PSIZE_T,
         ) > 0;
 
-        assert!(success);
+        if (!success) {
+            panic_shell_spawn();
+        }
     }
 
     // Set thread attribute list's Pseudo Console to the specified ConPTY
@@ -198,7 +203,9 @@ pub fn new<'a>(
             ptr::null_mut(),
         ) > 0;
 
-        assert!(success);
+        if (!success) {
+            panic_shell_spawn();
+        }
     }
 
     // Get process commandline
@@ -218,7 +225,7 @@ pub fn new<'a>(
 
     let mut proc_info: PROCESS_INFORMATION = Default::default();
     unsafe {
-        let process_found = CreateProcessW(
+        success = CreateProcessW(
             ptr::null(),
             cmdline.as_ptr() as LPWSTR,
             ptr::null_mut(),
@@ -231,8 +238,8 @@ pub fn new<'a>(
             &mut proc_info as *mut PROCESS_INFORMATION,
         ) > 0;
 
-        if (!process_found) {
-            panic!("Unable to spawn shell: File can not be found in PATH");
+        if (!success) {
+            panic_shell_spawn();
         }
     }
 
@@ -253,6 +260,11 @@ pub fn new<'a>(
         read_token: 0.into(),
         write_token: 0.into(),
     })
+}
+
+// Panic with the last os error as message
+fn panic_shell_spawn() {
+    panic!("Unable to spawn shell: {}", Error::last_os_error());
 }
 
 impl OnResize for ConptyHandle {


### PR DESCRIPTION
Currently with WinPTY there is no error at all if the shell does not
exist and on ConPTY the error is cryptic 'assertion failed: success'.

This changes the ConPTY assertion to a human-readable error which
clearly states that the file could not be found.

Currently the WinPTY backend has not been fixed yet.

This fixes #2016.