### PR TITLE
Correct path to license file so cargo-deb works

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -30,7 +30,7 @@ bench = []
 
 [package.metadata.deb]
 maintainer = "Joe Wilm <joe@jwilm.com>"
-license-file = ["LICENSE-APACHE", "3"]
+license-file = ["../LICENSE-APACHE", "3"]
 extended-description = """\
 Alacritty is the fastest terminal emulator in existence. Using the GPU for \
 rendering enables optimizations that simply aren't possible without it.  """


### PR DESCRIPTION
Correct the path to the `LICENSE-APACHE` license file in alacritty's `Cargo.toml` post crate split so that building a Debian package with cargo-deb works correctly again.