### PR TITLE
Fix dependencies for arch in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ On Arch Linux, you need a few extra libraries to build Alacritty. Here's a
 to be missing, please open an issue.
 
 ```sh
-pacman -S cmake freetype2 fontconfig pkg-config make
+pacman -S cmake freetype2 fontconfig pkg-config make libxcb
 ```
 
 #### Fedora


### PR DESCRIPTION
current master does not build on arch w/o libxcb
https://www.archlinux.org/packages/extra/x86_64/libxcb/