### PR TITLE
Fix rows only resetting partially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Performance issues while resizing Alacritty
 - First unfullscreen action ignored on window launched in fullscreen mode
 - The window is now filled with the background color before displaying
+- Cells sometimes not getting cleared correctly
 
 ## 0.3.3
 

--- a/alacritty_terminal/src/grid/row.rs
+++ b/alacritty_terminal/src/grid/row.rs
@@ -80,9 +80,8 @@ impl<T: Copy> Row<T> {
     }
 
     /// Resets contents to the contents of `other`
-    #[inline(never)]
     pub fn reset(&mut self, other: &T) {
-        for item in &mut self.inner[..self.occ] {
+        for item in &mut self.inner[..] {
             *item = *other;
         }
         self.occ = 0;


### PR DESCRIPTION
This resolves an issue with rows only resetting partially, based on
their `occ` state. However this state is not always accurate, so more
than just the occupied elements need to be cleared.

Fixes #2340.