### PR TITLE
Change mouse cursor when hovering over the message bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow setting general window class on X11 using CLI or config (`window.class.general`)
 - Config option `window.gtk_theme_variant` to set GTK theme variant
 - Completions for `--class` and `-t` (short title)
-- Change the mouse cursor when mousing over the message bar and its close button
+- Change the mouse cursor when hovering over the message bar and its close button
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow setting general window class on X11 using CLI or config (`window.class.general`)
 - Config option `window.gtk_theme_variant` to set GTK theme variant
 - Completions for `--class` and `-t` (short title)
+- Change the mouse cursor when mousing over the message bar and its close button
 
 ### Fixed
 

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -946,7 +946,6 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         let size = self.ctx.size_info();
         point.col + message_bar::CLOSE_BUTTON_TEXT.len() >= size.cols()
             && point.line == size.lines() - message.text(&size).len()
-
     }
 
     /// Handle clicks on the message bar.

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -420,7 +420,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
         // Only report motions when cell changed and mouse is not over the message bar
         if let Some(message) = self.message_at_point(Some(point)) {
-            self.message_cursor(point, message);
+            self.update_message_cursor(point, message);
 
             return;
         } else {
@@ -919,7 +919,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     }
 
     /// Set the cursor depending on where the mouse is on the message bar
-    fn message_cursor(&mut self, point: Point, message: Message) {
+    fn update_message_cursor(&mut self, point: Point, message: Message) {
         if self.message_close_at_point(point, message) {
             self.ctx.terminal_mut().set_mouse_cursor(MouseCursor::Hand);
         } else {
@@ -956,7 +956,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 if self.message_close_at_point(point, message) {
                     self.ctx.terminal_mut().message_buffer_mut().pop();
                     if let Some(message) = self.message_at_point(Some(point)) {
-                        self.message_cursor(point, message);
+                        self.update_message_cursor(point, message);
                     } else {
                         self.ctx.terminal_mut().reset_mouse_cursor();
                     }

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -412,9 +412,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
 
         let cell_changed =
             prev_line != self.ctx.mouse().line || prev_col != self.ctx.mouse().column;
-        let mouse_moved = cell_changed || prev_side != cell_side;
 
-        if !mouse_moved {
+        // If the mouse hasn't changed cells, do nothing
+        if cell_changed || prev_side != cell_side {
             return;
         }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -743,9 +743,6 @@ pub struct Term {
     /// Got a request to set the mouse cursor; it's buffered here until the next draw
     next_mouse_cursor: Option<MouseCursor>,
 
-    /// Keep track of the current mouse cursor to avoid unnecessarily changing it
-    current_mouse_cursor: MouseCursor,
-
     /// Alternate grid
     alt_grid: Grid<Cell>,
 
@@ -929,7 +926,6 @@ impl Term {
 
         Term {
             next_title: None,
-            current_mouse_cursor: MouseCursor::Default,
             next_mouse_cursor: None,
             dirty: false,
             visual_bell: VisualBell::new(config),
@@ -1412,11 +1408,7 @@ impl ansi::Handler for Term {
     /// Set the mouse cursor
     #[inline]
     fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
-        if cursor != self.current_mouse_cursor {
-            self.current_mouse_cursor = cursor;
-            self.next_mouse_cursor = Some(cursor);
-            self.dirty = true;
-        }
+        self.next_mouse_cursor = Some(cursor);
     }
 
     /// A character to be displayed

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1347,7 +1347,7 @@ impl Term {
     }
 
     #[inline]
-    pub fn reset_url_highlight(&mut self) {
+    pub fn reset_mouse_cursor(&mut self) {
         let mouse_mode =
             TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG | TermMode::MOUSE_REPORT_CLICK;
         let mouse_cursor = if self.mode().intersects(mouse_mode) {
@@ -1356,6 +1356,11 @@ impl Term {
             MouseCursor::Text
         };
         self.set_mouse_cursor(mouse_cursor);
+    }
+
+    #[inline]
+    pub fn reset_url_highlight(&mut self) {
+        self.reset_mouse_cursor();
 
         self.grid.url_highlight = None;
         self.dirty = true;
@@ -1404,6 +1409,7 @@ impl ansi::Handler for Term {
     #[inline]
     fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
         self.next_mouse_cursor = Some(cursor);
+        self.dirty = true;
     }
 
     /// A character to be displayed

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -743,6 +743,9 @@ pub struct Term {
     /// Got a request to set the mouse cursor; it's buffered here until the next draw
     next_mouse_cursor: Option<MouseCursor>,
 
+    /// Keep track of the current mouse cursor to avoid unnecessarily changing it
+    current_mouse_cursor: MouseCursor,
+
     /// Alternate grid
     alt_grid: Grid<Cell>,
 
@@ -926,6 +929,7 @@ impl Term {
 
         Term {
             next_title: None,
+            current_mouse_cursor: MouseCursor::Default,
             next_mouse_cursor: None,
             dirty: false,
             visual_bell: VisualBell::new(config),
@@ -1408,8 +1412,11 @@ impl ansi::Handler for Term {
     /// Set the mouse cursor
     #[inline]
     fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
-        self.next_mouse_cursor = Some(cursor);
-        self.dirty = true;
+        if cursor != self.current_mouse_cursor {
+            self.current_mouse_cursor = cursor;
+            self.next_mouse_cursor = Some(cursor);
+            self.dirty = true;
+        }
     }
 
     /// A character to be displayed

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1409,6 +1409,7 @@ impl ansi::Handler for Term {
     #[inline]
     fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
         self.next_mouse_cursor = Some(cursor);
+        self.dirty = true;
     }
 
     /// A character to be displayed

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -61,6 +61,9 @@ pub struct Window {
     windowed_context: glutin::WindowedContext<PossiblyCurrent>,
     mouse_visible: bool,
 
+    /// Keep track of the current mouse cursor to avoid unnecessarily changing it
+    current_mouse_cursor: MouseCursor,
+
     /// Whether or not the window is the focused window.
     pub is_focused: bool,
 }
@@ -164,8 +167,13 @@ impl Window {
         // Set OpenGL symbol loader. This call MUST be after window.make_current on windows.
         gl::load_with(|symbol| windowed_context.get_proc_address(symbol) as *const _);
 
-        let window =
-            Window { event_loop, windowed_context, mouse_visible: true, is_focused: false };
+        let window = Window {
+            event_loop,
+            current_mouse_cursor: MouseCursor::Default,
+            windowed_context,
+            mouse_visible: true,
+            is_focused: false,
+        };
 
         window.run_os_extensions();
 
@@ -239,8 +247,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_mouse_cursor(&self, cursor: MouseCursor) {
-        self.window().set_cursor(cursor);
+    pub fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
+        if cursor != self.current_mouse_cursor {
+            self.current_mouse_cursor = cursor;
+            self.window().set_cursor(cursor);
+        }
     }
 
     /// Set mouse cursor visible


### PR DESCRIPTION
This PR sets the mouse cursor to an arrow when over the message bar, and to a pointer when over the close button. This indicates that the message bar isn't part of the regular terminal, and that the close button can be clicked on and closed.

Feedback welcome!