### PR TITLE
Add block selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Block selection mode when Control is held while starting a selection
+
 ### Fixed
 
 - GUI programs launched by Alacritty starting in the background on X11

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -102,6 +102,12 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         self.terminal.dirty = true;
     }
 
+    fn block_selection(&mut self, point: Point, side: Side) {
+        let point = self.terminal.visible_to_buffer(point);
+        *self.terminal.selection_mut() = Some(Selection::block(point, side));
+        self.terminal.dirty = true;
+    }
+
     fn semantic_selection(&mut self, point: Point) {
         let point = self.terminal.visible_to_buffer(point);
         *self.terminal.selection_mut() = Some(Selection::semantic(point));

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -66,6 +66,7 @@ pub trait ActionContext {
     fn clear_selection(&mut self);
     fn update_selection(&mut self, point: Point, side: Side);
     fn simple_selection(&mut self, point: Point, side: Side);
+    fn block_selection(&mut self, point: Point, side: Side);
     fn semantic_selection(&mut self, point: Point);
     fn line_selection(&mut self, point: Point);
     fn selection_is_empty(&self) -> bool;
@@ -612,7 +613,11 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 // Start new empty selection
                 let side = self.ctx.mouse().cell_side;
                 if let Some(point) = point {
-                    self.ctx.simple_selection(point, side);
+                    if modifiers.ctrl {
+                        self.ctx.block_selection(point, side);
+                    } else {
+                        self.ctx.simple_selection(point, side);
+                    }
                 }
 
                 let report_modes =
@@ -990,6 +995,8 @@ mod tests {
         fn update_selection(&mut self, _point: Point, _side: Side) {}
 
         fn simple_selection(&mut self, _point: Point, _side: Side) {}
+
+        fn block_selection(&mut self, _point: Point, _side: Side) {}
 
         fn copy_selection(&mut self, _: ClipboardType) {}
 


### PR DESCRIPTION
This implements a block selection mode which can be triggered by holding
Control before starting a selection.

If text is copied using this block selection, newlines will be
automatically added to the end of the lines.

This fixes #526.