### PR TITLE
Add macro for boilerplate combination errors

### DIFF
--- a/alacritty_terminal/src/display.rs
+++ b/alacritty_terminal/src/display.rs
@@ -35,63 +35,11 @@ use crate::term::{RenderableCell, SizeInfo, Term};
 use crate::window::{self, Window};
 use font::{self, Rasterize};
 
-#[derive(Debug)]
-pub enum Error {
-    /// Error with window management
-    Window(window::Error),
-
-    /// Error dealing with fonts
-    Font(font::Error),
-
-    /// Error in renderer
-    Render(renderer::Error),
-}
-
-impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
-        match *self {
-            Error::Window(ref err) => Some(err),
-            Error::Font(ref err) => Some(err),
-            Error::Render(ref err) => Some(err),
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::Window(ref err) => err.description(),
-            Error::Font(ref err) => err.description(),
-            Error::Render(ref err) => err.description(),
-        }
-    }
-}
-
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match *self {
-            Error::Window(ref err) => err.fmt(f),
-            Error::Font(ref err) => err.fmt(f),
-            Error::Render(ref err) => err.fmt(f),
-        }
-    }
-}
-
-impl From<window::Error> for Error {
-    fn from(val: window::Error) -> Error {
-        Error::Window(val)
-    }
-}
-
-impl From<font::Error> for Error {
-    fn from(val: font::Error) -> Error {
-        Error::Font(val)
-    }
-}
-
-impl From<renderer::Error> for Error {
-    fn from(val: renderer::Error) -> Error {
-        Error::Render(val)
-    }
-}
+combination_err!(Error, {
+    Window: (window::Error),
+    Font: (font::Error),
+    Render: (renderer::Error)
+});
 
 /// The display wraps a window, font rasterizer, and GPU renderer
 pub struct Display {

--- a/alacritty_terminal/src/macros.rs
+++ b/alacritty_terminal/src/macros.rs
@@ -19,3 +19,86 @@ macro_rules! die {
         ::std::process::exit(1);
     }}
 }
+
+macro_rules! combination_err_base {
+    ($ename:ident, { $( $variant:ident: $inner:ty ),+ }) => {
+        #[derive(Debug)]
+        pub enum $ename {
+            $(
+                $variant($inner)
+            ),*
+        }
+
+        impl $ename {
+            #[inline(always)]
+            fn inner_error(&self) -> &dyn ::std::error::Error {
+                match *self {
+                    $(
+                        $ename::$variant(ref err) => err,
+                    )*
+                }
+            }
+        }
+
+        $(
+            impl From<$inner> for $ename {
+                fn from(val: $inner) -> Self {
+                    $ename::$variant(val)
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! combination_err {
+    ($ename:ident, { $( $variant:ident : $inner:ty ),+ }) => {
+        combination_err_base!($ename, { $( $variant : $inner ),* });
+
+        impl ::std::error::Error for $ename {
+            fn cause(&self) -> Option<&dyn (::std::error::Error)> {
+                Some(self.inner_error())
+            }
+
+            fn description(&self) -> &str {
+                self.source().unwrap().description()
+            }
+        }
+
+        impl ::std::fmt::Display for $ename {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                std::fmt::Display::fmt(self.inner_error(), f)
+            }
+        }
+    };
+    ($ename:ident, { $( $variant:ident : $inner:ty : $description:expr ),+ }) => {
+        combination_err_base!($ename, { $( $variant : $inner ),* });
+
+        impl ::std::error::Error for $ename {
+            fn cause(&self) -> Option<&dyn (::std::error::Error)> {
+                Some(self.inner_error())
+            }
+
+            fn description(&self) -> &str {
+                match *self {
+                    $(
+                        $ename::$variant(..) => $description,
+                    )*
+                }
+            }
+        }
+
+        impl ::std::fmt::Display for $ename {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                let description = {
+                    use std::error::Error;
+                    self.description()
+                };
+                match *self {
+                    $(
+                        $ename::$variant(ref err) => write!(f, "{}: {}", description, err),
+                    )*
+                }
+            }
+        }
+    };
+}

--- a/alacritty_terminal/src/renderer/mod.rs
+++ b/alacritty_terminal/src/renderer/mod.rs
@@ -72,40 +72,9 @@ enum Msg {
     ShaderReload,
 }
 
-#[derive(Debug)]
-pub enum Error {
-    ShaderCreation(ShaderCreationError),
-}
-
-impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
-        match *self {
-            Error::ShaderCreation(ref err) => Some(err),
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::ShaderCreation(ref err) => err.description(),
-        }
-    }
-}
-
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match *self {
-            Error::ShaderCreation(ref err) => {
-                write!(f, "There was an error initializing the shaders: {}", err)
-            },
-        }
-    }
-}
-
-impl From<ShaderCreationError> for Error {
-    fn from(val: ShaderCreationError) -> Error {
-        Error::ShaderCreation(val)
-    }
-}
+combination_err!(Error, {
+    ShaderCreation: ShaderCreationError: "There was an error initializing the shaders"
+});
 
 /// Text drawing program
 ///

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -14,7 +14,6 @@
 use std::convert::From;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use std::ffi::c_void;
-use std::fmt::Display;
 
 use crate::gl;
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
@@ -40,15 +39,10 @@ static WINDOW_ICON: &'static [u8] = include_bytes!("../../extra/windows/alacritt
 /// Default Alacritty name, used for window title and class.
 pub const DEFAULT_NAME: &str = "Alacritty";
 
-/// Window errors
-#[derive(Debug)]
-pub enum Error {
-    /// Error creating the window
-    ContextCreation(glutin::CreationError),
-
-    /// Error manipulating the rendering context
-    Context(glutin::ContextError),
-}
+combination_err!(Error, {
+    ContextCreation: glutin::CreationError: "Error creating gl context",
+    Context: glutin::ContextError: "Error operating on render context"
+});
 
 /// Result of fallible operations concerning a Window.
 type Result<T> = ::std::result::Result<T, Error>;
@@ -80,43 +74,6 @@ pub struct DeviceProperties {
     /// This will be 1. on standard displays and may have a different value on
     /// hidpi displays.
     pub scale_factor: f64,
-}
-
-impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
-        match *self {
-            Error::ContextCreation(ref err) => Some(err),
-            Error::Context(ref err) => Some(err),
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::ContextCreation(ref _err) => "Error creating gl context",
-            Error::Context(ref _err) => "Error operating on render context",
-        }
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        match *self {
-            Error::ContextCreation(ref err) => write!(f, "Error creating GL context; {}", err),
-            Error::Context(ref err) => write!(f, "Error operating on render context; {}", err),
-        }
-    }
-}
-
-impl From<glutin::CreationError> for Error {
-    fn from(val: glutin::CreationError) -> Error {
-        Error::ContextCreation(val)
-    }
-}
-
-impl From<glutin::ContextError> for Error {
-    fn from(val: glutin::ContextError) -> Error {
-        Error::Context(val)
-    }
 }
 
 fn create_gl_window(


### PR DESCRIPTION
Hey,

I've been working on some `alacritty`-related stuff just for fun, and found that adding *anything* to these `Error` enums was quite painful. This patch would provide macros (for internal use) that allow easy generation of the boilerplate for error-container enums.

It's just a simple refactor, but I'm hoping to gain some experience with the contribution process before I contribute my larger projects down the line (if they pan out).

Thanks in advance for the help.