### PR TITLE
Bump appdata to v0.3.3

### DIFF
--- a/extra/linux/io.alacritty.Alacritty.appdata.xml
+++ b/extra/linux/io.alacritty.Alacritty.appdata.xml
@@ -28,7 +28,7 @@ However, it does allow configuration of many aspects of the terminal.</p>
   <url type="homepage">https://github.com/jwilm/alacritty</url>
   <url type="bugtracker">https://github.com/jwilm/alacritty/issues</url>
   <releases>
-    <release version="0.3.2" date="19.04.24" unix_timestamp="1556145865"/>
+    <release version="0.3.3" date="2019-06-16" unix_timestamp="1560694196"/>
   </releases>
   <update_contact>https://github.com/jwilm/alacritty/blob/master/CONTRIBUTING.md#contact</update_contact>
   <developer_name>Joe Wilm</developer_name> 


### PR DESCRIPTION
The timestamp is that of when the `v0.3.3` tag was created.

While at it, I also changed the date format to follow ISO 8601 :+1: