### PR TITLE
Update UPDATE.md with Fedora X11 dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,7 +71,7 @@ libraries to build Alacritty. Here's an apt command that should install all of
 them. If something is still found to be missing, please open an issue.
 
 ```sh
-apt-get install cmake pkg-config libfreetype6-dev libfontconfig1-dev
+apt-get install cmake pkg-config libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev
 ```
 
 #### Arch Linux

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,7 +91,7 @@ command that should install all of them. If something is still found to be
 missing, please open an issue.
 
 ```sh
-dnf install cmake freetype-devel fontconfig-devel
+dnf install cmake freetype-devel fontconfig-devel libxcb-devel
 ```
 
 #### CentOS/RHEL 7


### PR DESCRIPTION
This is similar to https://github.com/jwilm/alacritty/pull/2387
On a Fedora system running X11 I had to install the `libxcb-devel` dependency in order to compile.