### PR TITLE
RPM packaging

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,14 @@
+version := $(shell rpmspec -q --srpm --qf "%{version}\n" extra/linux/redhat/alacritty.spec)
+commands = git
+
+srpm: $(commands)
+	$(eval top := $(shell mktemp -d))
+	mkdir -p "$(top)/SOURCES"
+	git archive HEAD --output "$(top)/SOURCES/alacritty-$(version).tar" --prefix "alacritty-$(version)/"
+	rpmbuild -bs "$(spec)" --define "_topdir $(top)" --define "_srcrpmdir $(outdir)"
+	rm -rf "$(top)"
+
+$(commands):
+	command -v $@ &> /dev/null || dnf -y install $@
+
+.PHONY: srpm $(commands)

--- a/extra/linux/redhat/alacritty.spec
+++ b/extra/linux/redhat/alacritty.spec
@@ -7,7 +7,7 @@ URL:           https://github.com/jwilm/alacritty
 VCS:           https://github.com/jwilm/alacritty.git
 Source:        alacritty-%{version}.tar
 
-BuildRequires: rust >= 1.31.0
+BuildRequires: rust >= 1.32.0
 BuildRequires: cargo
 BuildRequires: cmake
 BuildRequires: freetype-devel

--- a/extra/linux/redhat/alacritty.spec
+++ b/extra/linux/redhat/alacritty.spec
@@ -1,0 +1,56 @@
+Name:          alacritty
+Version:       0.3.2
+Release:       1%{?dist}
+Summary:       A cross-platform, GPU enhanced terminal emulator
+License:       ASL 2.0
+URL:           https://github.com/jwilm/alacritty
+VCS:           https://github.com/jwilm/alacritty.git
+Source:        alacritty-%{version}.tar
+
+BuildRequires: rust >= 1.31.0
+BuildRequires: cargo
+BuildRequires: cmake
+BuildRequires: freetype-devel
+BuildRequires: fontconfig-devel
+BuildRequires: libxcb-devel
+BuildRequires: desktop-file-utils
+BuildRequires: python36
+
+%description
+Alacritty is a terminal emulator with a strong focus on simplicity and
+performance. With such a strong focus on performance, included features are
+carefully considered and you can always expect Alacritty to be blazingly fast.
+By making sane choices for defaults, Alacritty requires no additional setup.
+However, it does allow configuration of many aspects of the terminal.
+
+%prep
+%setup -q -n alacritty-%{version}
+
+%build
+cargo build --release
+
+%install
+install -p -D -m755 target/release/alacritty         %{buildroot}%{_bindir}/alacritty
+install -p -D -m644 extra/linux/alacritty.desktop    %{buildroot}%{_datadir}/applications/alacritty.desktop
+install -p -D -m644 extra/logo/alacritty-term.svg    %{buildroot}%{_datadir}/pixmaps/Alacritty.svg
+install -p -D -m644 alacritty.yml                    %{buildroot}%{_datadir}/alacritty/alacritty.yml
+tic     -xe alacritty,alacritty-direct \
+                    extra/alacritty.info       -o    %{buildroot}%{_datadir}/terminfo
+install -p -D -m644 extra/completions/alacritty.bash %{buildroot}%{_datadir}/bash-completion/completions/alacritty
+install -p -D -m644 extra/completions/_alacritty     %{buildroot}%{_datadir}/zsh/site-functions/_alacritty
+install -p -D -m644 extra/completions/alacritty.fish %{buildroot}%{_datadir}/fish/vendor_completions.d/alacritty.fish
+install -p -D -m644 extra/alacritty.man              %{buildroot}%{_mandir}/man1/alacritty.1
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/alacritty.desktop
+
+%files
+%{_bindir}/alacritty
+%{_datadir}/applications/alacritty.desktop
+%{_datadir}/pixmaps/Alacritty.svg
+%{_datadir}/alacritty/alacritty.yml
+%{_datadir}/terminfo/a/alacritty*
+%{_datadir}/bash-completion/completions/alacritty
+%{_datadir}/zsh/site-functions/_alacritty
+%{_datadir}/fish/vendor_completions.d/alacritty.fish
+%{_mandir}/man1/alacritty.1*


### PR DESCRIPTION
I added a specfile template that enables building alacritty with [rpkg](https://docs.pagure.org/rpkg-util/), for example in [COPR](https://copr.fedorainfracloud.org). I would be happy to maintain an inofficial COPR repo that we could mention in README.md for Fedora and EL7/Centos users.

I hope I got all the building and installation steps right, but it seems to work fine in my testing.

Is libEGL a build or a runtime dependency? I was able to build without the package mesa-libEGL-devel . I could add mesa-libEGL (no -dev) as Requires: if it's a runtime dependency.

I had to base this on #2443, as the rpmbuild chroot is not a git repository, and the build failed otherwise.
Unfortunately, I was unable to place the files into extra/linux/rpm or similar, because rpkg expects the macros in the project root.

Lastly, I made some assumptions when generating the RPM package version: I take the output of git describe, replace dashes with dots and drop the leading "v" from the tag name. I didn't want to repeat the crate version in the spec template so it doesn't need to be bumped for every release.
(N.B. `git_version` is a built-in rpkg macro, but I override it because it expects a specific tagging scheme in the repo).
