### PR TITLE
Fix saving of ref tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cells sometimes not getting cleared correctly
 - X11 clipboard hanging when mime type is set
 - On macOS, Alacritty will now fallback to Menlo if a font specified in the config cannot be loaded
+- Debug ref tests are now written to disk regardless of shutdown method
 
 ## 0.3.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_tools_util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -16,6 +16,7 @@ time = "0.1.40"
 env_logger = "0.6.0"
 crossbeam-channel = "0.3.8"
 serde_yaml = "0.8"
+serde_json = "1"
 
 [build-dependencies]
 rustc_tools_util = "0.2.0"

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -252,7 +252,7 @@ impl Options {
         config.window.title = self.title.or(config.window.title);
 
         if let Some(class) = self.class {
-            let parts : Vec<_> = class.split(',').collect();
+            let parts: Vec<_> = class.split(',').collect();
             config.window.class.instance = parts[0].into();
             if let Some(&general) = parts.get(1) {
                 config.window.class.general = general.into();

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -22,21 +22,21 @@
 // See https://msdn.microsoft.com/en-us/library/4cc7ya5b.aspx for more details.
 #![windows_subsystem = "windows"]
 
+#[cfg(target_os = "macos")]
+use std::env;
 use std::error::Error;
 use std::fs::{self, File};
 use std::io::{self, Write};
-use std::sync::Arc;
-#[cfg(target_os = "macos")]
-use std::env;
 #[cfg(not(windows))]
 use std::os::unix::io::AsRawFd;
+use std::sync::Arc;
 
 #[cfg(target_os = "macos")]
 use dirs;
-#[cfg(windows)]
-use winapi::um::wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS};
 use log::{error, info};
 use serde_json as json;
+#[cfg(windows)]
+use winapi::um::wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS};
 
 use alacritty_terminal::clipboard::Clipboard;
 use alacritty_terminal::config::{Config, Monitor};
@@ -47,7 +47,7 @@ use alacritty_terminal::locale;
 use alacritty_terminal::message_bar::MessageBuffer;
 use alacritty_terminal::panic;
 use alacritty_terminal::sync::FairMutex;
-use alacritty_terminal::term::{Term, cell::Cell};
+use alacritty_terminal::term::{cell::Cell, Term};
 use alacritty_terminal::tty;
 use alacritty_terminal::util::fmt::Red;
 use alacritty_terminal::{die, event};
@@ -285,12 +285,9 @@ fn write_ref_test_results(terminal: &Term) {
 
     let serialized_grid = json::to_string(&grid).expect("serialize grid");
 
-    let serialized_size =
-        json::to_string(terminal.size_info())
-            .expect("serialize size");
+    let serialized_size = json::to_string(terminal.size_info()).expect("serialize size");
 
-    let serialized_config =
-        format!("{{\"history_size\":{}}}", grid.history_size());
+    let serialized_config = format!("{{\"history_size\":{}}}", grid.history_size());
 
     File::create("./grid.json")
         .and_then(|mut f| f.write_all(serialized_grid.as_bytes()))

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -22,24 +22,21 @@
 // See https://msdn.microsoft.com/en-us/library/4cc7ya5b.aspx for more details.
 #![windows_subsystem = "windows"]
 
-#[cfg(target_os = "macos")]
-use dirs;
-
-#[cfg(windows)]
-use winapi::um::wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS};
-
-use log::{error, info};
-
 use std::error::Error;
-use std::fs;
+use std::fs::{self, File};
 use std::io::{self, Write};
 use std::sync::Arc;
-
 #[cfg(target_os = "macos")]
 use std::env;
-
 #[cfg(not(windows))]
 use std::os::unix::io::AsRawFd;
+
+#[cfg(target_os = "macos")]
+use dirs;
+#[cfg(windows)]
+use winapi::um::wincon::{AttachConsole, FreeConsole, ATTACH_PARENT_PROCESS};
+use log::{error, info};
+use serde_json as json;
 
 use alacritty_terminal::clipboard::Clipboard;
 use alacritty_terminal::config::{Config, Monitor};
@@ -50,7 +47,7 @@ use alacritty_terminal::locale;
 use alacritty_terminal::message_bar::MessageBuffer;
 use alacritty_terminal::panic;
 use alacritty_terminal::sync::FairMutex;
-use alacritty_terminal::term::Term;
+use alacritty_terminal::term::{Term, cell::Cell};
 use alacritty_terminal::tty;
 use alacritty_terminal::util::fmt::Red;
 use alacritty_terminal::{die, event};
@@ -258,6 +255,11 @@ fn run(config: Config, message_buffer: MessageBuffer) -> Result<(), Box<dyn Erro
         }
     }
 
