### PR TITLE
Fix Double-click selects trailing tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cursor color setting with escape sequence
 - Override default bindings with subset terminal mode match
 - On Linux, respect fontconfig's `embeddedbitmap` configuration option
+- Selecting trailing tab with semantic expansion
 
 ## 0.3.3
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -291,7 +291,7 @@ visual_bell:
 background_opacity: 1.0
 
 selection:
-  semantic_escape_chars: ",│`|:\"' ()[]{}<>"
+  semantic_escape_chars: ",│`|:\"' ()[]{}<>\t"
 
   # When set to `true`, selected text will be copied to the primary clipboard.
   save_to_clipboard: false

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -298,7 +298,7 @@ struct EscapeChars(String);
 
 impl Default for EscapeChars {
     fn default() -> Self {
-        EscapeChars(String::from(",│`|:\"' ()[]{}<>"))
+        EscapeChars(String::from(",│`|:\"' ()[]{}<>\t"))
     }
 }
 


### PR DESCRIPTION
Add `\t` to the `semantic_escape_chars` in alacritty.yml.

Fixes #2639