### PR TITLE
Fix last line update criterion in update_lines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On Linux, respect fontconfig's `embeddedbitmap` configuration option
 - Selecting trailing tab with semantic expansion
 - URL parser incorrectly handling Markdown URLs and angled brackets
+- Last line underline/strikeout update
 
 ## 0.3.3
 

--- a/alacritty_terminal/src/display.rs
+++ b/alacritty_terminal/src/display.rs
@@ -519,20 +519,12 @@ impl Display {
 
                 self.renderer.with_api(config, &size_info, |mut api| {
                     // Iterate over all non-empty cells in the grid
-                    if let Some(last_cell) = grid_cells.last() {
-                        let (last_col, last_line) = (last_cell.column, last_cell.line);
-                        for cell in grid_cells {
-                            // Update underline/strikeout
-                            if cell.line == last_line && cell.column == last_col {
-                                // Mark last cell
-                                rects.update_lines(&cell, true);
-                            } else {
-                                rects.update_lines(&cell, false);
-                            }
+                    for cell in grid_cells {
+                        // Update underline/strikeout
+                        rects.update_lines(&cell);
 
-                            // Draw the cell
-                            api.render_cell(cell, glyph_cache);
-                        }
+                        // Draw the cell
+                        api.render_cell(cell, glyph_cache);
                     }
                 });
             }

--- a/alacritty_terminal/src/display.rs
+++ b/alacritty_terminal/src/display.rs
@@ -519,12 +519,20 @@ impl Display {
 
                 self.renderer.with_api(config, &size_info, |mut api| {
                     // Iterate over all non-empty cells in the grid
-                    for cell in grid_cells {
-                        // Update underline/strikeout
-                        rects.update_lines(&size_info, &cell);
+                    if let Some(last_cell) = grid_cells.last() {
+                        let (last_col, last_line) = (last_cell.column, last_cell.line);
+                        for cell in grid_cells {
+                            // Update underline/strikeout
+                            if cell.line == last_line && cell.column == last_col {
+                                // Mark last cell
+                                rects.update_lines(&cell, true);
+                            } else {
+                                rects.update_lines(&cell, false);
+                            }
 
-                        // Draw the cell
-                        api.render_cell(cell, glyph_cache);
+                            // Draw the cell
+                            api.render_cell(cell, glyph_cache);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
`SizeInfo` lines/cols start from 1, however `RenderableCell` lines/cols start from 0, so explicit inc/dec is required. Also checking for `cell.column == size_info.cols() + 1` seems incorrect here, since it will be called, when our terminal last line will be entirely occupied by text, so underline/strikethrough wouldn't be updated most of the time.

Fixes: #2680