### PR TITLE
Fix duplicate resize events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reset scrolling region when the RIS escape sequence is received
 - Subprocess spawning on macos
+- Filter duplicate resize events
 
 ## Version 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reset scrolling region when the RIS escape sequence is received
 - Subprocess spawning on macos
 - Unnecessary resize at startup
+- Text getting blurry after live-reloading shaders with padding active
 
 ## Version 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reset scrolling region when the RIS escape sequence is received
 - Subprocess spawning on macos
-- Filter duplicate resize events
+- Unnecessary resize at startup
 
 ## Version 0.3.0
 

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -77,7 +77,7 @@ impl crate::Rasterize for RustTypeRasterizer {
             FontCollection::from_bytes(
                 system_fonts::get(&fp.build()).ok_or_else(|| Error::MissingFont(desc.clone()))?.0,
             )
-            .and_then(|fc| fc.into_font())
+            .and_then(FontCollection::into_font)
             .map_err(|_| Error::UnsupportedFont)?,
         );
         Ok(FontKey { token: (self.fonts.len() - 1) as u16 })

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -485,6 +485,10 @@ impl WindowConfig {
     pub fn start_maximized(&self) -> bool {
         self.start_maximized
     }
+
+    pub fn position(&self) -> Option<Delta<i32>> {
+        self.position
+    }
 }
 
 /// Top-level config type
@@ -1792,11 +1796,6 @@ impl Config {
     #[inline]
     pub fn dimensions(&self) -> Dimensions {
         self.dimensions.unwrap_or(self.window.dimensions)
-    }
-
-    #[inline]
-    pub fn position(&self) -> Option<Delta<i32>> {
-        self.window.position
     }
 
     /// Get window config

--- a/src/display.rs
+++ b/src/display.rs
@@ -227,7 +227,7 @@ impl Display {
             tx,
             rx,
             meter: Meter::new(),
-            font_size: font::Size::new(0.),
+            font_size: config.font().size(),
             size_info,
             last_message: None,
         })
@@ -320,6 +320,16 @@ impl Display {
         // Font size/DPI factor modification detected
         let font_changed =
             terminal.font_size != self.font_size || (dpr - self.size_info.dpr).abs() > f64::EPSILON;
+
+        // Skip resize if nothing changed
+        if let Some(new_size) = new_size {
+            if !font_changed
+                && new_size.width as f32 == self.size_info.width
+                && new_size.height as f32 == self.size_info.height
+            {
+                return;
+            }
+        }
 
         if font_changed || self.last_message != terminal.message_buffer_mut().message() {
             if new_size == None {

--- a/src/display.rs
+++ b/src/display.rs
@@ -176,11 +176,11 @@ impl Display {
         if let Some((width, height)) =
             Self::calculate_dimensions(config, options, dpr, cell_width, cell_height)
         {
-            if dimensions != Some((width, height)) {
+            if dimensions == Some((width, height)) {
+                info!("Estimated DPR correctly, skipping resize");
+            } else {
                 viewport_size = PhysicalSize::new(width, height);
                 window.set_inner_size(viewport_size.to_logical(dpr));
-            } else {
-                info!("Estimated DPR correctly, skipping resize");
             }
         } else if config.window().dynamic_padding() {
             // Make sure additional padding is spread evenly
@@ -358,8 +358,8 @@ impl Display {
         // Skip resize if nothing changed
         if let Some(new_size) = new_size {
             if !font_changed
-                && new_size.width as f32 == self.size_info.width
-                && new_size.height as f32 == self.size_info.height
+                && (new_size.width - f64::from(self.size_info.width)).abs() < f64::EPSILON
+                && (new_size.height - f64::from(self.size_info.height)).abs() < f64::EPSILON
             {
                 return;
             }

--- a/src/display.rs
+++ b/src/display.rs
@@ -180,6 +180,8 @@ impl Display {
                 f64::from(width) + 2. * padding_x,
                 f64::from(height) + 2. * padding_y,
             );
+
+            window.set_inner_size(viewport_size.to_logical(dpr));
         } else if config.window().dynamic_padding() {
             // Make sure additional padding is spread evenly
             let cw = f64::from(cell_width);
@@ -188,7 +190,6 @@ impl Display {
             padding_y = (padding_y + (viewport_size.height - 2. * padding_y) % ch / 2.).floor();
         }
 
-        window.set_inner_size(viewport_size.to_logical(dpr));
         renderer.resize(viewport_size, padding_x as f32, padding_y as f32);
 
         info!("Cell Size: ({} x {})", cell_width, cell_height);

--- a/src/tty/windows/conpty.rs
+++ b/src/tty/windows/conpty.rs
@@ -143,7 +143,7 @@ pub fn new<'a>(
 
     let mut startup_info_ex: STARTUPINFOEXW = Default::default();
 
-    let title = options.title.as_ref().map(|w| w.as_str()).unwrap_or("Alacritty");
+    let title = options.title.as_ref().map(String::as_str).unwrap_or("Alacritty");
     let title = U16CString::from_str(title).unwrap();
     startup_info_ex.StartupInfo.lpTitle = title.as_ptr() as LPWSTR;
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -150,7 +150,8 @@ impl Window {
         let title = options.title.as_ref().map_or(DEFAULT_NAME, |t| t);
         let class = options.class.as_ref().map_or(DEFAULT_NAME, |c| c);
         let window_builder = Window::get_platform_window(title, class, window_config);
-        let windowed_context = create_gl_window(window_builder.clone(), &event_loop, false, dimensions)
+        let windowed_context =
+            create_gl_window(window_builder.clone(), &event_loop, false, dimensions)
                 .or_else(|_| create_gl_window(window_builder, &event_loop, true, dimensions))?;
         let window = windowed_context.window();
         window.show();


### PR DESCRIPTION
If a resize event is identical to the current size, it is no longer
propagated but the resize is discarded immediately.

Fixes #1825.
Fixes #204.