### PR TITLE
Fix regression causing the cursor to only show over the left half of wide characters

### DIFF
--- a/alacritty_terminal/src/cursor.rs
+++ b/alacritty_terminal/src/cursor.rs
@@ -23,8 +23,8 @@ use crate::ansi::CursorStyle;
 /// Width/Height of the cursor relative to the font width
 pub const CURSOR_WIDTH_PERCENTAGE: i32 = 15;
 
+/// A key for caching cursor glyphs
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Deserialize)]
-/// An enum that represents all data about the state of the cursor
 pub struct CursorKey {
     pub style: CursorStyle,
     pub is_wide: bool,

--- a/alacritty_terminal/src/cursor.rs
+++ b/alacritty_terminal/src/cursor.rs
@@ -25,51 +25,34 @@ pub const CURSOR_WIDTH_PERCENTAGE: i32 = 15;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash, Deserialize)]
 /// An enum that represents all data about the state of the cursor
-pub enum CursorKey {
-    Block { height: i32, width: i32 },
-    Underline { width: i32, line_width: i32 },
-    Beam { height: i32, line_width: i32 },
-    HollowBlock { height: i32, width: i32, line_width: i32 },
-    Hidden,
+pub struct CursorKey {
+    pub style: CursorStyle,
+    pub is_wide: bool,
 }
 
-impl CursorKey {
-    pub fn new(
-        cursor: CursorStyle,
-        metrics: Metrics,
-        offset_x: i8,
-        offset_y: i8,
-        is_wide: bool,
-    ) -> CursorKey {
-        // Calculate the cell metrics
-        let height = metrics.line_height as i32 + i32::from(offset_y);
-        let mut width = metrics.average_advance as i32 + i32::from(offset_x);
-        let line_width = cmp::max(width * CURSOR_WIDTH_PERCENTAGE / 100, 1);
+pub fn get_cursor_glyph(
+    cursor: CursorStyle,
+    metrics: Metrics,
+    offset_x: i8,
+    offset_y: i8,
+    is_wide: bool,
+) -> RasterizedGlyph {
+    // Calculate the cell metrics
+    let height = metrics.line_height as i32 + i32::from(offset_y);
+    let mut width = metrics.average_advance as i32 + i32::from(offset_x);
+    let line_width = cmp::max(width * CURSOR_WIDTH_PERCENTAGE / 100, 1);
 
-        // Double the cursor width if it's above a double-width glyph
-        if is_wide {
-            width *= 2;
-        }
-
-        match cursor {
-            CursorStyle::Block => CursorKey::Block { height, width },
-            CursorStyle::Underline => CursorKey::Underline { width, line_width },
-            CursorStyle::Beam => CursorKey::Beam { height, line_width },
-            CursorStyle::HollowBlock => CursorKey::HollowBlock { height, width, line_width },
-            CursorStyle::Hidden => CursorKey::Hidden,
-        }
+    // Double the cursor width if it's above a double-width glyph
+    if is_wide {
+        width *= 2;
     }
-}
 
-pub fn get_cursor_glyph(cursor_key: CursorKey) -> RasterizedGlyph {
-    match cursor_key {
-        CursorKey::HollowBlock { height, width, line_width } => {
-            get_box_cursor_glyph(height, width, line_width)
-        },
-        CursorKey::Underline { width, line_width } => get_underline_cursor_glyph(width, line_width),
-        CursorKey::Beam { height, line_width } => get_beam_cursor_glyph(height, line_width),
-        CursorKey::Block { height, width } => get_block_cursor_glyph(height, width),
-        CursorKey::Hidden => RasterizedGlyph::default(),
+    match cursor {
+        CursorStyle::HollowBlock => get_box_cursor_glyph(height, width, line_width),
+        CursorStyle::Underline => get_underline_cursor_glyph(width, line_width),
+        CursorStyle::Beam => get_beam_cursor_glyph(height, line_width),
+        CursorStyle::Block => get_block_cursor_glyph(height, width),
+        CursorStyle::Hidden => RasterizedGlyph::default(),
     }
 }
 

--- a/alacritty_terminal/src/display.rs
+++ b/alacritty_terminal/src/display.rs
@@ -438,7 +438,7 @@ impl Display {
 
         let window_focused = self.window.is_focused;
         let grid_cells: Vec<RenderableCell> =
-            terminal.renderable_cells(config, window_focused, metrics).collect();
+            terminal.renderable_cells(config, window_focused).collect();
 
         // Get message from terminal to ignore modifications after lock is dropped
         let message_buffer = terminal.message_buffer_mut().message();

--- a/alacritty_terminal/src/renderer/mod.rs
+++ b/alacritty_terminal/src/renderer/mod.rs
@@ -996,14 +996,14 @@ impl<'a> RenderApi<'a> {
         let chars = match cell.inner {
             RenderableCellContent::Cursor(cursor_key) => {
                 // Raw cell pixel buffers like cursors don't need to go through font lookup
-                let metrics = &glyph_cache.metrics;
+                let metrics = glyph_cache.metrics;
                 let glyph = glyph_cache.cursor_cache.entry(cursor_key).or_insert_with(|| {
                     let offset_x = self.config.font.offset.x;
                     let offset_y = self.config.font.offset.y;
 
                     self.load_glyph(&get_cursor_glyph(
                         cursor_key.style,
-                        *metrics,
+                        metrics,
                         offset_x,
                         offset_y,
                         cursor_key.is_wide,

--- a/alacritty_terminal/src/renderer/mod.rs
+++ b/alacritty_terminal/src/renderer/mod.rs
@@ -96,7 +96,7 @@ impl ::std::fmt::Display for Error {
         match *self {
             Error::ShaderCreation(ref err) => {
                 write!(f, "There was an error initializing the shaders: {}", err)
-            }
+            },
         }
     }
 }
@@ -649,8 +649,8 @@ impl QuadRenderer {
                         | DebouncedEvent::Write(_)
                         | DebouncedEvent::Chmod(_) => {
                             msg_tx.send(Msg::ShaderReload).expect("msg send ok");
-                        }
-                        _ => {}
+                        },
+                        _ => {},
                     }
                 }
             });
@@ -815,11 +815,11 @@ impl QuadRenderer {
 
                 info!("... successfully reloaded shaders");
                 (program, rect_program)
-            }
+            },
             (Err(err), _) | (_, Err(err)) => {
                 error!("{}", err);
                 return;
-            }
+            },
         };
 
         self.active_tex = 0;
@@ -1011,7 +1011,7 @@ impl<'a> RenderApi<'a> {
                 });
                 self.add_render_item(&cell, &glyph);
                 return;
-            }
+            },
             RenderableCellContent::Chars(chars) => chars,
         };
 
