### PR TITLE
Fix cursor flickering on url hover

### DIFF
--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -410,6 +410,7 @@ impl<N: Notify> Processor<N> {
                             processor.ctx.terminal.next_is_urgent = Some(false);
                         } else {
                             processor.ctx.terminal.reset_url_highlight();
+                            processor.ctx.terminal.reset_mouse_cursor();
                             processor.ctx.terminal.dirty = true;
                             *hide_mouse = false;
                         }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -896,6 +896,7 @@ impl Term {
     pub fn scroll_display(&mut self, scroll: Scroll) {
         self.grid.scroll_display(scroll);
         self.reset_url_highlight();
+        self.reset_mouse_cursor();
         self.dirty = true;
     }
 
@@ -1360,8 +1361,6 @@ impl Term {
 
     #[inline]
     pub fn reset_url_highlight(&mut self) {
-        self.reset_mouse_cursor();
-
         self.grid.url_highlight = None;
         self.dirty = true;
     }


### PR DESCRIPTION
This commit fixes the regression introduced in
84aca672964e29b5b4503b7da7bc34fc395f08ab.

Fixes #2665.

`reset_mouse_cursor()` was called most of the time twice during mouse move actions and in case of hovering over already highlighted url, we were resetting `hand` cursor and then immediately setting it back,  this behavior was causing cursor "flickering".