### PR TITLE
Fix selection of double-width characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Text Cursor disappearing
 - Incorrect positioning of zero-width characters over double-width characters
 - Mouse mode generating events when the cell has not changed
+- Selections not automatically expanding across double-width characters
 
 ## Version 0.3.2
 

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -22,7 +22,8 @@ use std::cmp::{max, min};
 use std::ops::Range;
 
 use crate::index::{Column, Point, Side};
-use crate::term::Search;
+use crate::term::cell::Flags;
+use crate::term::{Search, Term};
 
 /// Describes a region of a 2-dimensional area
 ///
@@ -129,19 +130,35 @@ impl Selection {
         }
     }
 
-    pub fn to_span<G>(&self, grid: &G, alt_screen: bool) -> Option<Span>
-    where
-        G: Search + Dimensions,
-    {
-        match *self {
-            Selection::Simple { ref region } => Selection::span_simple(grid, region, alt_screen),
+    pub fn to_span(&self, term: &Term, alt_screen: bool) -> Option<Span> {
+        let span = match *self {
+            Selection::Simple { ref region } => Selection::span_simple(term, region, alt_screen),
             Selection::Semantic { ref region } => {
-                Selection::span_semantic(grid, region, alt_screen)
+                Selection::span_semantic(term, region, alt_screen)
             },
             Selection::Lines { ref region, initial_line } => {
-                Selection::span_lines(grid, region, initial_line, alt_screen)
+                Selection::span_lines(term, region, initial_line, alt_screen)
             },
-        }
+        };
+
+        // Expand selection across double-width cells
+        span.map(|mut span| {
+            let grid = term.grid();
+
+            if span.end.col < grid.num_cols()
+                && grid[span.end.line][span.end.col].flags.contains(Flags::WIDE_CHAR_SPACER)
+            {
+                span.end.col = Column(span.end.col.saturating_sub(1));
+            }
+
+            if span.start.col.0 < grid.num_cols().saturating_sub(1)
+                && grid[span.start.line][span.start.col].flags.contains(Flags::WIDE_CHAR)
+            {
+                span.start.col += 1;
+            }
+
+            span
+        })
     }
 
     pub fn is_empty(&self) -> bool {
@@ -161,27 +178,27 @@ impl Selection {
         let lines = grid.dimensions().line.0 as isize;
 
         // Normalize ordering of selected cells
-        let (mut front, mut tail) = if region.start < region.end {
+        let (mut start, mut end) = if region.start < region.end {
             (region.start, region.end)
         } else {
             (region.end, region.start)
         };
 
         if alt_screen {
-            Selection::alt_screen_clamp(&mut front, &mut tail, lines, cols)?;
+            Selection::alt_screen_clamp(&mut start, &mut end, lines, cols)?;
         }
 
-        let (mut start, mut end) = if front < tail && front.line == tail.line {
-            (grid.semantic_search_left(front.into()), grid.semantic_search_right(tail.into()))
+        let (mut start, mut end) = if start < end && start.line == end.line {
+            (grid.semantic_search_left(start.into()), grid.semantic_search_right(end.into()))
         } else {
-            (grid.semantic_search_right(front.into()), grid.semantic_search_left(tail.into()))
+            (grid.semantic_search_right(start.into()), grid.semantic_search_left(end.into()))
         };
 
         if start > end {
             ::std::mem::swap(&mut start, &mut end);
         }
 
-        Some(Span { cols, front: start, tail: end, ty: SpanType::Inclusive })
+        Some(Span { start, end })
     }
 
     fn span_lines<G>(
@@ -216,7 +233,7 @@ impl Selection {
             Selection::alt_screen_clamp(&mut start, &mut end, lines, cols)?;
         }
 
-        Some(Span { cols, front: start.into(), tail: end.into(), ty: SpanType::Inclusive })
+        Some(Span { start: start.into(), end: end.into() })
     }
 
     fn span_simple<G>(grid: &G, region: &Range<Anchor>, alt_screen: bool) -> Option<Span>
@@ -230,8 +247,8 @@ impl Selection {
         let cols = grid.dimensions().col;
         let lines = grid.dimensions().line.0 as isize;
 
-        // Make sure front is always the "bottom" and tail is always the "top"
-        let (mut front, mut tail, front_side, tail_side) =
+        // Make sure start is always the "bottom" and end is always the "top"
+        let (mut start, mut end, start_side, end_side) =
             if start.line > end.line || start.line == end.line && start.col <= end.col {
                 // Selected upward; start/end are swapped
                 (end, start, end_side, start_side)
@@ -241,137 +258,79 @@ impl Selection {
             };
 
         // No selection for single cell with identical sides or two cell with right+left sides
-        if (front == tail && front_side == tail_side)
-            || (tail_side == Side::Right
-                && front_side == Side::Left
-                && front.line == tail.line
-                && front.col == tail.col + 1)
+        if (start == end && start_side == end_side)
+            || (end_side == Side::Right
+                && start_side == Side::Left
+                && start.line == end.line
+                && start.col == end.col + 1)
         {
             return None;
         }
 
         // Remove last cell if selection ends to the left of a cell
-        if front_side == Side::Left && start != end {
+        if start_side == Side::Left && start != end {
             // Special case when selection starts to left of first cell
-            if front.col == Column(0) {
-                front.col = cols - 1;
-                front.line += 1;
+            if start.col == Column(0) {
+                start.col = cols - 1;
+                start.line += 1;
             } else {
-                front.col -= 1;
+                start.col -= 1;
             }
         }
 
         // Remove first cell if selection starts at the right of a cell
-        if tail_side == Side::Right && front != tail {
-            tail.col += 1;
+        if end_side == Side::Right && start != end {
+            end.col += 1;
         }
 
         if alt_screen {
-            Selection::alt_screen_clamp(&mut front, &mut tail, lines, cols)?;
+            Selection::alt_screen_clamp(&mut start, &mut end, lines, cols)?;
         }
 
         // Return the selection with all cells inclusive
-        Some(Span { cols, front: front.into(), tail: tail.into(), ty: SpanType::Inclusive })
+        Some(Span { start: start.into(), end: end.into() })
     }
 
     // Clamp selection in the alternate screen to the visible region
     fn alt_screen_clamp(
-        front: &mut Point<isize>,
-        tail: &mut Point<isize>,
+        start: &mut Point<isize>,
+        end: &mut Point<isize>,
         lines: isize,
         cols: Column,
     ) -> Option<()> {
-        if tail.line >= lines {
+        if end.line >= lines {
             // Don't show selection above visible region
-            if front.line >= lines {
+            if start.line >= lines {
                 return None;
             }
 
             // Clamp selection above viewport to visible region
-            tail.line = lines - 1;
-            tail.col = Column(0);
+            end.line = lines - 1;
+            end.col = Column(0);
         }
 
-        if front.line < 0 {
+        if start.line < 0 {
             // Don't show selection below visible region
-            if tail.line < 0 {
+            if end.line < 0 {
                 return None;
             }
 
             // Clamp selection below viewport to visible region
-            front.line = 0;
-            front.col = cols - 1;
+            start.line = 0;
+            start.col = cols - 1;
         }
 
         Some(())
     }
 }
 
-/// How to interpret the locations of a Span.
-#[derive(Debug, Eq, PartialEq)]
-pub enum SpanType {
-    /// Includes the beginning and end locations
-    Inclusive,
-
-    /// Exclude both beginning and end
-    Exclusive,
-
-    /// Excludes last cell of selection
-    ExcludeTail,
-
-    /// Excludes first cell of selection
-    ExcludeFront,
-}
-
 /// Represents a span of selected cells
 #[derive(Debug, Eq, PartialEq)]
 pub struct Span {
-    front: Point<usize>,
-    tail: Point<usize>,
-    cols: Column,
-
-    /// The type says whether ends are included or not.
-    ty: SpanType,
-}
-
-#[derive(Debug)]
-pub struct Locations {
     /// Start point from bottom of buffer
     pub start: Point<usize>,
     /// End point towards top of buffer
     pub end: Point<usize>,
-}
-
-impl Span {
-    pub fn to_locations(&self) -> Locations {
-        let (start, end) = match self.ty {
-            SpanType::Inclusive => (self.front, self.tail),
-            SpanType::Exclusive => {
-                (Span::wrap_start(self.front, self.cols), Span::wrap_end(self.tail, self.cols))
-            },
-            SpanType::ExcludeFront => (Span::wrap_start(self.front, self.cols), self.tail),
-            SpanType::ExcludeTail => (self.front, Span::wrap_end(self.tail, self.cols)),
-        };
-
-        Locations { start, end }
-    }
-
-    fn wrap_start(mut start: Point<usize>, cols: Column) -> Point<usize> {
-        if start.col == cols - 1 {
-            Point { line: start.line + 1, col: Column(0) }
-        } else {
-            start.col += 1;
-            start
-        }
-    }
-
-    fn wrap_end(end: Point<usize>, cols: Column) -> Point<usize> {
-        if end.col == Column(0) && end.line != 0 {
-            Point { line: end.line - 1, col: cols }
-        } else {
-            Point { line: end.line, col: end.col - 1 }
-        }
-    }
 }
 
 /// Tests for selection
@@ -385,35 +344,27 @@ impl Span {
 /// look like [ B] and [E ].
 #[cfg(test)]
 mod test {
-    use super::{Selection, Span, SpanType};
+    use std::mem;
+
+    use super::{Selection, Span};
+    use crate::clipboard::Clipboard;
+    use crate::grid::Grid;
     use crate::index::{Column, Line, Point, Side};
-    use crate::url::Url;
+    use crate::message_bar::MessageBuffer;
+    use crate::term::cell::{Cell, Flags};
+    use crate::term::{SizeInfo, Term};
 
-    struct Dimensions(Point);
-    impl super::Dimensions for Dimensions {
-        fn dimensions(&self) -> Point {
-            self.0
-        }
-    }
-
-    impl Dimensions {
-        pub fn new(line: usize, col: usize) -> Self {
-            Dimensions(Point { line: Line(line), col: Column(col) })
-        }
-    }
-
-    impl super::Search for Dimensions {
-        fn semantic_search_left(&self, point: Point<usize>) -> Point<usize> {
-            point
-        }
-
-        fn semantic_search_right(&self, point: Point<usize>) -> Point<usize> {
-            point
-        }
-
-        fn url_search(&self, _: Point<usize>) -> Option<Url> {
-            None
-        }
+    fn term(width: usize, height: usize) -> Term {
+        let size = SizeInfo {
+            width: width as f32,
+            height: height as f32,
+            cell_width: 1.0,
+            cell_height: 1.0,
+            padding_x: 0.0,
+            padding_y: 0.0,
+            dpr: 1.0,
+        };
+        Term::new(&Default::default(), size, MessageBuffer::new(), Clipboard::new_nop())
     }
 
     /// Test case of single cell selection
@@ -427,11 +378,9 @@ mod test {
         let mut selection = Selection::simple(location, Side::Left);
         selection.update(location, Side::Right);
 
-        assert_eq!(selection.to_span(&Dimensions::new(1, 1), false).unwrap(), Span {
-            cols: Column(1),
-            ty: SpanType::Inclusive,
-            front: location,
-            tail: location
+        assert_eq!(selection.to_span(&term(1, 1), false).unwrap(), Span {
+            start: location,
+            end: location
         });
     }
 
@@ -446,11 +395,9 @@ mod test {
         let mut selection = Selection::simple(location, Side::Right);
         selection.update(location, Side::Left);
 
-        assert_eq!(selection.to_span(&Dimensions::new(1, 1), false).unwrap(), Span {
-            cols: Column(1),
-            ty: SpanType::Inclusive,
-            front: location,
-            tail: location
+        assert_eq!(selection.to_span(&term(1, 1), false).unwrap(), Span {
+            start: location,
+            end: location
         });
     }
 
@@ -464,7 +411,7 @@ mod test {
         let mut selection = Selection::simple(Point::new(0, Column(0)), Side::Right);
         selection.update(Point::new(0, Column(1)), Side::Left);
 
-        assert_eq!(selection.to_span(&Dimensions::new(1, 2), false), None);
+        assert_eq!(selection.to_span(&term(2, 1), false), None);
     }
 
     /// Test adjacent cell selection from right to left
@@ -477,7 +424,7 @@ mod test {
         let mut selection = Selection::simple(Point::new(0, Column(1)), Side::Left);
         selection.update(Point::new(0, Column(0)), Side::Right);
 
-        assert_eq!(selection.to_span(&Dimensions::new(1, 2), false), None);
+        assert_eq!(selection.to_span(&term(2, 1), false), None);
     }
 
     /// Test selection across adjacent lines
@@ -494,11 +441,9 @@ mod test {
         let mut selection = Selection::simple(Point::new(1, Column(1)), Side::Right);
         selection.update(Point::new(0, Column(1)), Side::Right);
 
-        assert_eq!(selection.to_span(&Dimensions::new(2, 5), false).unwrap(), Span {
-            cols: Column(5),
-            front: Point::new(0, Column(1)),
-            tail: Point::new(1, Column(2)),
-            ty: SpanType::Inclusive,
+        assert_eq!(selection.to_span(&term(5, 2), false).unwrap(), Span {
+            start: Point::new(0, Column(1)),
+            end: Point::new(1, Column(2)),
         });
     }
 
@@ -519,11 +464,9 @@ mod test {
         selection.update(Point::new(1, Column(1)), Side::Right);
         selection.update(Point::new(1, Column(0)), Side::Right);
 
-        assert_eq!(selection.to_span(&Dimensions::new(2, 5), false).unwrap(), Span {
-            cols: Column(5),
-            front: Point::new(0, Column(1)),
-            tail: Point::new(1, Column(1)),
-            ty: SpanType::Inclusive,
+        assert_eq!(selection.to_span(&term(5, 2), false).unwrap(), Span {
+            start: Point::new(0, Column(1)),
+            end: Point::new(1, Column(1)),
         });
     }
 
@@ -533,11 +476,9 @@ mod test {
         selection.update(Point::new(5, Column(3)), Side::Right);
         selection.rotate(-3);
 
-        assert_eq!(selection.to_span(&Dimensions::new(10, 5), true).unwrap(), Span {
-            cols: Column(5),
-            front: Point::new(0, Column(4)),
-            tail: Point::new(2, Column(0)),
-            ty: SpanType::Inclusive,
+        assert_eq!(selection.to_span(&term(5, 10), true).unwrap(), Span {
+            start: Point::new(0, Column(4)),
+            end: Point::new(2, Column(0)),
         });
     }
 
@@ -547,11 +488,9 @@ mod test {
         selection.update(Point::new(5, Column(3)), Side::Right);
         selection.rotate(-3);
 
-        assert_eq!(selection.to_span(&Dimensions::new(10, 5), true).unwrap(), Span {
-            cols: Column(5),
-            front: Point::new(0, Column(4)),
-            tail: Point::new(2, Column(3)),
-            ty: SpanType::Inclusive,
+        assert_eq!(selection.to_span(&term(5, 10), true).unwrap(), Span {
+            start: Point::new(0, Column(4)),
+            end: Point::new(2, Column(3)),
         });
     }
 
@@ -561,11 +500,28 @@ mod test {
         selection.update(Point::new(5, Column(3)), Side::Right);
         selection.rotate(-3);
 
-        assert_eq!(selection.to_span(&Dimensions::new(10, 5), true).unwrap(), Span {
-            cols: Column(5),
-            front: Point::new(0, Column(4)),
-            tail: Point::new(2, Column(4)),
-            ty: SpanType::Inclusive,
+        assert_eq!(selection.to_span(&term(5, 10), true).unwrap(), Span {
+            start: Point::new(0, Column(4)),
+            end: Point::new(2, Column(4)),
+        });
+    }
+
+    #[test]
+    fn double_width_expansion() {
+        let mut term = term(10, 1);
+        let mut grid = Grid::new(Line(1), Column(10), 0, Cell::default());
+        grid[Line(0)][Column(0)].flags.insert(Flags::WIDE_CHAR);
+        grid[Line(0)][Column(1)].flags.insert(Flags::WIDE_CHAR_SPACER);
+        grid[Line(0)][Column(8)].flags.insert(Flags::WIDE_CHAR);
+        grid[Line(0)][Column(9)].flags.insert(Flags::WIDE_CHAR_SPACER);
+        mem::swap(term.grid_mut(), &mut grid);
+
+        let mut selection = Selection::simple(Point::new(0, Column(1)), Side::Left);
+        selection.update(Point::new(0, Column(8)), Side::Right);
+
+        assert_eq!(selection.to_span(&term, false).unwrap(), Span {
+            start: Point::new(0, Column(9)),
+            end: Point::new(0, Column(0)),
         });
     }
 }


### PR DESCRIPTION
This changes the selection behavior to automatically select both cells
of double width characters in either selection direction.

This fixes #2322.