### PR TITLE
Update shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Block selection mode when Control is held while starting a selection
 - Allow setting general window class on X11 using CLI or config (`window.class.general`)
 - Config option `window.gtk_theme_variant` to set GTK theme variant
+- Completions for `--class` and `-t` (short title)
 
 ### Fixed
 

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -17,7 +17,8 @@ _alacritty() {
         "--config-file[Specify an alternative config file]:file:_files" \
         "(-d --dimensions)"{-d,--dimensions}"[Window dimensions]:dimensions:_guard '<->' width: :_guard '<->' length" \
         "--position[Window position]:position:_guard '<->' x-pos: :_guard '<->' y-pos" \
-        "--title[Defines the window title]:title:" \
+        "(-t --title)"{-t,--title}"[Defines the window title]:title:" \
+        "--class[Defines the window class]:class:" \
         "--working-directory[Start shell in specified directory]:directory:_dir_list" \
         "(-e --command)"{-e,--command}"[Execute command (must be last arg)]:program: _command_names -e:*::program arguments: _normal"
 }

--- a/extra/completions/alacritty.bash
+++ b/extra/completions/alacritty.bash
@@ -11,7 +11,7 @@ _alacritty()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     prevprev="${COMP_WORDS[COMP_CWORD-2]}"
-    opts="-h --help -V --version --live-config-reload --no-live-config-reload --persistent-logging --print-events -q -qq -v -vv -vvv --ref-test -e --command --config-file -d --dimensions --position -t --title --working-directory"
+    opts="-h --help -V --version --live-config-reload --no-live-config-reload --persistent-logging --print-events -q -qq -v -vv -vvv --ref-test -e --command --config-file -d --dimensions --position -t --title --class --working-directory"
 
     # If `--command` or `-e` is used, stop completing
     for i in "${!COMP_WORDS[@]}"; do
@@ -40,7 +40,7 @@ _alacritty()
             compopt -o filenames
             COMPREPLY=( $(compgen -f -- "${cur}") )
             return 0;;
-        --dimensions | -d | --title | -t)
+        --dimensions | -d | --class | --title | -t)
             # Don't complete here
             return 0;;
         --working-directory)

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -23,8 +23,12 @@ complete -c alacritty \
   -l "config-file" \
   -d "Specify an alternative config file"
 complete -c alacritty \
+  -s "t" \
   -l "title" \
   -d "Defines the window title"
+complete -c alacritty \
+  -l "class" \
+  -d "Defines the window class"
 complete -c alacritty \
   -x \
   -a '(__fish_complete_directories (commandline -ct))' \


### PR DESCRIPTION
Add `--class` and `-t` options to shell completions.

Fixes: #2612