### PR TITLE
RFC: Dump scrollback buffer to new instance of alacritty running a pager

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -28,6 +28,7 @@ pub struct Options {
     pub live_config_reload: Option<bool>,
     pub print_events: bool,
     pub ref_test: bool,
+    pub inherit_stdin: bool,
     pub dimensions: Option<Dimensions>,
     pub position: Option<Delta<i32>>,
     pub title: Option<String>,
@@ -45,6 +46,7 @@ impl Default for Options {
             live_config_reload: None,
             print_events: false,
             ref_test: false,
+            inherit_stdin: false,
             dimensions: None,
             position: None,
             title: None,
@@ -84,6 +86,11 @@ impl Options {
                     .long("no-live-config-reload")
                     .help("Disable automatic config reloading")
                     .conflicts_with("live-config-reload"),
+            )
+            .arg(
+                Arg::with_name("inherit-stdin")
+                    .long("inherit-stdin")
+                    .help("Forward stdin to the command to be run.  Only useful with `-e`."),
             )
             .arg(
                 Arg::with_name("print-events")
@@ -172,6 +179,10 @@ impl Options {
             options.print_events = true;
         }
 
+        if matches.is_present("inherit-stdin") {
+            options.inherit_stdin = true;
+        }
+
         if matches.is_present("live-config-reload") {
             options.live_config_reload = Some(true);
         } else if matches.is_present("no-live-config-reload") {
@@ -246,6 +257,7 @@ impl Options {
             self.working_dir.or_else(|| config.working_directory().to_owned()),
         );
         config.shell = self.command.or(config.shell);
+        config.inherit_stdin = self.inherit_stdin;
 
         config.window.dimensions = self.dimensions.unwrap_or(config.window.dimensions);
         config.window.position = self.position.or(config.window.position);

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -95,6 +95,10 @@ pub struct Config {
     #[serde(default, deserialize_with = "failure_default")]
     pub shell: Option<Shell<'static>>,
 
+    /// Path to a pager to use for searching the scrollback buffer
+    #[serde(default, deserialize_with = "failure_default")]
+    pub pager: Option<Shell<'static>>,
+
     /// Path where config was loaded from
     #[serde(default, deserialize_with = "failure_default")]
     pub config_path: Option<PathBuf>,
@@ -337,7 +341,7 @@ impl Cursor {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct Shell<'a> {
     pub program: Cow<'a, str>,
 

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -137,6 +137,10 @@ pub struct Config {
     #[serde(default, deserialize_with = "failure_default")]
     working_directory: WorkingDirectory,
 
+    /// Forward stdin to `self.shell`
+    #[serde(default, deserialize_with = "failure_default")]
+    pub inherit_stdin: bool,
+
     /// Debug options
     #[serde(default, deserialize_with = "failure_default")]
     pub debug: Debug,

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -183,6 +183,10 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         }
     }
 
+    fn spawn_pager(&mut self) {
+        self.terminal.spawn_pager()
+    }
+
     fn toggle_fullscreen(&mut self) {
         self.window_changes.toggle_fullscreen();
     }

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -80,6 +80,7 @@ pub trait ActionContext {
     fn terminal(&self) -> &Term;
     fn terminal_mut(&mut self) -> &mut Term;
     fn spawn_new_instance(&mut self);
+    fn spawn_pager(&mut self);
     fn toggle_fullscreen(&mut self);
     #[cfg(target_os = "macos")]
     fn toggle_simple_fullscreen(&mut self);
@@ -254,6 +255,10 @@ pub enum Action {
     /// Spawn a new instance of Alacritty.
     SpawnNewInstance,
 
+    /// Dump the contents of the scrollback buffer into a new instance of
+    /// alacritty running a pager.
+    SpawnPager,
+
     /// Toggle fullscreen.
     ToggleFullscreen,
 
@@ -349,6 +354,9 @@ impl Action {
             },
             Action::SpawnNewInstance => {
                 ctx.spawn_new_instance();
+            },
+            Action::SpawnPager => {
+                ctx.spawn_pager();
             },
             Action::None => (),
         }
@@ -998,6 +1006,8 @@ mod tests {
         fn hide_window(&mut self) {}
 
         fn spawn_new_instance(&mut self) {}
+
+        fn spawn_pager(&mut self) {}
 
         fn toggle_fullscreen(&mut self) {}
 

--- a/alacritty_terminal/src/tty/unix.rs
+++ b/alacritty_terminal/src/tty/unix.rs
@@ -180,7 +180,9 @@ pub fn new<T: ToWinsize>(config: &Config, size: &T, window_id: Option<usize>) ->
     // Ownership of fd is transferred to the Stdio structs and will be closed by them at the end of
     // this scope. (It is not an issue that the fd is closed three times since File::drop ignores
     // error on libc::close.)
-    builder.stdin(unsafe { Stdio::from_raw_fd(slave) });
+    let stdin =
+        if config.inherit_stdin { Stdio::inherit() } else { unsafe { Stdio::from_raw_fd(slave) } };
+    builder.stdin(stdin);
     builder.stderr(unsafe { Stdio::from_raw_fd(slave) });
     builder.stdout(unsafe { Stdio::from_raw_fd(slave) });
 


### PR DESCRIPTION
This is a potential compromise for fixing #1017.  Currently being unable to search the scrollback buffer severely limits its usefulness but at the same it's questionable whether this should be implemented directly in alacritty itself.

This PR adds an action to spawn a new instance of alacritty with a user specified pager and then dump the contents of the scrollback buffer into the stdin of the new instance.  This neatly sidesteps the issue of having to implement search functionality in alacritty itself while giving users the freedom to use whichever pager best suits their needs.  The default is `less` but there's nothing stopping someone from using an editor like `vim` as their pager instead.

The contents of the scrollback buffer are first converted into a string (by iterating over every occupied cell) before being written out, which means we end up with a copy of the buffer in memory.  However since this is something that is only done in response to explicit user action, it shouldn't end up getting out of hand.

This is probably not fit for merging in its current state but I wanted to ask if this is something that would be accepted upstream before spending time cleaning it up.