### PR TITLE
Unset DESKTOP_STARTUP_ID environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- GUI programs launched by Alacritty starting in the background on X11
+
 ## 0.3.3
 
 ### Packaging

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -89,6 +89,9 @@ pub fn setup_env(config: &Config) {
     // Advertise 24-bit color support
     env::set_var("COLORTERM", "truecolor");
 
+    // Prevent child processes from inheriting startup notification env
+    env::remove_var("DESKTOP_STARTUP_ID");
+
     // Set env vars from config
     for (key, value) in config.env.iter() {
         env::set_var(key, value);


### PR DESCRIPTION
This unsets the DESKTOP_STARTUP_ID environment variable at startup, to
prevent child processes from inheriting it. This solves problems with
child windows not properly spawning in the foreground with KDE.

More information can be found here:
https://specifications.freedesktop.org/startup-notification-spec/startup-notification-latest.txt

Fixes https://github.com/jwilm/alacritty/issues/2515.