### PR TITLE
Update wayland comment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,16 +212,12 @@ Alacritty discussion can be found in `#alacritty` on freenode.
 
 ## Wayland
 
-Wayland support is available, but not everything works as expected. Many people
-have found a better experience using XWayland which can be achieved by
-launching Alacritty with the `WAYLAND_DISPLAY` environment variable cleared:
+Wayland is used by default on systems that support it. Using XWayland may
+circumvent wayland specific issues and can be enabled through:
 
 ```sh
-env WAYLAND_DISPLAY="" alacritty
+env WINIT_UNIX_BACKEND=x11 alacritty
 ```
-
-If you're interested in seeing our Wayland support improve, please head over to
-the [Wayland meta issue] on the _winit_ project to see how you may contribute.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Alacritty discussion can be found in `#alacritty` on freenode.
 ## Wayland
 
 Wayland is used by default on systems that support it. Using XWayland may
-circumvent wayland specific issues and can be enabled through:
+circumvent Wayland specific issues and can be enabled through:
 
 ```sh
 env WINIT_UNIX_BACKEND=x11 alacritty


### PR DESCRIPTION
Although wayland support still has some issues I believe that functionality has improved a lot since this comment in the README was written, and with more support on the way such as [native wayland clipboard support](https://github.com/jwilm/alacritty/pull/2207). I've been using alacritty on the wayland backend for a few months now and no longer experienced any notable issues.

`env WINIT_UNIX_BACKEND=x11 alacritty` seems more correct as it allows winit to decide to use x11 instead of just disabling access to wayland.

The winit wayland meta issue seems to be stagnant and not be tracking improvements made to wayland support.