### PR TITLE
Non-Git directory manually provides commit hash

### DIFF
--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 fn main() {
-    let hash = rustc_tools_util::get_commit_hash().expect("couldn't get commit hash");
+    let mut hash = rustc_tools_util::get_commit_hash().unwrap_or("".to_owned());
+    if hash.is_empty() {
+        hash = std::env::var("GIT_HASH").expect("couldn't get commit hash");
+    }
+
     println!("cargo:rustc-env=GIT_HASH={}", hash);
 }


### PR DESCRIPTION
Sorry, I opened this PR directly without opening a Issue. This is my reason:

1. In some environments, the `git clone` will not be used, but by downloading the zip or tar.gz package. At this time, the failure to read the commit hash will fail to build. A concrete example is to build the Rust software via the openSUSE Build Service: https://build.opensuse.org/package/show/X11:terminals/alacritty.
2. On my local git version `2.21.0`, the `rustc_tools_util::get_commit_hash` function will not return `None` even if it does not read the commit hash, but instead returns a `Some("")`, An empty string. This causes the `expect` to never be triggered to terminate the build.

If the `rustc_tools_util::get_commit_hash` function does not get a commit hash (empty string) then the environment variable is read. I think this will solve both problems at the same time.

Even if you decide not to merge this commit, I still hope to improve `build.rs` so that it can be built without the .git directory.

Thanks!