### PR TITLE
Fix wayland clipboard integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Selecting trailing tab with semantic expansion
 - URL parser incorrectly handling Markdown URLs and angled brackets
 - Intermediate bytes of CSI sequences not checked
+- Wayland clipboard integration
 
 ## 0.3.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
  "objc-foundation 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc_id 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smithay-client-toolkit 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smithay-clipboard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-clipboard 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.23.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-clipboard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "smithay-clipboard"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2762,7 +2762,7 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum smithay-client-toolkit 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2ccb8c57049b2a34d2cc2b203fa785020ba0129d31920ef0d317430adaf748fa"
 "checksum smithay-client-toolkit 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8c23093ebdaac1ad67558c7aef153522c6b3be7e0257820909e3a25c4519e78d"
-"checksum smithay-clipboard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8e61f8a9ef7a15bd38c29b4a39d423776b2d6092723dc7df3f0545ce7a4751e"
+"checksum smithay-clipboard 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f396e0b3877db6855c2df5c730e7fbf547e92aee6cd4d4331d4536f52556e944"
 "checksum socket2 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df028e0e632c2a1823d920ad74895e7f9128e6438cbc4bc6fd1f180e644767b9"
 "checksum spsc-buffer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be6c3f39c37a4283ee4b43d1311c828f2e1fb0541e76ea0cb1a2abd9ef2f5b3b"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -774,7 +774,7 @@ where
 
             // Set icon name
             // This is ignored, since alacritty has no concept of tabs
-            b"1" => return,
+            b"1" => (),
 
             // Set color index
             b"4" => {
@@ -903,7 +903,6 @@ where
                     "[Unhandled CSI] action={:?}, args={:?}, intermediates={:?}",
                     action, args, intermediates
                 );
-                return;
             }};
         }
 
@@ -917,6 +916,7 @@ where
 
         if has_ignored_intermediates || intermediates.len() > 1 {
             unhandled!();
+            return;
         }
 
         let handler = &mut self.handler;
@@ -958,7 +958,10 @@ where
                 let mode = match arg_or_default!(idx: 0, default: 0) {
                     0 => TabulationClearMode::Current,
                     3 => TabulationClearMode::All,
-                    _ => unhandled!(),
+                    _ => {
+                        unhandled!();
+                        return;
+                    },
                 };
 
                 handler.clear_tabs(mode);
@@ -978,7 +981,10 @@ where
                     1 => ClearMode::Above,
                     2 => ClearMode::All,
                     3 => ClearMode::Saved,
-                    _ => unhandled!(),
+                    _ => {
+                        unhandled!();
+                        return;
+                    },
                 };
 
                 handler.clear_screen(mode);
@@ -988,7 +994,10 @@ where
                     0 => LineClearMode::Right,
                     1 => LineClearMode::Left,
                     2 => LineClearMode::All,
-                    _ => unhandled!(),
+                    _ => {
+                        unhandled!();
+                        return;
+                    },
                 };
 
                 handler.clear_line(mode);
@@ -1002,13 +1011,19 @@ where
                 let is_private_mode = match intermediate {
                     Some(b'?') => true,
                     None => false,
-                    _ => unhandled!(),
+                    _ => {
+                        unhandled!();
+                        return;
+                    },
                 };
                 for arg in args {
                     let mode = Mode::from_primitive(is_private_mode, *arg);
                     match mode {
                         Some(mode) => handler.unset_mode(mode),
-                        None => unhandled!(),
+                        None => {
+                            unhandled!();
+                            return;
+                        },
                     }
                 }
             },
@@ -1027,13 +1042,19 @@ where
                 let is_private_mode = match intermediate {
                     Some(b'?') => true,
                     None => false,
-                    _ => unhandled!(),
+                    _ => {
+                        unhandled!();
+                        return;
+                    },
                 };
                 for arg in args {
                     let mode = Mode::from_primitive(is_private_mode, *arg);
                     match mode {
                         Some(mode) => handler.set_mode(mode),
-                        None => unhandled!(),
+                        None => {
+                            unhandled!();
+                            return;
+                        },
                     }
                 }
             },