@@ -1082,7 +1082,7 @@ fn load_glyph(
                 atlas.push(new);
             }
             load_glyph(active_tex, atlas, current_atlas, rasterized)
-        }
+        },
         Err(AtlasInsertError::GlyphTooLarge) => Glyph {
             tex_id: atlas[*current_atlas].id,
             top: 0.0,
@@ -1432,7 +1432,7 @@ impl ::std::fmt::Display for ShaderCreationError {
             ShaderCreationError::Io(ref err) => write!(f, "Couldn't read shader: {}", err),
             ShaderCreationError::Compile(ref path, ref log) => {
                 write!(f, "Failed compiling shader at {}: {}", path.display(), log)
-            }
+            },
             ShaderCreationError::Link(ref log) => write!(f, "Failed linking shader: {}", log),
         }
     }

--- a/alacritty_terminal/src/renderer/mod.rs
+++ b/alacritty_terminal/src/renderer/mod.rs
@@ -26,8 +26,8 @@ use font::{self, FontDesc, FontKey, GlyphKey, Rasterize, RasterizedGlyph, Raster
 use glutin::dpi::PhysicalSize;
 use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
 
-use crate::ansi::CursorStyle;
 use crate::config::{self, Config, Delta};
+use crate::cursor::{get_cursor_glyph, CursorKey};
 use crate::gl;
 use crate::gl::types::*;
 use crate::index::{Column, Line};
@@ -160,7 +160,7 @@ pub struct GlyphCache {
     cache: HashMap<GlyphKey, Glyph, BuildHasherDefault<FnvHasher>>,
 
     /// Cache of buffered cursor glyphs
-    cursor_cache: HashMap<CursorStyle, Glyph, BuildHasherDefault<FnvHasher>>,
+    cursor_cache: HashMap<CursorKey, Glyph, BuildHasherDefault<FnvHasher>>,
 
     /// Rasterizer for loading new glyphs
     rasterizer: Rasterizer,
@@ -994,12 +994,12 @@ impl<'a> RenderApi<'a> {
 
     pub fn render_cell(&mut self, cell: RenderableCell, glyph_cache: &mut GlyphCache) {
         let chars = match cell.inner {
-            RenderableCellContent::Cursor((cursor_style, ref raw)) => {
+            RenderableCellContent::Cursor(cursor_key) => {
                 // Raw cell pixel buffers like cursors don't need to go through font lookup
                 let glyph = glyph_cache
                     .cursor_cache
-                    .entry(cursor_style)
-                    .or_insert_with(|| self.load_glyph(raw));
+                    .entry(cursor_key)
+                    .or_insert_with(|| self.load_glyph(&get_cursor_glyph(cursor_key)));
                 self.add_render_item(&cell, &glyph);
                 return;
             },

--- a/alacritty_terminal/src/renderer/mod.rs
+++ b/alacritty_terminal/src/renderer/mod.rs
@@ -96,7 +96,7 @@ impl ::std::fmt::Display for Error {
         match *self {
             Error::ShaderCreation(ref err) => {
                 write!(f, "There was an error initializing the shaders: {}", err)
-            },
+            }
         }
     }
 }
@@ -649,8 +649,8 @@ impl QuadRenderer {
                         | DebouncedEvent::Write(_)
                         | DebouncedEvent::Chmod(_) => {
                             msg_tx.send(Msg::ShaderReload).expect("msg send ok");
-                        },
-                        _ => {},
+                        }
+                        _ => {}
                     }
                 }
             });
