### PR TITLE
macOS app manifest requests NSSystemAdministrationUsageDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Packaging
 
 - The xclip dependency has been removed
+- On macOS, Alacritty now requests NSSystemAdministrationUsageDescription to
+   avoid permission failures
 
 ### Added
 

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -52,5 +52,7 @@
     <string>An application in Alacritty would like to access your microphone.</string>
     <key>NSRemindersUsageDescription</key>
     <string>An application in Alacritty would like to access your reminders.</string>
+    <key>NSSystemAdministrationUsageDescription</key>
+    <string>An application in Alacritty requires elevated permissions.</string>
 </dict>
 </plist>


### PR DESCRIPTION
This resolves permission failures when modifying root-owned files
and such, e.g., modifying /etc/hosts. It had been possible
to work around this by adding alacritty to the set of
applications with "Full Disk Access" in System Preferences. macOS
now opens a prompt to confirm permission with a new installation.

Tested on macOS Mojave (10.14.4).

This closes #2337.