### PR TITLE
Suggest installing fish completions per-user

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -316,10 +316,8 @@ echo "source ~/.bash_completion/alacritty" >> ~/.bashrc
 To install the completions for fish, run
 
 ```
-sudo cp extra/completions/alacritty.fish $__fish_data_dir/vendor_completions.d/alacritty.fish
+cp extra/completions/alacritty.fish $fish_complete_path[1]/alacritty.fish
 ```
-
-**Note:** For fish versions below 3.0 `$__fish_datadir` must be used instead.
 
 ## Terminfo
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -316,6 +316,7 @@ echo "source ~/.bash_completion/alacritty" >> ~/.bashrc
 To install the completions for fish, run
 
 ```
+mkdir -p $fish_complete_path[1]
 cp extra/completions/alacritty.fish $fish_complete_path[1]/alacritty.fish
 ```
 


### PR DESCRIPTION
This uses $fish_complete_path[1], which should be in the user's home directory, so `sudo` is no longer needed.