@@ -815,11 +815,11 @@ impl QuadRenderer {
 
                 info!("... successfully reloaded shaders");
                 (program, rect_program)
-            },
+            }
             (Err(err), _) | (_, Err(err)) => {
                 error!("{}", err);
                 return;
-            },
+            }
         };
 
         self.active_tex = 0;
@@ -996,13 +996,22 @@ impl<'a> RenderApi<'a> {
         let chars = match cell.inner {
             RenderableCellContent::Cursor(cursor_key) => {
                 // Raw cell pixel buffers like cursors don't need to go through font lookup
-                let glyph = glyph_cache
-                    .cursor_cache
-                    .entry(cursor_key)
-                    .or_insert_with(|| self.load_glyph(&get_cursor_glyph(cursor_key)));
+                let metrics = &glyph_cache.metrics;
+                let glyph = glyph_cache.cursor_cache.entry(cursor_key).or_insert_with(|| {
+                    let offset_x = self.config.font.offset.x;
+                    let offset_y = self.config.font.offset.y;
+
+                    self.load_glyph(&get_cursor_glyph(
+                        cursor_key.style,
+                        *metrics,
+                        offset_x,
+                        offset_y,
+                        cursor_key.is_wide,
+                    ))
+                });
                 self.add_render_item(&cell, &glyph);
                 return;
-            },
+            }
             RenderableCellContent::Chars(chars) => chars,
         };
 
