### PR TITLE
Fix index out of bounds during selection

### DIFF
--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -71,12 +71,6 @@ impl From<Point> for Point<usize> {
     }
 }
 
-impl From<Point<usize>> for Point {
-    fn from(point: Point<usize>) -> Self {
-        Point::new(Line(point.line), point.col)
-    }
-}
-
 impl From<&RenderableCell> for Point<Line> {
     fn from(cell: &RenderableCell) -> Self {
         Point::new(cell.line, cell.column)

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -71,6 +71,12 @@ impl From<Point> for Point<usize> {
     }
 }
 
+impl From<Point<usize>> for Point {
+    fn from(point: Point<usize>) -> Self {
+        Point::new(Line(point.line), point.col)
+    }
+}
+
 impl From<&RenderableCell> for Point<Line> {
     fn from(cell: &RenderableCell) -> Self {
         Point::new(cell.line, cell.column)


### PR DESCRIPTION
This reworks the selection logic to prevent any possible index out of
bounds exceptions by clamping the start and end points before doing
anything else with them when converting selections to spans.

This also fixes a bug where semantic selections would not automatically
expand across double-width characters.

Fixes #2486.