### PR TITLE
Perform clear + `swap_buffers` before `window.show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Text Cursor position when scrolling
 - Performance issues while resizing Alacritty
 - First unfullscreen action ignored on window launched in fullscreen mode
+- The window is now filled with the background color before displaying
 
 ## 0.3.3
 

--- a/alacritty_terminal/src/display.rs
+++ b/alacritty_terminal/src/display.rs
@@ -240,14 +240,13 @@ impl Display {
             window.set_position(logical);
         }
 
-        use StartupMode::*;
         #[allow(clippy::single_match)]
         match config.window.startup_mode() {
-            Fullscreen => window.set_fullscreen(true),
+            StartupMode::Fullscreen => window.set_fullscreen(true),
             #[cfg(target_os = "macos")]
-            SimpleFullscreen => window.set_simple_fullscreen(true),
-            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-            Maximized if window.is_x11() => window.set_maximized(true),
+            StartupMode::SimpleFullscreen => window.set_simple_fullscreen(true),
+            #[cfg(not(any(target_os = "macos", windows)))]
+            StartupMode::Maximized if window.is_x11() => window.set_maximized(true),
             _ => (),
         }
 


### PR DESCRIPTION
This should fill window with background color while it is offscreen instead of
showing uninitilized window (just borders) and then performing `clear`. So, the new behavior
should prevent glitches during startup (e.g. content of a windows below,
garbage from drivers, so on).

--
However, I was able to get glitches ( previous app content ) with the new behavior, but it happens 1 time out of 15-20 openings, instead of every time. So if someone knows how should I prevent this 1 time, I'll appreciate it.

P.s. I'm not very familiar with `opengl`, so if you see something completely wrong, let me know.