### PR TITLE
Gnome tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Block selection mode when Control is held while starting a selection
+- Allow setting general window class on X11 using CLI or config (`window.class.general`)
+- Config option `window.gtk_theme_variant` to set GTK theme variant
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -72,6 +72,12 @@ window:
     # General application class
     general: Alacritty
 
+  # GTK theme variant (Linux only)
+  #
+  # Override the variant of the GTK theme. Commonly supported values are `dark` and `light`.
+  # Set this to `None` to use the default theme variant.
+  gtk_theme_variant: None
+
 scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -66,7 +66,11 @@ window:
   #title: Alacritty
 
   # Window class (Linux only):
-  #class: Alacritty
+  class:
+    # Application instance name
+    instance: Alacritty
+    # General application class
+    general: Alacritty
 
 scrolling:
   # Maximum number of lines in the scrollback buffer.

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -250,7 +250,14 @@ impl Options {
         config.window.dimensions = self.dimensions.unwrap_or(config.window.dimensions);
         config.window.position = self.position.or(config.window.position);
         config.window.title = self.title.or(config.window.title);
-        config.window.class = self.class.or(config.window.class);
+
+        if let Some(class) = self.class {
+            let parts : Vec<_> = class.split(',').collect();
+            config.window.class.instance = parts[0].into();
+            if let Some(&general) = parts.get(1) {
+                config.window.class.general = general.into();
+            }
+        }
 
         config.set_dynamic_title(config.dynamic_title() && config.window.title.is_none());
 

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -136,8 +136,8 @@ pub struct Config {
     alt_send_esc: DefaultTrueBool,
 
     /// Shell startup directory
-    #[serde(default, deserialize_with = "failure_default")]
-    working_directory: WorkingDirectory,
+    #[serde(default, deserialize_with = "option_explicit_none")]
+    working_directory: Option<PathBuf>,
 
     /// Debug options
     #[serde(default, deserialize_with = "failure_default")]
@@ -214,37 +214,12 @@ impl Config {
 
     #[inline]
     pub fn working_directory(&self) -> &Option<PathBuf> {
-        &self.working_directory.0
+        &self.working_directory
     }
 
     #[inline]
     pub fn set_working_directory(&mut self, working_directory: Option<PathBuf>) {
-        self.working_directory.0 = working_directory;
-    }
-}
-
-#[derive(Default, Debug, PartialEq, Eq)]
-struct WorkingDirectory(Option<PathBuf>);
-
-impl<'de> Deserialize<'de> for WorkingDirectory {
-    fn deserialize<D>(deserializer: D) -> Result<WorkingDirectory, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = serde_yaml::Value::deserialize(deserializer)?;
-
-        // Accept `None` to use the default path
-        if value.as_str().filter(|v| v.to_lowercase() == "none").is_some() {
-            return Ok(WorkingDirectory(None));
-        }
-
-        Ok(match PathBuf::deserialize(value) {
-            Ok(path) => WorkingDirectory(Some(path)),
-            Err(err) => {
-                error!("Problem with config: {}; using None", err);
-                WorkingDirectory(None)
-            },
-        })
+        self.working_directory = working_directory;
     }
 }
 

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -94,7 +94,7 @@ pub struct Config {
     pub mouse: Mouse,
 
     /// Path to a shell program to run on startup
-    #[serde(default, deserialize_with = "failure_default")]
+    #[serde(default, deserialize_with = "option_from_string_or_deserialize")]
     pub shell: Option<Shell<'static>>,
 
     /// Path where config was loaded from
@@ -331,6 +331,12 @@ impl<'a> Shell<'a> {
         S: Into<Cow<'a, str>>,
     {
         Shell { program: program.into(), args }
+    }
+}
+
+impl From<String> for Shell<'static> {
+    fn from(value: String) -> Self {
+        Shell::new(value)
     }
 }
 

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -1,5 +1,6 @@
-use crate::config::{failure_default, Delta};
+use crate::config::{failure_default, from_string_or_deserialize, Delta};
 use crate::index::{Column, Line};
+use crate::window::DEFAULT_NAME;
 
 #[serde(default)]
 #[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
@@ -33,8 +34,12 @@ pub struct WindowConfig {
     pub title: Option<String>,
 
     /// Window class
+    #[serde(deserialize_with = "from_string_or_deserialize")]
+    pub class: Class,
+
+    /// Window class instance
     #[serde(deserialize_with = "failure_default")]
-    pub class: Option<String>,
+    pub instance: Option<String>,
 
     /// TODO: DEPRECATED
     #[serde(deserialize_with = "failure_default")]
@@ -115,5 +120,25 @@ impl Dimensions {
     #[inline]
     pub fn columns_u32(&self) -> u32 {
         self.columns.0 as u32
+    }
+}
+
+/// Window class hint
+#[serde(default)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Class {
+    pub instance: String,
+    pub general: String
+}
+
+impl Default for Class {
+    fn default() -> Self {
+        Class { instance: DEFAULT_NAME.into(), general: DEFAULT_NAME.into() }
+    }
+}
+
+impl From<String> for Class {
+    fn from(value: String) -> Self {
+        Class { instance: value, general: DEFAULT_NAME.into() }
     }
 }

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -1,4 +1,4 @@
-use crate::config::{failure_default, option_explicit_none, from_string_or_deserialize, Delta};
+use crate::config::{failure_default, option_explicit_none, from_string_or_deserialize, Delta, FromString};
 use crate::index::{Column, Line};
 use crate::window::DEFAULT_NAME;
 
@@ -137,7 +137,7 @@ impl Default for Class {
     }
 }
 
