### PR TITLE
Fix double-width characters only highlighting halfway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- URLs with double-width characters not correctly highlighting
 - PTY size not getting updated when message bar is shown
 - Text Cursor disappearing
 - Incorrect positioning of zero-width characters over double-width characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+
+
 # Changelog
 All notable changes to this project will be documented in this file.
 
@@ -21,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- URLs with double-width characters not correctly highlighting
+- Double-width characters in URLS only being highlit on the left half
 - PTY size not getting updated when message bar is shown
 - Text Cursor disappearing
 - Incorrect positioning of zero-width characters over double-width characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-
-
-
 # Changelog
 All notable changes to this project will be documented in this file.
 
@@ -24,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Double-width characters in URLS only being highlit on the left half
+- Double-width characters in URLs only being highlit on the left half
 - PTY size not getting updated when message bar is shown
 - Text Cursor disappearing
 - Incorrect positioning of zero-width characters over double-width characters

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -418,15 +418,12 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                 let selected =
                     self.selection.as_ref().map(|range| range.contains_(index)).unwrap_or(false);
 
-                // Skip empty cells
-                if cell.is_empty() && !selected {
-                    continue;
-                }
-
                 // Underline URL highlights
                 if self.url_highlight.as_ref().map(|range| range.contains_(index)).unwrap_or(false)
                 {
                     cell.inner.flags.insert(Flags::UNDERLINE);
+                } else if cell.is_empty() && !selected {
+                    continue;
                 }
 
                 return Some(RenderableCell::new(self.config, self.colors, cell, selected));

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -422,11 +422,10 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                 if self.url_highlight.as_ref().map(|range| range.contains_(index)).unwrap_or(false)
                 {
                     cell.inner.flags.insert(Flags::UNDERLINE);
-                } else if cell.is_empty() && !selected {
-                    continue;
                 }
-
-                return Some(RenderableCell::new(self.config, self.colors, cell, selected));
+                if !cell.is_empty() || selected {
+                    return Some(RenderableCell::new(self.config, self.colors, cell, selected));
+                }
             }
         }
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -423,6 +423,7 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                 {
                     cell.inner.flags.insert(Flags::UNDERLINE);
                 }
+
                 if !cell.is_empty() || selected {
                     return Some(RenderableCell::new(self.config, self.colors, cell, selected));
                 }


### PR DESCRIPTION
Currently, `RenderableCellsIter` skips over the `WIDE_CHAR_SPACER`, as it's empty, and doesn't underline it, resulting in only the left half of the character being underlined. This PR makes it so that `RenderableCellsIter` always underlines every cell in `url_highlight`, even if it's empty.