### PR TITLE
Fix dynamic color escape response

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1602,7 +1602,8 @@ impl ansi::Handler for Term {
             },
             6 => {
                 let pos = self.cursor.point;
-                let _ = write!(writer, "\x1b[{};{}R", pos.line + 1, pos.col + 1);
+                let response = format!("\x1b[{};{}R", pos.line + 1, pos.col + 1);
+                let _ = writer.write_all(response.as_bytes());
             },
             _ => debug!("unknown device status query: {}", arg),
         };
@@ -1883,11 +1884,11 @@ impl ansi::Handler for Term {
     fn dynamic_color_sequence<W: io::Write>(&mut self, writer: &mut W, code: u8, index: usize) {
         trace!("Writing escape sequence for dynamic color code {}: color[{}]", code, index);
         let color = self.colors[index];
-        let _ = write!(
-            writer,
+        let response = format!(
             "\x1b]{};rgb:{1:02x}{1:02x}/{2:02x}{2:02x}/{3:02x}{3:02x}\x07",
             code, color.r, color.g, color.b
         );
+        let _ = writer.write_all(response.as_bytes());
     }
 
     /// Reset the indexed color to original value

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1883,7 +1883,11 @@ impl ansi::Handler for Term {
     fn dynamic_color_sequence<W: io::Write>(&mut self, writer: &mut W, code: u8, index: usize) {
         trace!("Writing escape sequence for dynamic color code {}: color[{}]", code, index);
         let color = self.colors[index];
-        let _ = write!(writer, "\x1b]{};rgb:{:x}/{:x}/{:x}\x07", code, color.r, color.g, color.b);
+        let _ = write!(
+            writer,
+            "\x1b]{};rgb:{1:02x}{1:02x}/{2:02x}{2:02x}/{3:02x}{3:02x}\x07",
+            code, color.r, color.g, color.b
+        );
     }
 
     /// Reset the indexed color to original value


### PR DESCRIPTION
The dynamic color escape response would answer to requests with
rgb:0/0/0 when the color was completely black, instead of properly
responding with double-digit hex colors. This has been changed so that
Alacritty now alwaysy properly responds with the same number of hex
digits for all colors.

The number of digits has also been changed from two to four digits per
color, since that is the more commonly used format.

Fixes #2543.