### PR TITLE
Fix cursor color setting with escape sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - X11 clipboard hanging when mime type is set
 - On macOS, Alacritty will now fallback to Menlo if a font specified in the config cannot be loaded
 - Debug ref tests are now written to disk regardless of shutdown method
+- Cursor color setting with escape sequence
 
 ## 0.3.3
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -539,8 +539,6 @@ pub enum NamedColor {
     Background,
     /// Color for the cursor itself
     Cursor,
-    /// Color for the text under the cursor
-    CursorText,
     /// Dim black
     DimBlack,
     /// Dim red

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -32,7 +32,7 @@ mod test;
 mod visual_bell;
 mod window;
 
-use crate::ansi::CursorStyle;
+use crate::ansi::{Color, CursorStyle, NamedColor};
 use crate::input::{Binding, KeyBinding, MouseBinding};
 
 pub use crate::config::bindings::Key;
@@ -44,6 +44,7 @@ pub use crate::config::mouse::{ClickHandler, Mouse};
 pub use crate::config::scrolling::Scrolling;
 pub use crate::config::visual_bell::{VisualBellAnimation, VisualBellConfig};
 pub use crate::config::window::{Decorations, Dimensions, StartupMode, WindowConfig};
+use crate::term::color::Rgb;
 
 pub static DEFAULT_ALACRITTY_CONFIG: &str =
     include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../alacritty.yml"));
@@ -188,6 +189,18 @@ impl Config {
     #[inline]
     pub fn dynamic_title(&self) -> bool {
         self.dynamic_title.0
+    }
+
+    /// Cursor foreground color
+    #[inline]
+    pub fn cursor_text_color(&self) -> Option<Rgb> {
+        self.colors.cursor.text
+    }
+
+    /// Cursor background color
+    #[inline]
+    pub fn cursor_cursor_color(&self) -> Option<Color> {
+        self.colors.cursor.cursor.map(|_| Color::Named(NamedColor::Cursor))
     }
 
     #[inline]

--- a/alacritty_terminal/src/term/color.rs
+++ b/alacritty_terminal/src/term/color.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer};
 use crate::ansi;
 use crate::config::Colors;
 
-pub const COUNT: usize = 270;
+pub const COUNT: usize = 269;
 
 pub const RED: Rgb = Rgb { r: 0xff, g: 0x0, b: 0x0 };
 pub const YELLOW: Rgb = Rgb { r: 0xff, g: 0xff, b: 0x0 };
@@ -135,9 +135,8 @@ impl FromStr for Rgb {
 /// The first 16 entries are the standard ansi named colors. Items 16..232 are
 /// the color cube.  Items 233..256 are the grayscale ramp. Item 256 is
 /// the configured foreground color, item 257 is the configured background
-/// color, item 258 is the cursor foreground color, item 259 is the cursor
-/// background color. Following that are 8 positions for dim colors.
-/// Item 268 is the bright foreground color, 269 the dim foreground.
+/// color, item 258 is the cursor color. Following that are 8 positions for dim colors.
+/// Item 267 is the bright foreground color, 268 the dim foreground.
 #[derive(Copy, Clone)]
 pub struct List([Rgb; COUNT]);
 
@@ -182,8 +181,7 @@ impl List {
         self[ansi::NamedColor::Foreground] = colors.primary.foreground;
         self[ansi::NamedColor::Background] = colors.primary.background;
 
-        // Foreground and background for custom cursor colors
-        self[ansi::NamedColor::CursorText] = colors.cursor.text.unwrap_or_else(Rgb::default);
+        // Background for custom cursor colors
         self[ansi::NamedColor::Cursor] = colors.cursor.cursor.unwrap_or_else(Rgb::default);
 
         // Dims

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -447,8 +447,8 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
 
                     renderable_cell.inner = RenderableCellContent::Cursor(cursor_key);
 
-                    if let Some(color) = self.config.colors.cursor.cursor {
-                        renderable_cell.fg = color;
+                    if let Some(color) = self.config.cursor_cursor_color() {
+                        renderable_cell.fg = RenderableCell::compute_bg_rgb(self.colors, color);
                     }
 
                     return Some(renderable_cell);
@@ -459,7 +459,7 @@ impl<'a> Iterator for RenderableCellsIter<'a> {
                     if self.cursor_style == CursorStyle::Block {
                         std::mem::swap(&mut cell.bg, &mut cell.fg);
 
-                        if let Some(color) = self.config.colors.cursor.text {
+                        if let Some(color) = self.config.cursor_text_color() {
                             cell.fg = color;
                         }
                     }


### PR DESCRIPTION
The cursor rework introduced a regression where cursor color was always picked
from a config file, rather then using `ansi::NamedColor::Cursor` and
`ansi::NamedColor::CursorText` for this purposes.

Fixes:  #2617