### PR TITLE
Call TIOCSWINSZ only on grid change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Subprocess spawning on macos
 - Unnecessary resize at startup
 - Text getting blurry after live-reloading shaders with padding active
-- Unnecessary update of process screens on every resize
+- Resize events are not send to the shell anymore if dimensions haven't changed
 
 ## Version 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Subprocess spawning on macos
 - Unnecessary resize at startup
 - Text getting blurry after live-reloading shaders with padding active
+- Unnecessary update of process screens on every resize
 
 ## Version 0.3.0
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -388,8 +388,8 @@ impl Display {
             let height = psize.height as f32;
             let cell_width = self.size_info.cell_width;
             let cell_height = self.size_info.cell_height;
-            let cols = self.size_info.cols().0;
-            let lines = self.size_info.lines().0;
+            let previous_cols = self.size_info.cols().0;
+            let previous_lines = self.size_info.lines().0;
 
             self.size_info.width = width;
             self.size_info.height = height;
@@ -415,7 +415,7 @@ impl Display {
                 pty_size.height -= pty_size.cell_height * message.text(&size).len() as f32;
             }
 
-            let grid_change = cols != size.cols().0 || lines != size.lines().0;
+            let grid_change = previous_cols != size.cols().0 || previous_lines != size.lines().0;
             if grid_change {
                 pty_resize_handle.on_resize(&pty_size);
             }

--- a/src/display.rs
+++ b/src/display.rs
@@ -388,8 +388,8 @@ impl Display {
             let height = psize.height as f32;
             let cell_width = self.size_info.cell_width;
             let cell_height = self.size_info.cell_height;
-            let previous_cols = self.size_info.cols().0;
-            let previous_lines = self.size_info.lines().0;
+            let previous_cols = self.size_info.cols();
+            let previous_lines = self.size_info.lines();
 
             self.size_info.width = width;
             self.size_info.height = height;
@@ -415,8 +415,7 @@ impl Display {
                 pty_size.height -= pty_size.cell_height * message.text(&size).len() as f32;
             }
 
-            let grid_change = previous_cols != size.cols().0 || previous_lines != size.lines().0;
-            if grid_change {
+            if previous_cols != size.cols() || previous_lines != size.lines()  {
                 pty_resize_handle.on_resize(&pty_size);
             }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -388,6 +388,8 @@ impl Display {
             let height = psize.height as f32;
             let cell_width = self.size_info.cell_width;
             let cell_height = self.size_info.cell_height;
+            let cols = self.size_info.cols().0;
+            let lines = self.size_info.lines().0;
 
             self.size_info.width = width;
             self.size_info.height = height;
@@ -412,7 +414,11 @@ impl Display {
             if let Some(message) = terminal.message_buffer_mut().message() {
                 pty_size.height -= pty_size.cell_height * message.text(&size).len() as f32;
             }
-            pty_resize_handle.on_resize(&pty_size);
+
+            let grid_change = cols != size.cols().0 || lines != size.lines().0;
+            if grid_change {
+                pty_resize_handle.on_resize(&pty_size);
+            }
 
             self.window.resize(psize);
             self.renderer.resize(psize, self.size_info.padding_x, self.size_info.padding_y);


### PR DESCRIPTION
Instead of calling TIOCSWINSZ for every pixel change it will now be called only on changes to the grid size. This should reduce screen refreshes.

This is my first pull-request for this project and first time really working with Rust. I'm open to improvements and hope that my code will be at least a bit useful.

This fixes #2177 