### PR TITLE
Query DirectWrite for the rendering mode to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Completions for `--class` and `-t` (short title)
 - Change the mouse cursor when hovering over the message bar and its close button
 
+### Changed
+
+- On Windows, query DirectWrite for recommended anti-aliasing settings
+
 ### Fixed
 
 - GUI programs launched by Alacritty starting in the background on X11

--- a/font/src/directwrite/mod.rs
+++ b/font/src/directwrite/mod.rs
@@ -143,11 +143,17 @@ impl crate::Rasterize for DirectWriteRasterizer {
             bidiLevel: 0,
         };
 
+        let rendering_mode = font.get_recommended_rendering_mode_default_params(
+            glyph.size.as_f32_pts(),
+            self.device_pixel_ratio * (96.0 / 72.0),
+            dwrote::DWRITE_MEASURING_MODE_NATURAL
+        );
+
         let glyph_analysis = GlyphRunAnalysis::create(
             &glyph_run,
             self.device_pixel_ratio * (96.0 / 72.0),
             None,
-            dwrote::DWRITE_RENDERING_MODE_NATURAL,
+            rendering_mode,
             dwrote::DWRITE_MEASURING_MODE_NATURAL,
             0.0,
             0.0,


### PR DESCRIPTION
As an alternative to #2598, query DirectWrite for the font rendering mode to use instead of hard-coding one.

With the settings on my system this doesn't make much of a difference visually, but asking for the OS to decide the mode seems better simply because there could be different system configurations that result in different modes, or it could even be varied on a per font basis by Microsoft.