@@ -1073,7 +1082,7 @@ fn load_glyph(
                 atlas.push(new);
             }
             load_glyph(active_tex, atlas, current_atlas, rasterized)
-        },
+        }
         Err(AtlasInsertError::GlyphTooLarge) => Glyph {
             tex_id: atlas[*current_atlas].id,
             top: 0.0,
@@ -1423,7 +1432,7 @@ impl ::std::fmt::Display for ShaderCreationError {
             ShaderCreationError::Io(ref err) => write!(f, "Couldn't read shader: {}", err),
             ShaderCreationError::Compile(ref path, ref log) => {
                 write!(f, "Failed compiling shader at {}: {}", path.display(), log)
-            },
+            }
             ShaderCreationError::Link(ref log) => write!(f, "Failed linking shader: {}", log),
         }
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -18,7 +18,7 @@ use std::ops::{Index, IndexMut, Range, RangeInclusive};
 use std::time::{Duration, Instant};
 use std::{io, mem, ptr};
 
-use font::{self, RasterizedGlyph, Size};
+use font::{self, Size};
 use glutin::MouseCursor;
 use unicode_width::UnicodeWidthChar;
 
@@ -27,7 +27,7 @@ use crate::ansi::{
 };
 use crate::clipboard::{Clipboard, ClipboardType};
 use crate::config::{Config, VisualBellAnimation};
-use crate::cursor;
+use crate::cursor::CursorKey;
 use crate::grid::{
     BidirectionalIterator, DisplayIter, Grid, GridCell, IndexRegion, Indexed, Scroll,
     ViewportPosition,
@@ -158,7 +158,7 @@ pub struct RenderableCellsIter<'a> {
     grid: &'a Grid<Cell>,
     cursor: &'a Point,
     cursor_offset: usize,
-    cursor_cell: Option<RasterizedGlyph>,
+    cursor_key: Option<CursorKey>,
     cursor_style: CursorStyle,
     config: &'a Config,
     colors: &'a color::List,
@@ -226,13 +226,13 @@ impl<'a> RenderableCellsIter<'a> {
         // Load cursor glyph
         let cursor = &term.cursor.point;
         let cursor_visible = term.mode.contains(TermMode::SHOW_CURSOR) && grid.contains(cursor);
-        let cursor_cell = if cursor_visible {
+        let cursor_key = if cursor_visible {
             let offset_x = config.font.offset.x;
             let offset_y = config.font.offset.y;
 
             let is_wide = grid[cursor].flags.contains(cell::Flags::WIDE_CHAR)
                 && (cursor.col + 1) < grid.num_cols();
-            Some(cursor::get_cursor_glyph(cursor_style, metrics, offset_x, offset_y, is_wide))
+            Some(CursorKey::new(cursor_style, metrics, offset_x, offset_y, is_wide))
         } else {
             // Use hidden cursor so text will not get inverted
             cursor_style = CursorStyle::Hidden;
@@ -248,7 +248,7 @@ impl<'a> RenderableCellsIter<'a> {
             url_highlight: &grid.url_highlight,
             config,
             colors: &term.colors,
-            cursor_cell,
+            cursor_key,
             cursor_style,
         }
     }
@@ -257,7 +257,7 @@ impl<'a> RenderableCellsIter<'a> {
 #[derive(Clone, Debug)]
 pub enum RenderableCellContent {
     Chars([char; cell::MAX_ZEROWIDTH_CHARS + 1]),
-    Cursor((CursorStyle, RasterizedGlyph)),
+    Cursor(CursorKey),
 }
 
 #[derive(Clone, Debug)]
@@ -377,7 +377,7 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
         loop {
             if self.cursor_offset == self.inner.offset() && self.inner.column() == self.cursor.col {
                 // Handle cursor
-                if let Some(cursor_cell) = self.cursor_cell.take() {
+                if let Some(cursor_key) = self.cursor_key.take() {
                     let cell = Indexed {
                         inner: self.grid[self.cursor],
                         column: self.cursor.col,
@@ -386,8 +386,7 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                     let mut renderable_cell =
                         RenderableCell::new(self.config, self.colors, cell, false);
 
-                    renderable_cell.inner =
-                        RenderableCellContent::Cursor((self.cursor_style, cursor_cell));
+                    renderable_cell.inner = RenderableCellContent::Cursor(cursor_key);
 
                     if let Some(color) = self.config.colors.cursor.cursor {
                         renderable_cell.fg = color;

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -191,16 +191,16 @@ impl<'a> RenderableCellsIter<'a> {
             let locations = match (start_line, end_line) {
                 (ViewportPosition::Visible(start_line), ViewportPosition::Visible(end_line)) => {
                     Some((start_line, span.start.col, end_line, span.end.col))
-                }
+                },
                 (ViewportPosition::Visible(start_line), ViewportPosition::Above) => {
                     Some((start_line, span.start.col, Line(0), Column(0)))
-                }
+                },
                 (ViewportPosition::Below, ViewportPosition::Visible(end_line)) => {
                     Some((grid.num_lines(), Column(0), end_line, span.end.col))
-                }
+                },
                 (ViewportPosition::Below, ViewportPosition::Above) => {
                     Some((grid.num_lines(), Column(0), Line(0), Column(0)))
-                }
+                },
                 _ => None,
             };
 
@@ -316,7 +316,7 @@ impl RenderableCell {
                             && config.colors.primary.bright_foreground.is_none() =>
                     {
                         colors[NamedColor::DimForeground]
-                    }
+                    },
                     // Draw bold text in bright colors *and* contains bold flag.
                     (true, cell::Flags::BOLD) => colors[ansi.to_bright()],
                     // Cell is marked as dim and not bold
@@ -324,7 +324,7 @@ impl RenderableCell {
                     // None of the above, keep original color.
                     _ => colors[ansi],
                 }
-            }
+            },
             Color::Indexed(idx) => {
                 let idx = match (
                     config.draw_bold_text_with_bright_colors(),
@@ -338,7 +338,7 @@ impl RenderableCell {
                 };
 
                 colors[idx]
-            }
+            },
         }
     }
 
@@ -587,7 +587,7 @@ impl VisualBell {
                     self.start_time = None;
                 }
                 false
-            }
+            },
             None => true,
         }
     }
