### PR TITLE
Remove clipboard loading error logging

### DIFF
--- a/alacritty_terminal/src/clipboard.rs
+++ b/alacritty_terminal/src/clipboard.rs
@@ -75,16 +75,22 @@ impl Clipboard {
         };
 
         clipboard.set_contents(text.into()).unwrap_or_else(|err| {
-            warn!("Error storing selection to clipboard. {}", err);
+            warn!("Unable to store text in clipboard: {}", err);
         });
     }
 
-    pub fn load(&mut self, ty: ClipboardType) -> Result<String, Box<std::error::Error>> {
+    pub fn load(&mut self, ty: ClipboardType) -> String {
         let clipboard = match (ty, &mut self.secondary) {
             (ClipboardType::Secondary, Some(provider)) => provider,
             _ => &mut self.primary,
         };
 
-        clipboard.get_contents()
+        match clipboard.get_contents() {
+            Err(err) => {
+                debug!("Unable to load text from clipboard: {}", err);
+                String::new()
+            }
+            Ok(text) => text,
+        }
     }
 }

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -39,7 +39,6 @@ use crate::message_bar::{self, Message};
 use crate::term::mode::TermMode;
 use crate::term::{Search, SizeInfo, Term};
 use crate::url::Url;
-use crate::util::fmt::Red;
 use crate::util::start_daemon;
 
 pub const FONT_SIZE_STEP: f32 = 0.5;
@@ -282,36 +281,26 @@ impl Action {
                 ctx.copy_selection(ClipboardType::Primary);
             },
             Action::Paste => {
-                ctx.terminal_mut()
+                let text = ctx.terminal_mut()
                     .clipboard()
-                    .load(ClipboardType::Primary)
-                    .map(|contents| self.paste(ctx, &contents))
-                    .unwrap_or_else(|err| {
-                        error!("Error loading data from clipboard: {}", Red(err));
-                    });
+                    .load(ClipboardType::Primary);
+                self.paste(ctx, &text);
             },
             Action::PasteSelection => {
                 // Only paste if mouse events are not captured by an application
                 if !mouse_mode {
-                    ctx.terminal_mut()
+                    let text = ctx.terminal_mut()
                         .clipboard()
-                        .load(ClipboardType::Secondary)
-                        .map(|contents| self.paste(ctx, &contents))
-                        .unwrap_or_else(|err| {
-                            error!("Error loading data from clipboard: {}", Red(err));
-                        });
+                        .load(ClipboardType::Secondary);
+                    self.paste(ctx, &text);
                 }
             },
             Action::Command(ref program, ref args) => {
                 trace!("Running command {} with args {:?}", program, args);
 
                 match start_daemon(program, args) {
-                    Ok(_) => {
-                        debug!("Spawned new proc");
-                    },
-                    Err(err) => {
-                        warn!("Couldn't run command {}", err);
-                    },
+                    Ok(_) => debug!("Spawned new proc"),
+                    Err(err) => warn!("Couldn't run command {}", err),
                 }
             },
             Action::ToggleFullscreen => {


### PR DESCRIPTION
On macOS the clipboard actually returns an error when loading it and it
is empty. However this is not an `Empty` error but all errors are simple
boxed Errors from std.

Since loading the clipboard data usually should not fail, we now do not
log it as error if it fails but just print it to the debug log instead.

This fixes #2389.