### PR TITLE
Add Ubuntu PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ else the instructions to build Alacritty from source can be found [here](INSTALL
 
 ### Pop!\_OS / Ubuntu
 
-> Ubuntu requires a third party repository, with packages copied from the Pop!\_OS PPA.
+> If you're not running Pop!_OS, you'll have to add a third party repository first:
 >
 > ```sh
 > add-apt-repository ppa:mmstick76/alacritty

--- a/README.md
+++ b/README.md
@@ -40,20 +40,15 @@ Precompiled binaries are available from the [GitHub releases page](https://githu
 Some operating systems already provide binaries for Alacritty, for everyone
 else the instructions to build Alacritty from source can be found [here](INSTALL.md).
 
-### Pop!\_OS
+### Pop!\_OS / Ubuntu
 
-Provided in the [Pop!\_OS repositories](https://launchpad.net/~system76/+archive/ubuntu/pop) for 18.04 (bionic) and higher.
-
-```sh
-apt install alacritty
-```
-
-### Ubuntu
-
-Packages from the Pop!\_OS PPA, copied into a [dedicated PPA for use outside of Pop](https://launchpad.net/~mmstick76/+archive/ubuntu/alacritty).
+> Ubuntu requires a third party repository, with packages copied from the Pop!\_OS PPA.
+>
+> ```sh
+> add-apt-repository ppa:mmstick76/alacritty
+> ```
 
 ```sh
-add-apt-repository ppa:mmstick76/alacritty
 apt install alacritty
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Provided in the [Pop!\_OS repositories](https://launchpad.net/~system76/+archive
 apt install alacritty
 ```
 
+### Ubuntu
+
+Packages from the Pop!\_OS PPA, copied into a [dedicated PPA for use outside of Pop](https://launchpad.net/~mmstick76/+archive/ubuntu/alacritty).
+
+```sh
+add-apt-repository ppa:mmstick76/alacritty
+apt install alacritty
+```
+
 ### Arch Linux
 
 ```sh


### PR DESCRIPTION
Packages are pulled from the Pop!_OS PPA so that Ubuntu and Ubuntu-derivatives may use it.