### PR TITLE
Fix cursor disappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - PTY size not getting updated when message bar is shown
+- Text Cursor disappearing
 
 ## Version 0.3.2
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -343,7 +343,7 @@ pub trait Handler {
 }
 
 /// Describes shape of cursor
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Deserialize)]
 pub enum CursorStyle {
     /// Cursor is a block like `▒`
     Block,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -26,6 +26,7 @@ use font::{self, FontDesc, FontKey, GlyphKey, Rasterize, RasterizedGlyph, Raster
 use glutin::dpi::PhysicalSize;
 use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
 
+use crate::ansi::CursorStyle;
 use crate::config::{self, Config, Delta};
 use crate::gl;
 use crate::gl::types::*;
@@ -154,6 +155,9 @@ pub struct GlyphCache {
     /// Cache of buffered glyphs
     cache: HashMap<GlyphKey, Glyph, BuildHasherDefault<FnvHasher>>,
 
+    /// Cache of buffered cursor glyphs
+    cursor_cache: HashMap<CursorStyle, Glyph, BuildHasherDefault<FnvHasher>>,
+
     /// Rasterizer for loading new glyphs
     rasterizer: Rasterizer,
 
@@ -195,6 +199,7 @@ impl GlyphCache {
 
         let mut cache = GlyphCache {
             cache: HashMap::default(),
+            cursor_cache: HashMap::default(),
             rasterizer,
             font_size: font.size(),
             font_key: regular,
@@ -302,6 +307,7 @@ impl GlyphCache {
         // Clear currently cached data in both GL and the registry
         loader.clear();
         self.cache = HashMap::default();
+        self.cursor_cache = HashMap::default();
 
         // Update dpi scaling
         self.rasterizer.update_dpr(dpr as f32);
@@ -984,9 +990,12 @@ impl<'a> RenderApi<'a> {
 
     pub fn render_cell(&mut self, cell: RenderableCell, glyph_cache: &mut GlyphCache) {
         let chars = match cell.inner {
-            RenderableCellContent::Raw(ref raw) => {
+            RenderableCellContent::Cursor((cursor_style, ref raw)) => {
                 // Raw cell pixel buffers like cursors don't need to go through font lookup
-                let glyph = self.load_glyph(raw);
+                let glyph = glyph_cache
+                    .cursor_cache
+                    .entry(cursor_style)
+                    .or_insert_with(|| self.load_glyph(raw));
                 self.add_render_item(&cell, &glyph);
                 return;
             },

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -259,7 +259,7 @@ impl<'a> RenderableCellsIter<'a> {
 #[derive(Clone, Debug)]
 pub enum RenderableCellContent {
     Chars([char; cell::MAX_ZEROWIDTH_CHARS + 1]),
-    Raw(RasterizedGlyph),
+    Cursor((CursorStyle, RasterizedGlyph)),
 }
 
 #[derive(Clone, Debug)]
@@ -385,7 +385,8 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                     let mut renderable_cell =
                         RenderableCell::new(self.config, self.colors, cell, false);
 
-                    renderable_cell.inner = RenderableCellContent::Raw(cursor_cell);
+                    renderable_cell.inner =
+                        RenderableCellContent::Cursor((self.cursor_style, cursor_cell));
 
                     if let Some(color) = self.config.cursor_cursor_color() {
                         renderable_cell.fg = color;


### PR DESCRIPTION
The cfc20d4f34dca535654cc32df18e785296af4cc5 commit introduced a
regression which would cause the cursor to disappear after the glyph
cache has been filled.

Since the cursor was not cached on the glyph cache, the cursor would
quickly fill up the OpenGL texture with lots of cursor textures and then
things would break after the atlas was filled completely.

This adds a separate cursor cache which is keyed by the cursor style
that will persist the texture without flooding the atlas.

This fixes #2355.
This fixes #2353.