@@ -632,12 +632,12 @@ impl VisualBell {
                 let inverse_intensity = match self.animation {
                     VisualBellAnimation::Ease | VisualBellAnimation::EaseOut => {
                         cubic_bezier(0.25, 0.1, 0.25, 1.0, time)
-                    }
+                    },
                     VisualBellAnimation::EaseOutSine => cubic_bezier(0.39, 0.575, 0.565, 1.0, time),
                     VisualBellAnimation::EaseOutQuad => cubic_bezier(0.25, 0.46, 0.45, 0.94, time),
                     VisualBellAnimation::EaseOutCubic => {
                         cubic_bezier(0.215, 0.61, 0.355, 1.0, time)
-                    }
+                    },
                     VisualBellAnimation::EaseOutQuart => cubic_bezier(0.165, 0.84, 0.44, 1.0, time),
                     VisualBellAnimation::EaseOutQuint => cubic_bezier(0.23, 1.0, 0.32, 1.0, time),
                     VisualBellAnimation::EaseOutExpo => cubic_bezier(0.19, 1.0, 0.22, 1.0, time),
@@ -648,7 +648,7 @@ impl VisualBell {
                 // Since we want the `intensity` of the VisualBell to decay over
                 // `time`, we subtract the `inverse_intensity` from 1.0.
                 1.0 - inverse_intensity
-            }
+            },
         }
     }
 
