### PR TITLE
Compatible without git

### DIFF
--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -13,10 +13,6 @@
 // limitations under the License.
 
 fn main() {
-    let mut hash = rustc_tools_util::get_commit_hash().unwrap_or("".to_owned());
-    if hash.is_empty() {
-        hash = std::env::var("GIT_HASH").expect("couldn't get commit hash");
-    }
-
+    let hash = rustc_tools_util::get_commit_hash().unwrap_or("".to_owned());
     println!("cargo:rustc-env=GIT_HASH={}", hash);
 }

--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 fn main() {
-    let hash = rustc_tools_util::get_commit_hash().unwrap_or("".to_owned());
+    let hash = rustc_tools_util::get_commit_hash().unwrap_or_default();
     println!("cargo:rustc-env=GIT_HASH={}", hash);
 }

--- a/alacritty/build.rs
+++ b/alacritty/build.rs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 fn main() {
-    let hash = rustc_tools_util::get_commit_hash().expect("couldn't get commit hash");
+    let mut hash = rustc_tools_util::get_commit_hash().unwrap_or("".to_owned());
+    if hash.is_empty() {
+        hash = std::env::var("GIT_HASH").expect("couldn't get commit hash");
+    }
+
     println!("cargo:rustc-env=GIT_HASH={}", hash);
 }

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -61,16 +61,16 @@ impl Default for Options {
 impl Options {
     /// Build `Options` from command line arguments.
     pub fn new() -> Self {
-        let mut options = Options::default();
+        let mut version = crate_version!().to_owned();
         let commit_hash = env!("GIT_HASH");
-        let version_string = if commit_hash.is_empty() {
-            format!("{}", crate_version!())
-        } else {
-            format!("{} ({})", crate_version!(), commit_hash)
-        };
+        if !commit_hash.is_empty() {
+            version = format!("{} ({})", version, commit_hash);
+        }
+
+        let mut options = Options::default();
 
         let matches = App::new(crate_name!())
-            .version(version_string.as_str())
+            .version(version.as_str())
             .author(crate_authors!("\n"))
             .about(crate_description!())
             .arg(Arg::with_name("ref-test").long("ref-test").help("Generates ref test"))

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -62,8 +62,12 @@ impl Options {
     /// Build `Options` from command line arguments.
     pub fn new() -> Self {
         let mut options = Options::default();
-
-        let version_string = format!("{} ({})", crate_version!(), env!("GIT_HASH"));
+        let commit_hash = env!("GIT_HASH");
+        let version_string = if commit_hash.is_empty() {
+            format!("{}", crate_version!())
+        } else {
+            format!("{} ({})", crate_version!(), commit_hash)
+        };
 
         let matches = App::new(crate_name!())
             .version(version_string.as_str())


### PR DESCRIPTION
Follow the discussion plan for [PR#2441](https://github.com/jwilm/alacritty/pull/2441). The ultimate goal is to continue building without `git` installed or without getting a commit hash, and correctly output `--version`.
The build script for openSUSE or other Linux distribution continues to be compatible without any source code patches.