@@ -1044,7 +1065,10 @@ where
                     for attr in attrs_from_sgr_parameters(args) {
                         match attr {
                             Some(attr) => handler.terminal_attribute(attr),
-                            None => unhandled!(),
+                            None => {
+                                unhandled!();
+                                return;
+                            },
                         }
                     }
                 }
@@ -1059,7 +1083,10 @@ where
                     1 | 2 => Some(CursorStyle::Block),
                     3 | 4 => Some(CursorStyle::Underline),
                     5 | 6 => Some(CursorStyle::Beam),
-                    _ => unhandled!(),
+                    _ => {
+                        unhandled!();
+                        return;
+                    },
                 };
 
                 handler.set_cursor_style(style);
@@ -1090,7 +1117,6 @@ where
                     "[unhandled] esc_dispatch params={:?}, ints={:?}, byte={:?} ({:02x})",
                     params, intermediates, byte as char, byte
                 );
-                return;
             }};
         }
 
@@ -1101,7 +1127,10 @@ where
                     Some(b')') => CharsetIndex::G1,
                     Some(b'*') => CharsetIndex::G2,
                     Some(b'+') => CharsetIndex::G3,
-                    _ => unhandled!(),
+                    _ => {
+                        unhandled!();
+                        return;
+                    },
                 };
                 self.handler.configure_charset(index, $charset)
             }};

