### PR TITLE
Update Cargo.toml

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -34,7 +34,7 @@ bench = []
 
 [package.metadata.deb]
 maintainer = "Joe Wilm <joe@jwilm.com>"
-license-file = ["../LICENSE-APACHE", "3"]
+license-file = ["LICENSE-APACHE", "3"]
 extended-description = """\
 Alacritty is the fastest terminal emulator in existence. Using the GPU for \
 rendering enables optimizations that simply aren't possible without it.  """


### PR DESCRIPTION
Fixes #2393 

If this doesn't get pulled then build instructions over at https://github.com/jwilm/alacritty/blob/master/INSTALL.md#cargo with fail with

```
cargo-deb: unable to read license file: ../LICENSE-APACHE
  because: No such file or directory (os error 2)
```