### PR TITLE
Fix cursor colors

### DIFF
--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -449,35 +449,6 @@ impl Font {
         _size: f64,
         use_thin_strokes: bool,
     ) -> Result<RasterizedGlyph, Error> {
-        // Render custom symbols for underline and beam cursor
-        match character {
-            super::UNDERLINE_CURSOR_CHAR => {
-                // Get the bottom of the bounding box
-                let descent = -(self.ct_font.descent() as i32);
-                // Get the width of the cell
-                let width = self.glyph_advance('0') as i32;
-                // Return the new custom glyph
-                return super::get_underline_cursor_glyph(descent, width);
-            },
-            super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
-                // Get the top of the bounding box
-                let metrics = self.metrics();
-                let height = metrics.line_height;
-                let ascent = (height - self.ct_font.descent()).ceil();
-
-                // Get the width of the cell
-                let width = self.glyph_advance('0') as i32;
-
-                // Return the new custom glyph
-                if character == super::BEAM_CURSOR_CHAR {
-                    return super::get_beam_cursor_glyph(ascent as i32, height as i32, width);
-                } else {
-                    return super::get_box_cursor_glyph(ascent as i32, height as i32, width);
-                }
-            },
-            _ => (),
-        }
-
         let glyph_index =
             self.glyph_index(character).ok_or_else(|| Error::MissingGlyph(character))?;
 

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -45,17 +45,14 @@ impl fmt::Debug for Face {
             .field("ft_face", &self.ft_face)
             .field("key", &self.key)
             .field("load_flags", &self.load_flags)
-            .field(
-                "render_mode",
-                &match self.render_mode {
-                    freetype::RenderMode::Normal => "Normal",
-                    freetype::RenderMode::Light => "Light",
-                    freetype::RenderMode::Mono => "Mono",
-                    freetype::RenderMode::Lcd => "Lcd",
-                    freetype::RenderMode::LcdV => "LcdV",
-                    freetype::RenderMode::Max => "Max",
-                },
-            )
+            .field("render_mode", &match self.render_mode {
+                freetype::RenderMode::Normal => "Normal",
+                freetype::RenderMode::Light => "Light",
+                freetype::RenderMode::Mono => "Mono",
+                freetype::RenderMode::Lcd => "Lcd",
+                freetype::RenderMode::LcdV => "LcdV",
+                freetype::RenderMode::Max => "Max",
+            })
             .field("lcd_filter", &self.lcd_filter)
             .finish()
     }

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -313,47 +313,6 @@ impl FreeTypeRasterizer {
     }
 
     fn get_rendered_glyph(&mut self, glyph_key: GlyphKey) -> Result<RasterizedGlyph, Error> {
-        // Render a custom symbol for the underline and beam cursor
-        match glyph_key.c {
-            super::UNDERLINE_CURSOR_CHAR => {
-                // Get the primary face metrics
-                // This always loads the default face
-                let full = self.full_metrics(glyph_key.font_key)?;
-
-                // Get the bottom of the bounding box
-                let descent = (full.size_metrics.descender / 64) as i32;
-
-                // Get the width of the cell
-                let width = full.cell_width as i32;
-
-                // Return the new custom glyph
-                return super::get_underline_cursor_glyph(descent, width);
-            },
-            super::BEAM_CURSOR_CHAR | super::BOX_CURSOR_CHAR => {
-                // Get the primary face metrics
-                // This always loads the default face
-                let full = self.full_metrics(glyph_key.font_key)?;
-
-                // Get the height of the cell
-                let height = (full.size_metrics.height / 64) as i32;
-
-                // Get the top of the bounding box
-                let descent = (full.size_metrics.descender / 64) as i32;
-                let ascent = height + descent;
-
-                // Get the width of the cell
-                let width = full.cell_width as i32;
-
-                // Return the new custom glyph
-                return if glyph_key.c == super::BEAM_CURSOR_CHAR {
-                    super::get_beam_cursor_glyph(ascent, height, width)
-                } else {
-                    super::get_box_cursor_glyph(ascent, height, width)
-                };
-            },
-            _ => (),
-        }
-
         // Render a normal character if it's not a cursor
         let font_key = self.face_for_glyph(glyph_key, false)?;
         let face = &self.faces[&font_key];

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -45,9 +45,9 @@ extern crate foreign_types;
 #[cfg_attr(not(windows), macro_use)]
 extern crate log;
 
+use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::fmt;
 
 // If target isn't macos or windows, reexport everything from ft
 #[cfg(not(any(target_os = "macos", windows)))]

--- a/font/src/rusttype/mod.rs
+++ b/font/src/rusttype/mod.rs
@@ -84,35 +84,6 @@ impl crate::Rasterize for RustTypeRasterizer {
     }
 
     fn get_glyph(&mut self, glyph_key: GlyphKey) -> Result<RasterizedGlyph, Error> {
-        match glyph_key.c {
-            super::UNDERLINE_CURSOR_CHAR => {
-                let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
-                return super::get_underline_cursor_glyph(
-                    metrics.descent as i32,
-                    metrics.average_advance as i32,
-                );
-            },
-            super::BEAM_CURSOR_CHAR => {
-                let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
-
-                return super::get_beam_cursor_glyph(
-                    (metrics.line_height + f64::from(metrics.descent)).round() as i32,
-                    metrics.line_height.round() as i32,
-                    metrics.average_advance.round() as i32,
-                );
-            },
-            super::BOX_CURSOR_CHAR => {
-                let metrics = self.metrics(glyph_key.font_key, glyph_key.size)?;
-
-                return super::get_box_cursor_glyph(
-                    (metrics.line_height + f64::from(metrics.descent)).round() as i32,
-                    metrics.line_height.round() as i32,
-                    metrics.average_advance.round() as i32,
-                );
-            },
-            _ => (),
-        }
-
         let scaled_glyph = self.fonts[glyph_key.font_key.token as usize]
             .glyph(glyph_key.c)
             .scaled(Scale::uniform(glyph_key.size.as_f32_pts() * self.dpi_ratio * 96. / 72.));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,7 +21,7 @@ use serde::de::{MapAccess, Unexpected, Visitor};
 use serde::{self, de, Deserialize};
 use serde_yaml;
 
-use crate::ansi::{Color, CursorStyle, NamedColor};
+use crate::ansi::CursorStyle;
 use crate::cli::Options;
 use crate::index::{Column, Line};
 use crate::input::{Action, Binding, KeyBinding, MouseBinding};
@@ -1877,14 +1877,14 @@ impl Config {
 
     /// Cursor foreground color
     #[inline]
-    pub fn cursor_text_color(&self) -> Option<Color> {
-        self.colors.cursor.text.map(|_| Color::Named(NamedColor::CursorText))
+    pub fn cursor_text_color(&self) -> Option<Rgb> {
+        self.colors.cursor.text
     }
 
     /// Cursor background color
     #[inline]
-    pub fn cursor_cursor_color(&self) -> Option<Color> {
-        self.colors.cursor.cursor.map(|_| Color::Named(NamedColor::Cursor))
+    pub fn cursor_cursor_color(&self) -> Option<Rgb> {
+        self.colors.cursor.cursor
     }
 
     /// Enable experimental conpty backend (Windows only)

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -385,6 +385,10 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
 
                     renderable_cell.inner = RenderableCellContent::Raw(cursor_cell);
 
+                    if let Some(color) = self.config.cursor_cursor_color() {
+                        renderable_cell.fg = color;
+                    }
+
                     return Some(renderable_cell);
                 } else {
                     let mut cell =
@@ -392,6 +396,10 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
 
                     if self.cursor_style == CursorStyle::Block {
                         std::mem::swap(&mut cell.bg, &mut cell.fg);
+
+                        if let Some(color) = self.config.cursor_text_color() {
+                            cell.fg = color;
+                        }
                     }
 
                     return Some(cell);


### PR DESCRIPTION
This fixes a recent regression in
cfc20d4f34dca535654cc32df18e785296af4cc5 which broke cursor colors when
specified in the `colors.cursor` field in the config.

It also removes a lot of unneeded code from the font crate related to
the cursor rendering.