### PR TITLE
Fix macos subprocess execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reset scrolling region when the RIS escape sequence is received
+- Subprocess spawning on macos
 
 ## Version 0.3.0
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -93,10 +93,16 @@ where
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .before_exec(|| unsafe {
-            if ::libc::fork() != 0 {
-                ::libc::_exit(0);
+            match ::libc::fork() {
+                -1 => return Err(io::Error::last_os_error()),
+                0 => (),
+                _ => ::libc::_exit(0),
             }
-            ::libc::setsid();
+
+            if ::libc::setsid() == -1 {
+                return Err(io::Error::last_os_error());
+            }
+
             Ok(())
         })
         .spawn()?

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::ffi::OsStr;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::{cmp, io};
 
 #[cfg(not(windows))]
@@ -21,8 +21,6 @@ use std::os::unix::process::CommandExt;
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
-#[cfg(windows)]
-use std::process::Stdio;
 #[cfg(windows)]
 use winapi::um::winbase::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
 
@@ -91,9 +89,14 @@ where
 {
     Command::new(program)
         .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .before_exec(|| unsafe {
-            #[allow(deprecated)]
-            libc::daemon(1, 0);
+            if ::libc::fork() != 0 {
+                ::libc::_exit(0);
+            }
+            ::libc::setsid();
             Ok(())
         })
         .spawn()?


### PR DESCRIPTION
This fixes the execution of subprocesses on macOS which could sometimes
prevent actions like `SpawnNewProcess` or custom commands from launching
their processes correctly.

This fixes #2259.