### PR TITLE
Fix inconsitent cursor position when scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - GUI programs launched by Alacritty starting in the background on X11
-- Cursor position when scrolling
+- Text Cursor position when scrolling
 
 ## 0.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - GUI programs launched by Alacritty starting in the background on X11
+- Cursor position when scrolling
 
 ## 0.3.3
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -436,7 +436,10 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                     let cell = Indexed {
                         inner: self.grid[self.cursor],
                         column: self.cursor.col,
-                        line: self.cursor.line,
+                        // Using `self.cursor.line` leads to inconsitent cursor position when
+                        // scrolling. See https://github.com/jwilm/alacritty/issues/2570 for more
+                        // info.
+                        line: self.inner.line(),
                     };
 
                     let mut renderable_cell =


### PR DESCRIPTION
This commit fixes regression introduced in cfc20d4f34dca535654cc32df18e785296af4cc5.
`self.cursor.line` forced the cursor to hold a fixed location while scrolling
until its "original" location (usually the shell prompt) went off the screen.
So cursor position should be keep updated, which can be achieved by using
`self.inner.line()`.

cc @chrisduerr @lovesegfault 