### PR TITLE
Dynamic color code escapes for foreground/background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pressing enter on the numpad should now insert a newline
 - The mouse bindings now support keyboard modifiers (shift/ctrl/alt/super)
 - Add support for the bright foreground color
+- Support for setting foreground, background colors in one escape sequence
 
 ### Changed
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -801,7 +801,7 @@ where
                             // 10 is the first dynamic color, also the foreground
                             let offset = dynamic_code as usize - 10;
                             let index = NamedColor::Foreground as usize + offset;
-                            
+
                             // End of setting dynamic colors
                             if index > NamedColor::Cursor as usize {
                                 unhandled(params);
@@ -811,11 +811,7 @@ where
                             if let Some(color) = parse_rgb_color(param) {
                                 self.handler.set_color(index, color);
                             } else if param == b"?" {
-                                self.handler.dynamic_color_sequence(
-                                    writer,
-                                    dynamic_code,
-                                    index,
-                                );
+                                self.handler.dynamic_color_sequence(writer, dynamic_code, index);
                             } else {
                                 unhandled(params);
                             }


### PR DESCRIPTION
Saw https://github.com/jwilm/alacritty/issues/2497 and decided to take a crack at it

Recursively causes os dispatch to parse the next
parameters, as if they were entered with their
own escape codes

Not too familiar with rust but seems like this 
would be tail recursive

before:
![Screen Shot 2019-06-04 at 4 56 34 PM](https://user-images.githubusercontent.com/24661601/58913242-c0b37880-86e9-11e9-8c8e-aa4edfb405a0.png)

after:
![Screen Shot 2019-06-04 at 4 56 39 PM](https://user-images.githubusercontent.com/24661601/58913243-c1e4a580-86e9-11e9-80b9-533d91279d4a.png)