+    // Write ref tests to disk
+    if config.debug.ref_test {
+        write_ref_test_results(&terminal.lock());
+    }
+
     loop_tx.send(Msg::Shutdown).expect("Error sending shutdown to event loop");
 
     // FIXME patch notify library to have a shutdown method
@@ -272,4 +274,33 @@ fn run(config: Config, message_buffer: MessageBuffer) -> Result<(), Box<dyn Erro
     info!("Goodbye");
 
     Ok(())
+}
+
+// Write the ref test results to the disk
+fn write_ref_test_results(terminal: &Term) {
+    // dump grid state
+    let mut grid = terminal.grid().clone();
+    grid.initialize_all(&Cell::default());
+    grid.truncate();
+
+    let serialized_grid = json::to_string(&grid).expect("serialize grid");
+
+    let serialized_size =
+        json::to_string(terminal.size_info())
+            .expect("serialize size");
+
+    let serialized_config =
+        format!("{{\"history_size\":{}}}", grid.history_size());
+
+    File::create("./grid.json")
+        .and_then(|mut f| f.write_all(serialized_grid.as_bytes()))
+        .expect("write grid.json");
+
+    File::create("./size.json")
+        .and_then(|mut f| f.write_all(serialized_size.as_bytes()))
+        .expect("write size.json");
+
+    File::create("./config.json")
+        .and_then(|mut f| f.write_all(serialized_config.as_bytes()))
+        .expect("write config.json");
 }

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -18,7 +18,6 @@ errno = "0.2"
 parking_lot = "0.7"
 serde = "1"
 serde_derive = "1"
-serde_json = "1"
 serde_yaml = "0.8"
 vte = "0.3"
 mio = "0.6"
@@ -65,3 +64,6 @@ bench = []
 
 [build-dependencies]
 gl_generator = "0.11.0"
+
+[dev-dependencies]
+serde_json = "1.0.0"

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -14,8 +14,8 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::fmt::Display;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Deserializer};
 use serde_yaml::Value;
@@ -402,7 +402,9 @@ impl Default for DefaultTrueBool {
 }
 
 fn fallback_default<T, E>(err: E) -> T
-    where T: Default, E: Display
+where
+    T: Default,
+    E: Display,
 {
     error!("Problem with config: {}; using default value", err);
     T::default()
@@ -417,20 +419,24 @@ where
 }
 
 pub fn option_explicit_none<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
-    where D: Deserializer<'de>, T: Deserialize<'de> + Default
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
 {
     Ok(match Value::deserialize(deserializer)? {
         Value::String(ref value) if value.to_lowercase() == "none" => None,
-        value => Some(T::deserialize(value).unwrap_or_else(fallback_default))
+        value => Some(T::deserialize(value).unwrap_or_else(fallback_default)),
     })
 }
 
 pub fn from_string_or_deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-    where D: Deserializer<'de>, T: Deserialize<'de> + FromString + Default
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + FromString + Default,
 {
     Ok(match Value::deserialize(deserializer)? {
         Value::String(value) => T::from(value),
-        value => T::deserialize(value).unwrap_or_else(fallback_default)
+        value => T::deserialize(value).unwrap_or_else(fallback_default),
     })
 }
 

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -1,4 +1,6 @@
-use crate::config::{failure_default, option_explicit_none, from_string_or_deserialize, Delta, FromString};
+use crate::config::{
+    failure_default, from_string_or_deserialize, option_explicit_none, Delta, FromString,
+};
 use crate::index::{Column, Line};
 use crate::window::DEFAULT_NAME;
 