--- a/alacritty_terminal/src/util.rs
+++ b/alacritty_terminal/src/util.rs
@@ -29,8 +29,7 @@ pub mod thread {
     /// Like `thread::spawn`, but with a `name` argument
     pub fn spawn_named<F, T, S>(name: S, f: F) -> ::std::thread::JoinHandle<T>
     where
-        F: FnOnce() -> T,
-        F: Send + 'static,
+        F: FnOnce() -> T + Send + 'static,
         T: Send + 'static,
         S: Into<String>,
     {

--- a/copypasta/Cargo.toml
+++ b/copypasta/Cargo.toml
@@ -17,7 +17,7 @@ objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 x11-clipboard = "0.3"
-smithay-clipboard = "0.3.2"
+smithay-clipboard = "0.3.4"
 wayland-client = { version = "0.23.3", features = ["dlopen"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dev-dependencies]

--- a/copypasta/examples/wayland.rs
+++ b/copypasta/examples/wayland.rs
@@ -14,7 +14,7 @@ mod wayland {
     extern crate copypasta;
     extern crate smithay_client_toolkit as sctk;
 
-    use wayland::copypasta::wayland_clipboard::{Clipboard, WaylandClipboardContext};
+    use wayland::copypasta::wayland_clipboard::create_clipboards;
     use wayland::copypasta::ClipboardProvider;
 
     use std::io::{Read, Seek, SeekFrom, Write};
@@ -37,7 +37,7 @@ mod wayland {
             Display::connect_to_env().expect("Failed to connect to the wayland server.");
         let env = Environment::from_display(&*display, &mut event_queue).unwrap();
 
-        let mut ctx = WaylandClipboardContext::<Clipboard>::new(&display);
+        let (mut ctx, _) = create_clipboards(&display);
         let cb_contents = Arc::new(Mutex::new(String::new()));
 
         let seat = env.manager.instantiate_range(2, 6, NewProxy::implement_dummy).unwrap();

--- a/copypasta/src/wayland_clipboard.rs
+++ b/copypasta/src/wayland_clipboard.rs
@@ -34,14 +34,14 @@ pub struct Primary {
 pub fn create_clipboards(display: &Display) -> (Primary, Clipboard) {
     let context = Arc::new(Mutex::new(WaylandClipboard::new(display)));
 
-    (Primary { context: context.clone() }, Clipboard { context } )
+    (Primary { context: context.clone() }, Clipboard { context })
 }
 
 pub unsafe fn create_clipboards_from_external(display: *mut c_void) -> (Primary, Clipboard) {
     let context =
         Arc::new(Mutex::new(WaylandClipboard::new_from_external(display as *mut wl_display)));
 
-    (Primary { context: context.clone() }, Clipboard { context} )
+    (Primary { context: context.clone() }, Clipboard { context })
 }
 
 impl ClipboardProvider for Clipboard {

--- a/copypasta/src/wayland_clipboard.rs
+++ b/copypasta/src/wayland_clipboard.rs
@@ -14,57 +14,69 @@
 
 use std::error::Error;
 use std::ffi::c_void;
-use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
 
 use smithay_clipboard::WaylandClipboard;
+
 use wayland_client::sys::client::wl_display;
 use wayland_client::Display;
 
 use common::ClipboardProvider;
 
-pub trait ClipboardType: Send {}
+pub struct Clipboard {
+    clipboard_context: Arc<Mutex<WaylandClipboard>>,
+}
+pub struct Primary {
+    clipboard_context: Arc<Mutex<WaylandClipboard>>,
+}
 
-pub struct Clipboard;
-impl ClipboardType for Clipboard {}
-
-pub struct Primary;
-impl ClipboardType for Primary {}
-
-pub struct WaylandClipboardContext<T: ClipboardType>(WaylandClipboard, PhantomData<T>);
-
-impl<T: ClipboardType> WaylandClipboardContext<T> {
-    /// Create a new clipboard context.
-    pub fn new(display: &Display) -> Self {
-        WaylandClipboardContext(WaylandClipboard::new(display), PhantomData)
-    }
-
-    /// Create a new clipboard context from an external pointer.
-    pub unsafe fn new_from_external(display: *mut c_void) -> Self {
-        WaylandClipboardContext(
-            WaylandClipboard::new_from_external(display as *mut wl_display),
-            PhantomData,
-        )
+impl Primary {
+    fn new(clipboard_context: Arc<Mutex<WaylandClipboard>>) -> Self {
+        Self { clipboard_context }
     }
 }
 
-impl ClipboardProvider for WaylandClipboardContext<Clipboard> {
+impl Clipboard {
+    fn new(clipboard_context: Arc<Mutex<WaylandClipboard>>) -> Self {
+        Self { clipboard_context }
+    }
+}
+
+pub fn create_clipboards(display: &Display) -> (Primary, Clipboard) {
+    let context = Arc::new(Mutex::new(WaylandClipboard::new(display)));
+    let context_clone = context.clone();
+    (Primary::new(context), Clipboard::new(context_clone))
+}
+
+pub unsafe fn create_clipboards_from_external(display: *mut c_void) -> (Primary, Clipboard) {
+    let context =
+        Arc::new(Mutex::new(WaylandClipboard::new_from_external(display as *mut wl_display)));
+    let context_clone = context.clone();
+    (Primary::new(context), Clipboard::new(context_clone))
+}
+
+impl ClipboardProvider for Clipboard {
     fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
-        Ok(self.0.load(None))
+        let mut clipboard = self.clipboard_context.lock().unwrap();
+        Ok(clipboard.load(None))
     }
 
     fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
-        self.0.store(None, data);
+        let mut clipboard = self.clipboard_context.lock().unwrap();
+        clipboard.store(None, data);
         Ok(())
     }
 }
 
-impl ClipboardProvider for WaylandClipboardContext<Primary> {
+impl ClipboardProvider for Primary {
     fn get_contents(&mut self) -> Result<String, Box<dyn Error>> {
-        Ok(self.0.load_primary(None))
+        let mut clipboard = self.clipboard_context.lock().unwrap();
+        Ok(clipboard.load_primary(None))
     }
 
     fn set_contents(&mut self, data: String) -> Result<(), Box<dyn Error>> {
-        self.0.store_primary(None, data);
+        let mut clipboard = self.clipboard_context.lock().unwrap();
+        clipboard.store_primary(None, data);
         Ok(())
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,9 @@
+format_code_in_doc_comments = true
 match_block_trailing_comma = true
 condense_wildcard_suffixes = true
 use_field_init_shorthand = true
 overflow_delimited_expr = true
 use_small_heuristics = "Max"
-format_doc_comments = true
 normalize_comments = true
 reorder_impl_items = true
 use_try_shorthand = true


### PR DESCRIPTION
What was fixed here:
- [x] Implement `gtk_primary_selection_device_manager` ( `smithay-clipborad`)
- [X] Fix race? or whatever with normal clipboard on GNOME ( `smithay-clipboard` or `alacritty` )
- [ ] Clipboard dies over time on sway/probably GNOME (`smithay-clipboard`)

Initial attempt to fix clipboard on wayland.

Fixes: #2574