### PR TITLE
Remove live shader reload feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,6 @@ dirs = "1.0.2"
 
 [features]
 default = []
-# Enabling this feature makes shaders automatically reload when changed
-live-shader-reload = []
-nightly = []
 bench = []
 
 [build-dependencies]

--- a/src/display.rs
+++ b/src/display.rs
@@ -156,7 +156,7 @@ impl Display {
             window.inner_size_pixels().expect("glutin returns window size").to_physical(dpr);
 
         // Create renderer
-        let mut renderer = QuadRenderer::new(viewport_size)?;
+        let mut renderer = QuadRenderer::new()?;
 
         let (glyph_cache, cell_width, cell_height) =
             Self::new_glyph_cache(dpr, &mut renderer, config)?;
@@ -189,6 +189,8 @@ impl Display {
         }
 
         window.set_inner_size(viewport_size.to_logical(dpr));
+
+        // Update the shader projection
         renderer.resize(viewport_size, padding_x as f32, padding_y as f32);
 
         info!("Cell Size: ({} x {})", cell_width, cell_height);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 //
 //! Alacritty - The GPU Enhanced Terminal
 #![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@
 //
 //! Alacritty - The GPU Enhanced Terminal
 #![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 // With the default subsystem, 'console', windows creates an additional console
 // window for the program.


### PR DESCRIPTION
This removes the live-shader-reload feature to make the renderer
significantly more concise and maintainable.

As far as I'm aware, this feature was never really used by anyone since
there isn't much of an advantage to recompiling Alacritty yourself just
to make live shader reload work.

This feature has also been broken for a long time, since the projection
is updated after the reload without considering the padding. Editing
with standard editors like vim also deletes the file and replaces it,
making it impossible to use them for live shader reload.

Closes #1523.

This is mostly a proposal at this point, since there is no *need* to remove
live shader reload at this point. However I currently do not see much
advantage in keeping this code around.

If anyone is actually using Alacritty with live shader reload enabled,
please let me know. I believe @towc is the only person to ever create
a live shader reload related issue. Do you still care about this?