### PR TITLE
Fix cursor dimensions with font offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resize events are not send to the shell anymore if dimensions haven't changed
 - Minor performance issues with underline and strikeout checks
 - Rare bug which would extend underline and strikeout beyond the end of line
+- Cursors not spanning two lines when over double-width characters
+- Incorrect cursor dimensions if the font offset isn't `0`
 
 ## Version 0.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,6 @@ dependencies = [
 name = "alacritty"
 version = "0.3.0"
 dependencies = [
- "arraydeque 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -128,11 +127,6 @@ dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "arraydeque"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "arrayvec"
@@ -2863,7 +2857,6 @@ dependencies = [
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 "checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
-"checksum arraydeque 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0ffd3d69bd89910509a5d31d1f1353f38ccffdd116dd0099bbd6627f7bd8ad8"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ log = "0.4"
 clap = "2"
 fnv = "1"
 unicode-width = "0.1"
-arraydeque = "0.4"
 glutin = { version = "0.21.0-rc2", features = ["icon_loading"] }
 env_logger = "0.6.0"
 base64 = "0.10.0"

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -213,6 +213,7 @@ impl ::std::ops::Add for Size {
     }
 }
 
+#[derive(Clone)]
 pub struct RasterizedGlyph {
     pub c: char,
     pub width: i32,
@@ -314,6 +315,7 @@ impl fmt::Debug for RasterizedGlyph {
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct Metrics {
     pub average_advance: f64,
     pub line_height: f64,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,0 +1,98 @@
+// Copyright 2016 Joe Wilm, The Alacritty Project Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helpers for creating different cursor glyphs from font metrics
+
+use std::cmp;
+
+use font::{Metrics, RasterizedGlyph};
+
+use crate::ansi::CursorStyle;
+
+/// Width/Height of the cursor relative to the font width
+pub const CURSOR_WIDTH_PERCENTAGE: i32 = 15;
+
+pub fn get_cursor_glyph(
+    cursor: CursorStyle,
+    metrics: Metrics,
+    offset_x: i8,
+    offset_y: i8,
+    is_wide: bool,
+) -> RasterizedGlyph {
+    // Calculate the cell metrics
+    let height = metrics.line_height as i32 + i32::from(offset_y);
+    let mut width = metrics.average_advance as i32 + i32::from(offset_x);
+    let line_width = cmp::max(width * CURSOR_WIDTH_PERCENTAGE / 100, 1);
+
+    // Double the cursor width if it's above a double-width glyph
+    if is_wide {
+        width *= 2;
+    }
+
+    match cursor {
+        CursorStyle::HollowBlock => get_box_cursor_glyph(height, width, line_width),
+        CursorStyle::Underline => get_underline_cursor_glyph(width, line_width),
+        CursorStyle::Beam => get_beam_cursor_glyph(height, line_width),
+        CursorStyle::Block => get_block_cursor_glyph(height, width),
+    }
+}
+
+// Returns a custom underline cursor character
+pub fn get_underline_cursor_glyph(width: i32, line_width: i32) -> RasterizedGlyph {
+    // Create a new rectangle, the height is relative to the font width
+    let buf = vec![255u8; (width * line_width * 3) as usize];
+
+    // Create a custom glyph with the rectangle data attached to it
+    RasterizedGlyph { c: ' ', top: line_width, left: 0, height: line_width, width, buf }
+}
+
+// Returns a custom beam cursor character
+pub fn get_beam_cursor_glyph(height: i32, line_width: i32) -> RasterizedGlyph {
+    // Create a new rectangle that is at least one pixel wide
+    let buf = vec![255u8; (line_width * height * 3) as usize];
+
+    // Create a custom glyph with the rectangle data attached to it
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width: line_width, buf }
+}
+
+// Returns a custom box cursor character
+pub fn get_box_cursor_glyph(height: i32, width: i32, line_width: i32) -> RasterizedGlyph {
+    // Create a new box outline rectangle
+    let mut buf = Vec::with_capacity((width * height * 3) as usize);
+    for y in 0..height {
+        for x in 0..width {
+            if y < line_width
+                || y >= height - line_width
+                || x < line_width
+                || x >= width - line_width
+            {
+                buf.append(&mut vec![255u8; 3]);
+            } else {
+                buf.append(&mut vec![0u8; 3]);
+            }
+        }
+    }
+
+    // Create a custom glyph with the rectangle data attached to it
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, buf }
+}
+
+// Returns a custom block cursor character
+pub fn get_block_cursor_glyph(height: i32, width: i32) -> RasterizedGlyph {
+    // Create a completely filled glyph
+    let buf = vec![255u8; (width * height * 3) as usize];
+
+    // Create a custom glyph with the rectangle data attached to it
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, buf }
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -435,10 +435,11 @@ impl Display {
         let size_info = *terminal.size_info();
         let visual_bell_intensity = terminal.visual_bell.intensity();
         let background_color = terminal.background_color();
+        let metrics = self.glyph_cache.font_metrics();
 
         let window_focused = self.window.is_focused;
         let grid_cells: Vec<RenderableCell> =
-            terminal.renderable_cells(config, window_focused).collect();
+            terminal.renderable_cells(config, window_focused, metrics).collect();
 
         // Get message from terminal to ignore modifications after lock is dropped
         let message_buffer = terminal.message_buffer_mut().message();
@@ -479,7 +480,6 @@ impl Display {
 
         {
             let glyph_cache = &mut self.glyph_cache;
-            let metrics = glyph_cache.font_metrics();
             let mut rects = Rects::new(&metrics, &size_info);
 
             // Draw grid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod macros;
 pub mod ansi;
 pub mod cli;
 pub mod config;
+mod cursor;
 pub mod display;
 pub mod event;
 pub mod event_loop;

--- a/src/renderer/rects.rs
+++ b/src/renderer/rects.rs
@@ -96,7 +96,7 @@ impl<'a> Rects<'a> {
 
                     // Start a new line if the flag is present
                     if cell.flags.contains(line.flag) {
-                        *start = *cell;
+                        *start = cell.clone();
                         *end = cell.into();
                     } else {
                         line.range = None;
@@ -105,7 +105,7 @@ impl<'a> Rects<'a> {
                 // Check for new start of line
                 None => {
                     if cell.flags.contains(line.flag) {
-                        line.range = Some((*cell, cell.into()));
+                        line.range = Some((cell.clone(), cell.into()));
                     }
                 },
             };


### PR DESCRIPTION
Previously cursor dimensions were not calculated correctly when a font
offset was specified, since the font offset was completely ignored.

This has been fixed by moving all the cursor logic from the font into
the Alacritty crate, applying the config's offsets before rasterizing
the cursors.

This has also fixed an issue with some cursors not being rendered as
double-width correctly when over double-width glyphs.

This fixes #2209.