### PR TITLE
Follow full xparsecolor spec in escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     and `debug.ref_test`
 - Select until next matching bracket when double-clicking a bracket
 - Added foreground/background escape code request sequences
+- Escape sequences now support 1, 3, and 4 digit hex colors
 
 ### Changed
 


### PR DESCRIPTION
Escape sequences in xterm are parsed according to xparsecolor. xparsecolor supports 1, 2, 3, and 4 digit hex colors. Previously, only 2 digits were supported.

This also fixes a bug where "fX" was parsed as "0xf" instead of "0xf0". xterm handles invalid hex values as 0, except for '/'.

The response to a request for fg/bg must be a valid escape sequence. Most terminals output a 4-digit hex response on request for fg/bg color. This changes the response to 4-digit, improving compatibility.

- [xterm control sequence document referencing xparsecolor](https://www.xfree86.org/current/ctlseqs.html)
- [xparsecolor spec describing the valid colors](https://linux.die.net/man/3/xparsecolor)
- [context for why we were using 2-digit color hex responses](https://github.com/jwilm/alacritty/pull/2495#discussion_r289637940)
