### PR TITLE
Don't attempt shader compilation if not supported.

### DIFF
--- a/alacritty_terminal/src/renderer/mod.rs
+++ b/alacritty_terminal/src/renderer/mod.rs
@@ -1307,6 +1307,16 @@ fn create_shader(
 
     let len: [GLint; 1] = [source.len() as GLint];
 
+    let shader_compiler = unsafe {
+        let mut val: GLboolean = gl::FALSE;
+        gl::GetBooleanv(gl::SHADER_COMPILER, &mut val);
+        val == gl::TRUE
+    };
+    if !shader_compiler {
+        return Err(ShaderCreationError::Compile(PathBuf::from(path),
+                "no shader compiler support".to_string()));
+    }
+
     let shader = unsafe {
         let shader = gl::CreateShader(kind);
         gl::ShaderSource(shader, 1, &(source.as_ptr() as *const _), len.as_ptr());


### PR DESCRIPTION
I was trying to get Alacritty to work in WSL. Hint: it doesn't. But I was getting a useless error that could be better:

```
Created log file at "/tmp/Alacritty-6058.log"
[2019-05-06 14:34] [ERROR] Alacritty encountered an unrecoverable error:

        There was an error initializing the shaders: Failed compiling shader at /home/markus/dist/alacritty/res/text.v.glsl: 

```

It turns out that shader compilation isn't supported, so it never executed and there is no log for `glGetShaderInfoLog()` to return. I guess that's because VcXsrv is starting with `Wgl="True"`, indicating that all OpenGL stuff should be indirectly executed by Windows WGL.

I'm not sure what the solution to that is. Precompiling GLSL files? Wait for WSL 2? I really wanted to use Alacritty :(

Also, I've never written a line of Rust before so this might not be the best.