### PR TITLE
update license-file path again now that mmstick/cargo-deb#94 is fixed

### DIFF
--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -38,7 +38,7 @@ bench = []
 
 [package.metadata.deb]
 maintainer = "Joe Wilm <joe@jwilm.com>"
-license-file = ["LICENSE-APACHE", "3"]
+license-file = ["../LICENSE-APACHE", "3"]
 extended-description = """\
 Alacritty is the fastest terminal emulator in existence. Using the GPU for \
 rendering enables optimizations that simply aren't possible without it.  """


### PR DESCRIPTION
Make license-path for cargo-deb relative again now that the behavior has been changed in mmstick/cargo-deb#94. 

This means that as of cargo-deb 1.18.0, a relative path is required for the cargo-deb build to succeed in the supported and documented `cargo deb --install --manifest-path alacritty/Cargo.toml` manner as per the alacritty [instructions](https://github.com/jwilm/alacritty/blob/master/INSTALL.md#debianubuntu-1).

Previously #2379 and #2423.