### PR TITLE
Show same fg/bg text when inversed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added ToggleFullscreen action
-- On macOS, there's a ToggleSimpleFullscreen action which allows switching to 
+- On macOS, there's a ToggleSimpleFullscreen action which allows switching to
     fullscreen without occupying another space
 - A new window option `startup_mode` which controls how the window is created
 
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - On Windows, Alacritty will now use the native DirectWrite font API
 - The `start_maximized` window option is now `startup_mode: Maximized`
+- Cells with identical foreground and background will now show their text upon selection/inversion
 
 ### Fixed
 


### PR DESCRIPTION
If a cell has a matching foreground and background and is inversed
through the escape or selection, it will now fall back to the default
background on top of the default foreground.

This makes it possible to show invisible text like this by selecting it.

Hidden text is unaffected by this change.

This fixes #2315.