### PR TITLE
Fix selection copying on Windows

### DIFF
--- a/copypasta/src/windows.rs
+++ b/copypasta/src/windows.rs
@@ -58,7 +58,7 @@ impl Store for Clipboard {
     where
         S: Into<String>,
     {
-        // No such thing on macOS
+        // No such thing on Windows
         Ok(())
     }
 }

--- a/copypasta/src/windows.rs
+++ b/copypasta/src/windows.rs
@@ -40,11 +40,6 @@ impl Load for Clipboard {
         let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
         ctx.get_contents().map_err(Error::Clipboard)
     }
-
-    fn load_selection(&self) -> Result<String, Self::Err> {
-        let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
-        ctx.get_contents().map_err(Error::Clipboard)
-    }
 }
 
 impl Store for Clipboard {
@@ -63,6 +58,7 @@ impl Store for Clipboard {
     where
         S: Into<String>,
     {
-        self.0.set_contents(contents.into()).map_err(Error::Clipboard)
+        // No such thing on macOS
+        Ok(())
     }
 }


### PR DESCRIPTION
The `copypasta` crate incorrectly mapped the secondary clipboard on
Windows to the primary clipboard, leading to the primary clipboard
getting overwritten whenever the selection clipboard was updated.

The new Windows clipboard mimics the macOS clipboard, which also does
not have a selection clipboard.

This fixes #2050.