### PR TITLE
remove redundant use

### DIFF
--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -403,7 +403,6 @@ impl Window {
 
     #[cfg(target_os = "macos")]
     pub fn set_simple_fullscreen(&self, fullscreen: bool) {
-        use glutin::os::macos::WindowExt;
         self.window().set_simple_fullscreen(fullscreen);
     }
 


### PR DESCRIPTION
The outputs below were printed in executing `make app` on macOS.

```
warning: the item `WindowExt` is imported redundantly
   --> alacritty_terminal/src/window.rs:406:13
    |
22  | use glutin::os::macos::WindowExt;
    |     ---------------------------- the item `WindowExt` is already imported here
...
406 |         use glutin::os::macos::WindowExt;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(unused_imports)] on by default
```