@@ -128,7 +130,7 @@ impl Dimensions {
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Class {
     pub instance: String,
-    pub general: String
+    pub general: String,
 }
 
 impl Default for Class {

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -3,15 +3,12 @@ use std::borrow::Cow;
 use std::env;
 #[cfg(unix)]
 use std::fs;
-use std::fs::File;
-use std::io::Write;
 use std::sync::mpsc;
 use std::time::Instant;
 
 use glutin::dpi::PhysicalSize;
 use glutin::{self, ElementState, Event, ModifiersState, MouseButton};
 use parking_lot::MutexGuard;
-use serde_json as json;
 
 use crate::clipboard::ClipboardType;
 use crate::config::{self, Config, StartupMode};
@@ -21,7 +18,6 @@ use crate::index::{Column, Line, Point, Side};
 use crate::input::{self, KeyBinding, MouseBinding};
 use crate::selection::Selection;
 use crate::sync::FairMutex;
-use crate::term::cell::Cell;
 use crate::term::{SizeInfo, Term};
 #[cfg(unix)]
 use crate::tty;
@@ -286,7 +282,6 @@ pub struct Processor<N> {
     notifier: N,
     mouse: Mouse,
     resize_tx: mpsc::Sender<PhysicalSize>,
-    ref_test: bool,
     size_info: SizeInfo,
     hide_mouse_when_typing: bool,
     hide_mouse: bool,
@@ -330,7 +325,6 @@ impl<N: Notify> Processor<N> {
             wait_for_event: true,
             notifier,
             resize_tx,
-            ref_test: config.debug.ref_test,
             mouse: Default::default(),
             size_info,
             hide_mouse_when_typing: config.mouse.hide_when_typing,
@@ -356,7 +350,6 @@ impl<N: Notify> Processor<N> {
     fn handle_event<'a>(
         processor: &mut input::Processor<'a, ActionContext<'a, N>>,
         event: Event,
-        ref_test: bool,
         resize_tx: &mpsc::Sender<PhysicalSize>,
         hide_mouse: &mut bool,
         window_is_focused: &mut bool,
@@ -367,37 +360,7 @@ impl<N: Notify> Processor<N> {
             Event::WindowEvent { event, .. } => {
                 use glutin::WindowEvent::*;
                 match event {
-                    CloseRequested => {
-                        if ref_test {
-                            // dump grid state
-                            let mut grid = processor.ctx.terminal.grid().clone();
-                            grid.initialize_all(&Cell::default());
-                            grid.truncate();
-
-                            let serialized_grid = json::to_string(&grid).expect("serialize grid");
-
-                            let serialized_size =
-                                json::to_string(processor.ctx.terminal.size_info())
-                                    .expect("serialize size");
-
-                            let serialized_config =
-                                format!("{{\"history_size\":{}}}", grid.history_size());
-
-                            File::create("./grid.json")
-                                .and_then(|mut f| f.write_all(serialized_grid.as_bytes()))
-                                .expect("write grid.json");
-
-                            File::create("./size.json")
-                                .and_then(|mut f| f.write_all(serialized_size.as_bytes()))
-                                .expect("write size.json");
-
-                            File::create("./config.json")
-                                .and_then(|mut f| f.write_all(serialized_config.as_bytes()))
-                                .expect("write config.json");
-                        }
-
-                        processor.ctx.terminal.exit();
-                    },
+                    CloseRequested => processor.ctx.terminal.exit(),
                     Resized(lsize) => {
                         // Resize events are emitted via glutin/winit with logical sizes
                         // However the terminal, window and renderer use physical sizes
@@ -492,7 +455,6 @@ impl<N: Notify> Processor<N> {
 
             let print_events = self.print_events;
 
-            let ref_test = self.ref_test;
             let resize_tx = &self.resize_tx;
 
             if self.wait_for_event {
@@ -542,7 +504,6 @@ impl<N: Notify> Processor<N> {
                     Processor::handle_event(
                         &mut processor,
                         event,
-                        ref_test,
                         resize_tx,
                         hide_mouse,
                         &mut window_is_focused,

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -252,10 +252,7 @@ impl Window {
     }
 
     #[cfg(not(any(target_os = "macos", windows)))]
-    pub fn get_platform_window(
-        title: &str,
-        window_config: &WindowConfig,
-    ) -> WindowBuilder {
+    pub fn get_platform_window(title: &str, window_config: &WindowConfig) -> WindowBuilder {
         use glutin::os::unix::WindowBuilderExt;
 
         let decorations = match window_config.decorations {
@@ -287,10 +284,7 @@ impl Window {
     }
 
     #[cfg(windows)]
-    pub fn get_platform_window(
-        title: &str,
-        window_config: &WindowConfig,
-    ) -> WindowBuilder {
+    pub fn get_platform_window(title: &str, window_config: &WindowConfig) -> WindowBuilder {
         let decorations = match window_config.decorations {
             Decorations::None => false,
             _ => true,
@@ -308,10 +302,7 @@ impl Window {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn get_platform_window(
-        title: &str,
-        window_config: &WindowConfig,
-    ) -> WindowBuilder {
+    pub fn get_platform_window(title: &str, window_config: &WindowConfig) -> WindowBuilder {
         use glutin::os::macos::WindowBuilderExt;
 
         let window = WindowBuilder::new()


### PR DESCRIPTION
Since ref tests were only stored whenever winit requested the window
close, they would not get stored properly when the terminal was closed
through Alacritty using `exit`, Ctrl+D or similar.

This moves the ref test code to the and of the main entry point, which
will always be executed regardless of how the terminal was shutdown.