### PR TITLE
Disable text reflow on `ALT_SCREEN` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Block selection mode when Control is held while starting a selection
 
+### Changed
+
+- Text reflow is now disabled in `ALT_SCREEN` mode
+
 ### Fixed
 
 - GUI programs launched by Alacritty starting in the background on X11

--- a/alacritty_terminal/src/grid/storage.rs
+++ b/alacritty_terminal/src/grid/storage.rs
@@ -12,6 +12,7 @@
 /// implementation is provided. Anything from Vec that should be exposed must be
 /// done so manually.
 use std::ops::{Index, IndexMut};
+use std::slice;
 
 use static_assertions::assert_eq_size;
 
@@ -250,6 +251,15 @@ impl<T> Storage<T> {
 
         let len = self.inner.len();
         self.zero = (self.zero as isize + count + len as isize) as usize % len;
+    }
+
+    /// Iterate over *all* entries in the underlying buffer
+    ///
+    /// This includes hidden entries.
+    ///
+    /// NOTE: This method is only needed to perform resize without reflow functionality.
+    pub fn iter_mut_raw<'a>(&'a mut self) -> slice::IterMut<'a, Row<T>> {
+        self.inner.iter_mut()
     }
 
     // Fast path

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -140,7 +140,7 @@ fn shrink_reflow() {
     grid[Line(0)][Column(3)] = cell('4');
     grid[Line(0)][Column(4)] = cell('5');
 
-    grid.resize(Line(1), Column(2), &mut Point::new(Line(0), Column(0)), &Cell::default());
+    grid.resize(Line(1), Column(2), &mut Point::new(Line(0), Column(0)), &Cell::default(), true);
 
     assert_eq!(grid.len(), 3);
 
@@ -166,8 +166,8 @@ fn shrink_reflow_twice() {
     grid[Line(0)][Column(3)] = cell('4');
     grid[Line(0)][Column(4)] = cell('5');
 
-    grid.resize(Line(1), Column(4), &mut Point::new(Line(0), Column(0)), &Cell::default());
-    grid.resize(Line(1), Column(2), &mut Point::new(Line(0), Column(0)), &Cell::default());
+    grid.resize(Line(1), Column(4), &mut Point::new(Line(0), Column(0)), &Cell::default(), true);
+    grid.resize(Line(1), Column(2), &mut Point::new(Line(0), Column(0)), &Cell::default(), true);
 
     assert_eq!(grid.len(), 3);
 
@@ -193,7 +193,7 @@ fn shrink_reflow_empty_cell_inside_line() {
     grid[Line(0)][Column(3)] = cell('4');
     grid[Line(0)][Column(4)] = Cell::default();
 
-    grid.resize(Line(1), Column(2), &mut Point::new(Line(0), Column(0)), &Cell::default());
+    grid.resize(Line(1), Column(2), &mut Point::new(Line(0), Column(0)), &Cell::default(), true);
 
     assert_eq!(grid.len(), 2);
 
@@ -205,7 +205,7 @@ fn shrink_reflow_empty_cell_inside_line() {
     assert_eq!(grid[0][Column(0)], cell('3'));
     assert_eq!(grid[0][Column(1)], cell('4'));
 
-    grid.resize(Line(1), Column(1), &mut Point::new(Line(0), Column(0)), &Cell::default());
+    grid.resize(Line(1), Column(1), &mut Point::new(Line(0), Column(0)), &Cell::default(), true);
 
     assert_eq!(grid.len(), 4);
 
@@ -230,7 +230,7 @@ fn grow_reflow() {
     grid[Line(1)][Column(0)] = cell('3');
     grid[Line(1)][Column(1)] = Cell::default();
 
-    grid.resize(Line(2), Column(3), &mut Point::new(Line(0), Column(0)), &Cell::default());
+    grid.resize(Line(2), Column(3), &mut Point::new(Line(0), Column(0)), &Cell::default(), true);
 
     assert_eq!(grid.len(), 2);
 
@@ -256,7 +256,7 @@ fn grow_reflow_multiline() {
     grid[Line(2)][Column(0)] = cell('5');
     grid[Line(2)][Column(1)] = cell('6');
 
-    grid.resize(Line(3), Column(6), &mut Point::new(Line(0), Column(0)), &Cell::default());
+    grid.resize(Line(3), Column(6), &mut Point::new(Line(0), Column(0)), &Cell::default(), true);
 
     assert_eq!(grid.len(), 3);
 


### PR DESCRIPTION
Apps that are using `ALT_SCREEN` mode are probably doing their own
reflow, so `our` reflow can lead to strange "artifacts" during resize.

> Other terminals should be checked to see what they do in this case.

I've testing `kitty` for this, and it seems like its doing text reflow on `ALT_SCREEN` mode. 

The behavior without reflow feels better in apps with `ALT_SCREEN` mode though.

This `PR` uses the approach that was before b1032bc , when we need resize without reflow.

Implements #2414 