### PR TITLE
Add foreground/background request escape codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config group `debug` with the options `debug.log_level`, `debug.print_events`
     and `debug.ref_test`
 - Select until next matching bracket when double-clicking a bracket
+- Added foreground/background escape code request sequences
 
 ### Changed
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -332,6 +332,9 @@ pub trait Handler {
     /// Set an indexed color value
     fn set_color(&mut self, _: usize, _: Rgb) {}
 
+    /// Write a foreground/background color escape sequence with the current color
+    fn dynamic_color_sequence<W: io::Write>(&mut self, _: &mut W, _: u8, _: usize) {}
+
     /// Reset an indexed color to original value
     fn reset_color(&mut self, _: usize) {}
 
@@ -741,6 +744,8 @@ where
     // TODO replace OSC parsing with parser combinators
     #[inline]
     fn osc_dispatch(&mut self, params: &[&[u8]]) {
+        let writer = &mut self.writer;
+
         fn unhandled(params: &[&[u8]]) {
             let mut buf = String::new();
             for items in params {
@@ -788,22 +793,28 @@ where
                 unhandled(params);
             },
 
-            // Set foreground color
+            // Get/set foreground color
             b"10" => {
                 if params.len() >= 2 {
                     if let Some(color) = parse_rgb_color(params[1]) {
                         self.handler.set_color(NamedColor::Foreground as usize, color);
+                        return;
+                    } else if params[1] == b"?" {
+                        self.handler.dynamic_color_sequence(writer, 10, NamedColor::Foreground as usize);
                         return;
                     }
                 }
                 unhandled(params);
             },
 
-            // Set background color
+            // Get/set background color
             b"11" => {
                 if params.len() >= 2 {
                     if let Some(color) = parse_rgb_color(params[1]) {
                         self.handler.set_color(NamedColor::Background as usize, color);
+                        return;
+                    } else if params[1] == b"?" {
+                        self.handler.dynamic_color_sequence(writer, 11, NamedColor::Background as usize);
                         return;
                     }
                 }

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -800,7 +800,11 @@ where
                         self.handler.set_color(NamedColor::Foreground as usize, color);
                         return;
                     } else if params[1] == b"?" {
-                        self.handler.dynamic_color_sequence(writer, 10, NamedColor::Foreground as usize);
+                        self.handler.dynamic_color_sequence(
+                            writer,
+                            10,
+                            NamedColor::Foreground as usize,
+                        );
                         return;
                     }
                 }
@@ -814,7 +818,11 @@ where
                         self.handler.set_color(NamedColor::Background as usize, color);
                         return;
                     } else if params[1] == b"?" {
-                        self.handler.dynamic_color_sequence(writer, 11, NamedColor::Background as usize);
+                        self.handler.dynamic_color_sequence(
+                            writer,
+                            11,
+                            NamedColor::Background as usize,
+                        );
                         return;
                     }
                 }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1875,11 +1875,7 @@ impl ansi::Handler for Term {
     fn dynamic_color_sequence<W: io::Write>(&mut self, writer: &mut W, code: u8, index: usize) {
         trace!("Writing escape sequence for dynamic color code {}: color[{}]", code, index);
         let color = self.colors[index];
-        let _ = write!(
-            writer,
-            "\x1b]{};rgb:{:x}/{:x}/{:x}\x07",
-            code, color.r, color.g, color.b
-        );
+        let _ = write!(writer, "\x1b]{};rgb:{:x}/{:x}/{:x}\x07", code, color.r, color.g, color.b);
     }
 
     /// Reset the indexed color to original value

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1870,6 +1870,18 @@ impl ansi::Handler for Term {
         self.color_modified[index] = true;
     }
 
+    /// Write a foreground/background color escape sequence with the current color
+    #[inline]
+    fn dynamic_color_sequence<W: io::Write>(&mut self, writer: &mut W, code: u8, index: usize) {
+        trace!("Writing escape sequence for dynamic color code {}: color[{}]", code, index);
+        let color = self.colors[index];
+        let _ = write!(
+            writer,
+            "\x1b]{};rgb:{:x}/{:x}/{:x}\x07",
+            code, color.r, color.g, color.b
+        );
+    }
+
     /// Reset the indexed color to original value
     #[inline]
     fn reset_color(&mut self, index: usize) {


### PR DESCRIPTION
When a "?" is given rather than a color in xterm for foreground/background escape codes, the current color is returned. This can be and is used by programs such as vim to preserve readability.

I have based the output format directly on xterm.