@@ -1026,7 +1026,7 @@ impl Term {
             // Selection within single line
             0 => {
                 res.append(&self.grid, &self.tabs, start.line, start.col..end.col);
-            }
+            },
 
             // Selection ends on line following start
             1 => {
@@ -1035,7 +1035,7 @@ impl Term {
 
                 // Starting line
                 res.append(&self.grid, &self.tabs, start.line, Column(0)..start.col);
-            }
+            },
 
             // Multi line selection
             _ => {
@@ -1049,7 +1049,7 @@ impl Term {
 
                 // Starting line
                 res.append(&self.grid, &self.tabs, start.line, Column(0)..start.col);
-            }
+            },
         }
 
         Some(res)
@@ -1543,11 +1543,11 @@ impl ansi::Handler for Term {
         match arg {
             5 => {
                 let _ = writer.write_all(b"\x1b[0n");
-            }
+            },
             6 => {
                 let pos = self.cursor.point;
                 let _ = write!(writer, "\x1b[{};{}R", pos.line + 1, pos.col + 1);
-            }
+            },
             _ => debug!("unknown device status query: {}", arg),
         };
     }
@@ -1798,19 +1798,19 @@ impl ansi::Handler for Term {
                 for cell in &mut row[col..] {
                     cell.reset(&template);
                 }
-            }
+            },
             ansi::LineClearMode::Left => {
                 let row = &mut self.grid[self.cursor.point.line];
                 for cell in &mut row[..=col] {
                     cell.reset(&template);
                 }
-            }
+            },
             ansi::LineClearMode::All => {
                 let row = &mut self.grid[self.cursor.point.line];
                 for cell in &mut row[..] {
                     cell.reset(&template);
                 }
-            }
+            },
         }
     }
 
@@ -1856,7 +1856,7 @@ impl ansi::Handler for Term {
                         .region_mut((self.cursor.point.line + 1)..)
                         .each(|cell| cell.reset(&template));
                 }
-            }
+            },
             ansi::ClearMode::All => self.grid.region_mut(..).each(|c| c.reset(&template)),
             ansi::ClearMode::Above => {
                 // If clearing more than one line
@@ -1871,7 +1871,7 @@ impl ansi::Handler for Term {
                 for cell in &mut self.grid[self.cursor.point.line][..end] {
                     cell.reset(&template);
                 }
-            }
+            },
             ansi::ClearMode::Saved => self.grid.clear_history(),
         }
     }
@@ -1883,10 +1883,10 @@ impl ansi::Handler for Term {
             ansi::TabulationClearMode::Current => {
                 let column = self.cursor.point.col;
                 self.tabs[column] = false;
-            }
+            },
             ansi::TabulationClearMode::All => {
                 self.tabs.clear_all();
-            }
+            },
         }
     }
 
@@ -1936,7 +1936,7 @@ impl ansi::Handler for Term {
                 self.cursor.template.fg = Color::Named(NamedColor::Foreground);
                 self.cursor.template.bg = Color::Named(NamedColor::Background);
                 self.cursor.template.flags = cell::Flags::empty();
-            }
+            },
             Attr::Reverse => self.cursor.template.flags.insert(cell::Flags::INVERSE),
             Attr::CancelReverse => self.cursor.template.flags.remove(cell::Flags::INVERSE),
             Attr::Bold => self.cursor.template.flags.insert(cell::Flags::BOLD),
@@ -1944,7 +1944,7 @@ impl ansi::Handler for Term {
             Attr::Dim => self.cursor.template.flags.insert(cell::Flags::DIM),
             Attr::CancelBoldDim => {
                 self.cursor.template.flags.remove(cell::Flags::BOLD | cell::Flags::DIM)
-            }
+            },
             Attr::Italic => self.cursor.template.flags.insert(cell::Flags::ITALIC),
             Attr::CancelItalic => self.cursor.template.flags.remove(cell::Flags::ITALIC),
             Attr::Underscore => self.cursor.template.flags.insert(cell::Flags::UNDERLINE),
