### PR TITLE
Update OpenBSD installation to reflect rust-xcb python3 build dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -141,13 +141,15 @@ pkg install cmake freetype2 fontconfig pkgconf
 
 #### OpenBSD
 
-Alacritty builds on OpenBSD 6.3 almost out-of-the-box if Rust and
-[Xenocara](https://xenocara.org) are installed.  If something is still found to
-be missing, please open an issue.
+On OpenBSD 6.5, you need [Xenocara](https://xenocara.org) and Rust to build
+Alacritty, plus Python 3 to build its XCB dependency. If something is still
+found to be missing, please open an issue.
 
 ```sh
-pkg_add rust
+pkg_add rust python
 ```
+
+Select the package for Python 3 (e.g. `python-3.6.8p0`) when prompted.
 
 #### Solus
 


### PR DESCRIPTION
Without having installed the Python 3 package, the Alacritty build fails as rust-xcb requires it:
```
error: failed to run custom build command for `xcb v0.8.2`
process didn't exit successfully: `/home/pwrdwnsys/building/alacritty/target/release/build/xcb-581edfd7cf040f3d/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'Unable to find build dependency python3: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/libcore/result.rs:997:5
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```