### PR TITLE
Reset scrolling region when receiving the RIS escape sequence (#2258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added ScrollLineUp and ScrollLineDown actions for scrolling line by line
+
+### Fixed
+
+- Reset scrolling region when the RIS escape sequence is received
+
 ## Version 0.3.0
 
 ### Packaging
@@ -55,7 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `start_maximized` option on X11
 - Error when parsing URLs ending with Unicode outside of the ascii range
 - On Windows, focusing a Window will no longer start a selection
-- Reset scrolling region when the RIS escape sequence is received
 
 ## Version 0.2.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `start_maximized` option on X11
 - Error when parsing URLs ending with Unicode outside of the ascii range
 - On Windows, focusing a Window will no longer start a selection
+- Reset scrolling region when the RIS escape sequence is received
 
 ## Version 0.2.9
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1995,6 +1995,7 @@ impl ansi::Handler for Term {
         self.cursor_style = None;
         self.grid.reset(&Cell::default());
         self.alt_grid.reset(&Cell::default());
+        self.scroll_region = Line(0)..self.grid.num_lines();
     }
 
     #[inline]


### PR DESCRIPTION
Reset the scrolling region (aka top/bottom margins) when the RIS escape sequence is received. 

The change is in `mod.rs:reset_state()`. This function is **only** called when the RIS sequence is received.

This mostly fixes #2258. It also mentions `DECSTR` (soft reset). That escape sequence doesn't appear to be implemented **at all**. This PR makes no attempt to implement it.