### PR TITLE
Move modifier check before URL search

### DIFF
--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -389,23 +389,32 @@ enum MousePosition {
 }
 
 impl<'a, A: ActionContext + 'a> Processor<'a, A> {
-    fn mouse_position(&mut self, point: Point) -> MousePosition {
+    fn mouse_position(&mut self, point: Point, modifiers: ModifiersState) -> MousePosition {
+        let mouse_mode =
+            TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG | TermMode::MOUSE_REPORT_CLICK;
+
         let buffer_point = self.ctx.terminal().visible_to_buffer(point);
 
         // Check message bar before URL to ignore URLs in the message bar
         if let Some(message) = self.message_at_point(Some(point)) {
             if self.message_close_at_point(point, message) {
-                MousePosition::MessageBarButton
+                return MousePosition::MessageBarButton;
             } else {
-                MousePosition::MessageBar
+                return MousePosition::MessageBar;
             }
-        } else if let Some(url) =
-            self.ctx.terminal().urls().drain(..).find(|url| url.contains(buffer_point))
-        {
-            MousePosition::Url(url)
-        } else {
-            MousePosition::Terminal
         }
+
+        // Check for URL at point with required modifiers held
+        if self.mouse_config.url.mods().relaxed_eq(modifiers)
+            && (!self.ctx.terminal().mode().intersects(mouse_mode) || modifiers.shift)
+            && self.mouse_config.url.launcher.is_some()
+        {
+            if let Some(url) = self.ctx.terminal().urls().drain(..).find(|url| url.contains(buffer_point)) {
+                return MousePosition::Url(url);
+            }
+        }
+
+        MousePosition::Terminal
     }
 
     #[inline]
@@ -435,20 +444,12 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         // Don't launch URLs if mouse has moved
         self.ctx.mouse_mut().block_url_launcher = true;
 
-        match self.mouse_position(point) {
+        match self.mouse_position(point, modifiers) {
             MousePosition::Url(url) => {
-                let mouse_mode =
-                    TermMode::MOUSE_MOTION | TermMode::MOUSE_DRAG | TermMode::MOUSE_REPORT_CLICK;
-
-                if self.mouse_config.url.mods().relaxed_eq(modifiers)
-                    && (!self.ctx.terminal().mode().intersects(mouse_mode) || modifiers.shift)
-                    && self.mouse_config.url.launcher.is_some()
-                {
-                    let url_bounds = url.linear_bounds(self.ctx.terminal());
-                    self.ctx.terminal_mut().set_url_highlight(url_bounds);
-                    self.ctx.terminal_mut().set_mouse_cursor(MouseCursor::Hand);
-                    self.ctx.terminal_mut().dirty = true;
-                }
+                let url_bounds = url.linear_bounds(self.ctx.terminal());
+                self.ctx.terminal_mut().set_url_highlight(url_bounds);
+                self.ctx.terminal_mut().set_mouse_cursor(MouseCursor::Hand);
+                self.ctx.terminal_mut().dirty = true;
             },
             MousePosition::MessageBar => {
                 self.ctx.terminal_mut().reset_url_highlight();

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -409,7 +409,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             && (!self.ctx.terminal().mode().intersects(mouse_mode) || modifiers.shift)
             && self.mouse_config.url.launcher.is_some()
         {
-            if let Some(url) = self.ctx.terminal().urls().drain(..).find(|url| url.contains(buffer_point)) {
+            if let Some(url) =
+                self.ctx.terminal().urls().drain(..).find(|url| url.contains(buffer_point))
+            {
                 return MousePosition::Url(url);
             }
         }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1350,6 +1350,7 @@ impl Term {
                 parser.reset();
             }
 
+            // Advance parser
             match parser.advance(cell.c) {
                 ParserState::Url(length) => {
                     urls.push(Url::new(point, length + extra_url_len, num_cols))

--- a/alacritty_terminal/src/url.rs
+++ b/alacritty_terminal/src/url.rs
@@ -18,14 +18,17 @@ impl Url {
         Url { end: Point::new(end_line, Column(end_col)), start }
     }
 
+    /// Check if point is within this URL
     pub fn contains(&self, point: impl Into<Point<usize>>) -> bool {
         let point = point.into();
+
         point.line <= self.start.line
             && point.line >= self.end.line
             && (point.line != self.start.line || point.col >= self.start.col)
             && (point.line != self.end.line || point.col <= self.end.col)
     }
 
+    /// Convert URLs bounding points to linear indices
     pub fn linear_bounds(&self, terminal: &Term) -> RangeInclusive<Linear> {
         let mut start = self.start;
         let mut end = self.end;


### PR DESCRIPTION
This makes sure that the URL search is only initiated when all required
modifiers are held down. This should improve performance with long URLs.

This was previously the case, however 72dfa47 introduced a regression
which broke this.