### PR TITLE
Add Gentoo install dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -156,7 +156,7 @@ Alacritty. Here's a `eopkg` command that should install all of them. If
 something is still found to be missing, please open an issue.
 
 ```sh
-sudo eopkg install fontconfig-devel
+eopkg install fontconfig-devel
 ```
 
 #### NixOS/Nixpkgs
@@ -175,7 +175,7 @@ command should install all of them. If something is still found to be missing,
 please open an issue.
 
 ```sh
-emerge media-libs/fontconfig media-libs/freetype:2 sys-devel/make dev-util/cmake dev-util/pkgconfig
+emerge --onlydeps x11-terms/alacritty
 ```
 
 #### Windows

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -168,6 +168,16 @@ dependencies on [NixOS](https://nixos.org).
 nix-shell -A alacritty '<nixpkgs>'
 ```
 
+#### Gentoo
+
+On Gentoo, you need a few extra libraries to build Alacritty. The following
+command should install all of them. If something is still found to be missing,
+please open an issue.
+
+```sh
+emerge media-libs/fontconfig media-libs/freetype:2 sys-devel/make dev-util/cmake dev-util/pkgconfig
+```
+
 #### Windows
 
 On windows you will need to have the `{architecture}-pc-windows-msvc` toolchain


### PR DESCRIPTION
While Gentoo was listed in the table of contents of the INSTALL.md, the
instructions to install the build dependencies were missing.

This adds the emerge command necessary to install all dependencies of
Alacritty (other than Rust) so building from source without the overlay
is possible.