-impl From<String> for Class {
+impl FromString for Class {
     fn from(value: String) -> Self {
         Class { instance: value, general: DEFAULT_NAME.into() }
     }

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -1,4 +1,4 @@
-use crate::config::{failure_default, from_string_or_deserialize, Delta};
+use crate::config::{failure_default, option_explicit_none, from_string_or_deserialize, Delta};
 use crate::index::{Column, Line};
 use crate::window::DEFAULT_NAME;
 
@@ -37,9 +37,9 @@ pub struct WindowConfig {
     #[serde(deserialize_with = "from_string_or_deserialize")]
     pub class: Class,
 
-    /// Window class instance
-    #[serde(deserialize_with = "failure_default")]
-    pub instance: Option<String>,
+    /// GTK theme variant
+    #[serde(deserialize_with = "option_explicit_none")]
+    pub gtk_theme_variant: Option<String>,
 
     /// TODO: DEPRECATED
     #[serde(deserialize_with = "failure_default")]

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -151,9 +151,8 @@ impl Window {
         dimensions: Option<LogicalSize>,
     ) -> Result<Window> {
         let title = config.window.title.as_ref().map_or(DEFAULT_NAME, |t| t);
-        let class = config.window.class.as_ref().map_or(DEFAULT_NAME, |c| c);
 
-        let window_builder = Window::get_platform_window(title, class, &config.window);
+        let window_builder = Window::get_platform_window(title, &config.window);
         let windowed_context =
             create_gl_window(window_builder.clone(), &event_loop, false, dimensions)
                 .or_else(|_| create_gl_window(window_builder, &event_loop, true, dimensions))?;
@@ -255,7 +254,6 @@ impl Window {
     #[cfg(not(any(target_os = "macos", windows)))]
     pub fn get_platform_window(
         title: &str,
-        class: &str,
         window_config: &WindowConfig,
     ) -> WindowBuilder {
         use glutin::os::unix::WindowBuilderExt;
@@ -267,6 +265,8 @@ impl Window {
 
         let icon = Icon::from_bytes_with_format(WINDOW_ICON, ImageFormat::ICO);
 
+        let class = &window_config.class;
+
         WindowBuilder::new()
             .with_title(title)
             .with_visibility(false)
@@ -275,15 +275,14 @@ impl Window {
             .with_maximized(window_config.startup_mode() == StartupMode::Maximized)
             .with_window_icon(icon.ok())
             // X11
-            .with_class(class.into(), DEFAULT_NAME.into())
+            .with_class(class.instance.clone(), class.general.clone())
             // Wayland
-            .with_app_id(class.into())
+            .with_app_id(class.instance.clone())
     }
 
     #[cfg(windows)]
     pub fn get_platform_window(
         title: &str,
-        _class: &str,
         window_config: &WindowConfig,
     ) -> WindowBuilder {
         let decorations = match window_config.decorations {
@@ -305,7 +304,6 @@ impl Window {
     #[cfg(target_os = "macos")]
     pub fn get_platform_window(
         title: &str,
-        _class: &str,
         window_config: &WindowConfig,
     ) -> WindowBuilder {
         use glutin::os::macos::WindowBuilderExt;

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -267,7 +267,7 @@ impl Window {
 
         let class = &window_config.class;
 
-        WindowBuilder::new()
+        let mut builder = WindowBuilder::new()
             .with_title(title)
             .with_visibility(false)
             .with_transparency(true)
@@ -277,7 +277,13 @@ impl Window {
             // X11
             .with_class(class.instance.clone(), class.general.clone())
             // Wayland
-            .with_app_id(class.instance.clone())
+            .with_app_id(class.instance.clone());
+
+        if let Some(ref val) = window_config.gtk_theme_variant {
+            builder = builder.with_gtk_theme_variant(val.clone())
+        }
+
+        builder
     }
 
     #[cfg(windows)]

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -39,8 +39,8 @@ Increases the level of verbosity (the max level is \fB\-vvv\fR)
 Prints version information
 .SH "OPTIONS"
 .TP
-\fB\-\-class\fR <class>
-Defines the window class on Linux [default: Alacritty]
+\fB\-\-class\fR [ <instance> | <instance>,<general> ]
+Defines the window class hint on Linux [default: Alacritty,Alacritty ]
 .TP
 \fB\-e\fR, \fB\-\-command\fR <command>...
 Command and args to execute (must be last argument)


### PR DESCRIPTION
This makes two small changes for better support under gnome:

- Allow setting the `_GTK_THEME_VARIANT` hint.  This permits selecting dark title bars to go with a dark terminal theme
- Allow setting both the instance and class portions of the `WM_CLASS` hint (with CLI support).  This gives complete control over which desktop entry gnome-shell associates with the window.  Without this, gnome-shell would always associated the created window with alacritty.desktop, even if it was launched from a custom desktop entry (e.g. to create a dedicated vim window).  The commit message gives an example.