### PR TITLE
Add config option to always highlight URLs on mouseover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On macOS, there's a ToggleSimpleFullscreen action which allows switching to
     fullscreen without occupying another space
 - A new window option `startup_mode` which controls how the window is created
+- Added config option to always highlight URLs on mouseover
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -326,6 +326,10 @@ mouse:
     #  program: xdg-open
     #  args: []
 
+    # If this is `true`, the URLs will be highlighted on mouseover regardless
+    # of pressed modifiers
+    always_highlight_on_mouseover: false
+
     # URL modifiers
     #
     # These are the modifiers that need to be held down for opening URLs when clicking

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -122,6 +122,10 @@ pub struct Url {
     #[serde(deserialize_with = "deserialize_launcher")]
     pub launcher: Option<CommandWrapper>,
 
+    // When the links will be highlighted
+    #[serde(deserialize_with = "failure_default")]
+    pub always_highlight_on_mouseover: bool,
+
     // Modifier used to open links
     #[serde(deserialize_with = "deserialize_modifiers")]
     pub modifiers: ModifiersState,
@@ -167,6 +171,7 @@ impl Default for Url {
             launcher: Some(CommandWrapper::Just(String::from("open"))),
             #[cfg(windows)]
             launcher: Some(CommandWrapper::Just(String::from("explorer"))),
+            always_highlight_on_mouseover: Default::default(),
             modifiers: Default::default(),
         }
     }

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -462,7 +462,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG | TermMode::MOUSE_REPORT_CLICK;
 
         // Only show URLs as launchable when all required modifiers are pressed
-        let url = if self.mouse_config.url.modifiers.relaxed_eq(modifiers)
+        let url = if (self.mouse_config.url.modifiers.relaxed_eq(modifiers)
+            || self.mouse_config.url.always_highlight_on_mouseover)
             && (!self.ctx.terminal().mode().intersects(mouse_mode) || modifiers.shift)
             && self.mouse_config.url.launcher.is_some()
         {


### PR DESCRIPTION
In my daily use of Alacritty I've started noticing that I always forget that URLs are clickable, since they are not highlighted unless you press modifier key. So this PR makes them to be highlighted by default, like in other terminals ( e.g. terminator  ). As alternative, config option could be added to control such behavior.