@@ -1955,7 +1955,7 @@ impl ansi::Handler for Term {
             Attr::CancelStrike => self.cursor.template.flags.remove(cell::Flags::STRIKEOUT),
             _ => {
                 debug!("Term got unhandled attr: {:?}", attr);
-            }
+            },
         }
     }
 
@@ -1970,21 +1970,21 @@ impl ansi::Handler for Term {
                     self.swap_alt();
                     self.save_cursor_position();
                 }
-            }
+            },
             ansi::Mode::ShowCursor => self.mode.insert(TermMode::SHOW_CURSOR),
             ansi::Mode::CursorKeys => self.mode.insert(TermMode::APP_CURSOR),
             ansi::Mode::ReportMouseClicks => {
                 self.mode.insert(TermMode::MOUSE_REPORT_CLICK);
                 self.set_mouse_cursor(MouseCursor::Default);
-            }
+            },
             ansi::Mode::ReportCellMouseMotion => {
                 self.mode.insert(TermMode::MOUSE_DRAG);
                 self.set_mouse_cursor(MouseCursor::Default);
-            }
+            },
             ansi::Mode::ReportAllMouseMotion => {
                 self.mode.insert(TermMode::MOUSE_MOTION);
                 self.set_mouse_cursor(MouseCursor::Default);
-            }
+            },
             ansi::Mode::ReportFocusInOut => self.mode.insert(TermMode::FOCUS_IN_OUT),
             ansi::Mode::BracketedPaste => self.mode.insert(TermMode::BRACKETED_PASTE),
             ansi::Mode::SgrMouse => self.mode.insert(TermMode::SGR_MOUSE),
@@ -1995,7 +1995,7 @@ impl ansi::Handler for Term {
             ansi::Mode::Insert => self.mode.insert(TermMode::INSERT), // heh
             ansi::Mode::BlinkingCursor => {
                 trace!("... unimplemented mode");
-            }
+            },
         }
     }
 
@@ -2010,21 +2010,21 @@ impl ansi::Handler for Term {
                     self.swap_alt();
                     self.restore_cursor_position();
                 }
-            }
+            },
             ansi::Mode::ShowCursor => self.mode.remove(TermMode::SHOW_CURSOR),
             ansi::Mode::CursorKeys => self.mode.remove(TermMode::APP_CURSOR),
             ansi::Mode::ReportMouseClicks => {
                 self.mode.remove(TermMode::MOUSE_REPORT_CLICK);
                 self.set_mouse_cursor(MouseCursor::Text);
-            }
+            },
             ansi::Mode::ReportCellMouseMotion => {
                 self.mode.remove(TermMode::MOUSE_DRAG);
                 self.set_mouse_cursor(MouseCursor::Text);
-            }
+            },
             ansi::Mode::ReportAllMouseMotion => {
                 self.mode.remove(TermMode::MOUSE_MOTION);
                 self.set_mouse_cursor(MouseCursor::Text);
-            }
+            },
             ansi::Mode::ReportFocusInOut => self.mode.remove(TermMode::FOCUS_IN_OUT),
             ansi::Mode::BracketedPaste => self.mode.remove(TermMode::BRACKETED_PASTE),
             ansi::Mode::SgrMouse => self.mode.remove(TermMode::SGR_MOUSE),
@@ -2035,7 +2035,7 @@ impl ansi::Handler for Term {
             ansi::Mode::Insert => self.mode.remove(TermMode::INSERT),
             ansi::Mode::BlinkingCursor => {
                 trace!("... unimplemented mode");
-            }
+            },
         }
     }
 


### PR DESCRIPTION
Commit 494348abe80f591dfdd68fd4987bafc59fcb32c1 only cached by cursor style, which meant that the cached cursor, which was probably single-width, would be used to draw over wide characters.
This commit caches by height, width, line_width, and style, so any time the cursor requirements change, a new cursor will be cached.