### PR TITLE
Use Menlo as fallback font on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The window is now filled with the background color before displaying
 - Cells sometimes not getting cleared correctly
 - X11 clipboard hanging when mime type is set
+- On macOS, Alacritty will now fallback to Menlo if a font specified in the config cannot be loaded
 
 ## 0.3.3
 

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -314,10 +314,11 @@ pub fn descriptors_for_family(family: &str) -> Vec<Descriptor> {
     let mut out = Vec::new();
 
     trace!("Family: {}", family);
-    let ct_collection = match create_for_family(family) {
-        Some(c) => c,
-        None => return out,
-    };
+    let ct_collection = create_for_family(family).unwrap_or_else(|| {
+        // Fallback to Menlo if we can't find the config specified font family.
+        warn!("Unable to load specified font {}, falling back to Menlo", &family);
+        create_for_family("Menlo").expect("Menlo exists")
+    });
 
     // CFArray of CTFontDescriptorRef (i think)
     let descriptors = ct_collection.get_descriptors();


### PR DESCRIPTION
This commit makes alacritty use Menlo as a fallback font on macOS if the config specified font family isn't found.

closes #2585 