### PR TITLE
Reset the Mouse Cursor While Selecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wayland clipboard integration
 - Use text mouse cursor when mouse mode is temporarily disabled with shift
 - Wayland primary selection clipboard not storing text when selection is stopped outside of the window
+- Block URL highlight while a selection is active
 
 ## 0.3.3
 

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -449,6 +449,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
         if self.mouse_config.url.mods().relaxed_eq(mods)
             && (!self.ctx.terminal().mode().intersects(mouse_mode) || mods.shift)
             && self.mouse_config.url.launcher.is_some()
+            && self.ctx.selection_is_empty()
+            && self.ctx.mouse().left_button_state != ElementState::Pressed
         {
             let buffer_point = self.ctx.terminal().visible_to_buffer(point);
             if let Some(url) =
@@ -691,34 +693,34 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             self.mouse_report(code, ElementState::Released, modifiers);
             return;
         } else if let (Some(point), true) = (point, button == MouseButton::Left) {
-            self.launch_url(modifiers, point);
+            let mouse_state = self.mouse_state(point, modifiers);
+            self.update_mouse_cursor(mouse_state);
+            if let MouseState::Url(url) = mouse_state {
+                let url_bounds = url.linear_bounds(self.ctx.terminal());
+                self.ctx.terminal_mut().set_url_highlight(url_bounds);
+                self.launch_url(url);
+            }
         }
 
         self.copy_selection();
     }
 
     // Spawn URL launcher when clicking on URLs
-    fn launch_url(&self, modifiers: ModifiersState, point: Point) -> Option<()> {
-        if !self.mouse_config.url.mods().relaxed_eq(modifiers)
-            || self.ctx.mouse().block_url_launcher
-        {
-            return None;
+    fn launch_url(&self, url: Url) {
+        if self.ctx.mouse().block_url_launcher {
+            return;
         }
 
-        let point = self.ctx.terminal().visible_to_buffer(point);
-        let url = self.ctx.terminal().urls().drain(..).find(|url| url.contains(point))?;
-        let text = self.ctx.terminal().url_to_string(&url);
+        let text = self.ctx.terminal().url_to_string(url);
+        if let Some(ref launcher) = self.mouse_config.url.launcher {
+            let mut args = launcher.args().to_vec();
+            args.push(text);
 
-        let launcher = self.mouse_config.url.launcher.as_ref()?;
-        let mut args = launcher.args().to_vec();
-        args.push(text);
-
-        match start_daemon(launcher.program(), &args) {
-            Ok(_) => debug!("Launched {} with args {:?}", launcher.program(), args),
-            Err(_) => warn!("Unable to launch {} with args {:?}", launcher.program(), args),
+            match start_daemon(launcher.program(), &args) {
+                Ok(_) => debug!("Launched {} with args {:?}", launcher.program(), args),
+                Err(_) => warn!("Unable to launch {} with args {:?}", launcher.program(), args),
+            }
         }
-
-        Some(())
     }
 
     pub fn on_mouse_wheel(

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -711,10 +711,9 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
             return;
         }
 
-        let text = self.ctx.terminal().url_to_string(url);
         if let Some(ref launcher) = self.mouse_config.url.launcher {
             let mut args = launcher.args().to_vec();
-            args.push(text);
+            args.push(self.ctx.terminal().url_to_string(url));
 
             match start_daemon(launcher.program(), &args) {
                 Ok(_) => debug!("Launched {} with args {:?}", launcher.program(), args),

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1359,7 +1359,7 @@ impl Term {
         urls
     }
 
-    pub fn url_to_string(&self, url: &Url) -> String {
+    pub fn url_to_string(&self, url: Url) -> String {
         let mut url_text = String::new();
 
         let mut iter = self.grid.iter_from(url.start);


### PR DESCRIPTION
This change makes the mouse cursor reset to it's default state while a selection is in progress. A click to clear the selection doesn't trigger a URL action, and so the mouse hand style isn't applied until the selection is cleared.

Before:
![before](https://user-images.githubusercontent.com/715947/62955430-0a41d300-bdbf-11e9-8629-dc5a1368a20b.gif)

After:
![after](https://user-images.githubusercontent.com/715947/62955446-10d04a80-bdbf-11e9-8353-dd5224951f9d.gif)