### PR TITLE
Reenable macOS automatic graphics switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect positioning of zero-width characters over double-width characters
 - Mouse mode generating events when the cell has not changed
 - Selections not automatically expanding across double-width characters
+- On macOS, automatic graphics switching has been enabled again
 
 ### Removed
 

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -29,7 +29,7 @@
   <key>NSMainNibFile</key>
   <string></string>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
-  <false/>
+  <true/>
   <key>CFBundleDisplayName</key>
   <string>Alacritty</string>
   <key>NSRequiresAquaSystemAppearance</key>


### PR DESCRIPTION
This issue has been resolved upstream by a macOS update, fixing all
crashing issues when switching between integrated and dedicated GPUs.

Fixes #2221.