### PR TITLE
Skip UTF-8 BOM when reading config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On macOS, automatic graphics switching has been enabled again
 - Text getting recognized as URLs without slashes separating the scheme
 - URL parser dropping trailing slashes from valid URLs
+- UTF-8 BOM skipped when reading config file
 
 ### Removed
 

--- a/alacritty/src/config.rs
+++ b/alacritty/src/config.rs
@@ -176,8 +176,17 @@ pub fn reload_from(path: &PathBuf) -> Result<Config> {
 }
 
 fn read_config(path: &PathBuf) -> Result<Config> {
-    let mut contents = String::new();
-    File::open(path)?.read_to_string(&mut contents)?;
+    let mut bytes_vec = Vec::new();
+    let mut f = File::open(path)?;
+    f.read_to_end(&mut bytes_vec)?;
+    let mut bytes: &[u8] = &bytes_vec;
+
+    // Skip UTF-8 BOM
+    if bytes.starts_with(&[0xef, 0xbb, 0xbf]) {
+        bytes = &bytes[3..];
+    }
+
+    let contents = String::from_utf8_lossy(&bytes);
 
     // Prevent parsing error with empty string
     if contents.is_empty() {

--- a/alacritty/src/config.rs
+++ b/alacritty/src/config.rs
@@ -176,17 +176,13 @@ pub fn reload_from(path: &PathBuf) -> Result<Config> {
 }
 
 fn read_config(path: &PathBuf) -> Result<Config> {
-    let mut bytes_vec = Vec::new();
-    let mut f = File::open(path)?;
-    f.read_to_end(&mut bytes_vec)?;
-    let mut bytes: &[u8] = &bytes_vec;
+    let mut contents = String::new();
+    File::open(path)?.read_to_string(&mut contents)?;
 
-    // Skip UTF-8 BOM
-    if bytes.starts_with(&[0xef, 0xbb, 0xbf]) {
-        bytes = &bytes[3..];
+    // Remove UTF-8 BOM
+    if contents.chars().nth(0) == Some('\u{FEFF}') {
+        contents = contents.split_off(3);
     }
-
-    let contents = String::from_utf8_lossy(&bytes);
 
     // Prevent parsing error with empty string
     if contents.is_empty() {


### PR DESCRIPTION
I'm currently stuck with Notepad when editing the config file and it insists on adding a BOM when saving it. Alacritty errors when loading the config file due to it and so this patch adds code to skip the BOM.

Note that my Rust knowledge is basically based on Googling for how-to-do-stuff and interpreting the results, so any improvements to the code are welcome.