### PR TITLE
Fix hidden cursor inverting cell colors

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -356,6 +356,9 @@ pub enum CursorStyle {
 
     /// Cursor is a box like `☐`
     HollowBlock,
+
+    /// Invisible cursor
+    Hidden,
 }
 
 impl Default for CursorStyle {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -45,6 +45,7 @@ pub fn get_cursor_glyph(
         CursorStyle::Underline => get_underline_cursor_glyph(width, line_width),
         CursorStyle::Beam => get_beam_cursor_glyph(height, line_width),
         CursorStyle::Block => get_block_cursor_glyph(height, width),
+        CursorStyle::Hidden => RasterizedGlyph::default(),
     }
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -175,7 +175,7 @@ impl<'a> RenderableCellsIter<'a> {
         term: &'b Term,
         config: &'b Config,
         selection: Option<Locations>,
-        cursor_style: CursorStyle,
+        mut cursor_style: CursorStyle,
         metrics: font::Metrics,
     ) -> RenderableCellsIter<'b> {
         let grid = &term.grid;
@@ -236,6 +236,8 @@ impl<'a> RenderableCellsIter<'a> {
                 && (cursor.col + 1) < grid.num_cols();
             Some(cursor::get_cursor_glyph(cursor_style, metrics, offset_x, offset_y, is_wide))
         } else {
+            // Use hidden cursor so text will not get inverted
+            cursor_style = CursorStyle::Hidden;
             None
         };
 


### PR DESCRIPTION
Since the block cursor inverts the background and foreground colors of a
cell, the hidden cursor has done the same thing without rendering a
cursor since it was using the block cursor shape.

A new `Hidden` cursor style has been introduced for explicitly handling
the invisible cursor differently.

This fixes #2342.