### PR TITLE
Install docs: Linux/windows headline and link

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@
         14. [Clear Linux](#clear-linux)
         15. [Other](#other)
 2. [Building](#building)
-    1. [Linux](#linux)
+    1. [Linux/Windows](#linux--windows)
         1. [Desktop Entry](#desktop-entry)
     2. [MacOS](#macos)
     3. [Cargo](#cargo)


### PR DESCRIPTION
Since the headline was changes, the relative link wasn't working anymore.

(minor)