### PR TITLE
Support bold italic font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config option `window.gtk_theme_variant` to set GTK theme variant
 - Completions for `--class` and `-t` (short title)
 - Change the mouse cursor when hovering over the message bar and its close button
+- Support combined bold and italic text (with `font.bold_italic` to customize it)
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -145,6 +145,17 @@ font:
     # The `style` can be specified to pick a specific face.
     #style: Italic
 
+  # Bold italic font face
+  #bold_italic:
+    # Font family
+    #
+    # If the bold italic family is not specified, it will fall back to the
+    # value specified for the normal font.
+    #family: monospace
+
+    # The `style` can be specified to pick a specific face.
+    #style: Bold Italic
+
   # Point size
   size: 11.0
 

--- a/alacritty_terminal/src/config/font.rs
+++ b/alacritty_terminal/src/config/font.rs
@@ -23,11 +23,15 @@ pub struct Font {
 
     /// Bold font face
     #[serde(deserialize_with = "failure_default")]
-    italic: SecondaryFontDescription,
+    bold: SecondaryFontDescription,
 
     /// Italic font face
     #[serde(deserialize_with = "failure_default")]
-    bold: SecondaryFontDescription,
+    italic: SecondaryFontDescription,
+
+    /// Bold italic font face
+    #[serde(deserialize_with = "failure_default")]
+    bold_italic: SecondaryFontDescription,
 
     /// Font size in points
     #[serde(deserialize_with = "DeserializeSize::deserialize")]
@@ -53,6 +57,7 @@ impl Default for Font {
             normal: Default::default(),
             bold: Default::default(),
             italic: Default::default(),
+            bold_italic: Default::default(),
             glyph_offset: Default::default(),
             offset: Default::default(),
             #[cfg(target_os = "macos")]
@@ -72,14 +77,19 @@ impl Font {
         &self.normal
     }
 
+    // Get bold font description
+    pub fn bold(&self) -> FontDescription {
+        self.bold.desc(&self.normal)
+    }
+
     // Get italic font description
     pub fn italic(&self) -> FontDescription {
         self.italic.desc(&self.normal)
     }
 
-    // Get bold font description
-    pub fn bold(&self) -> FontDescription {
-        self.bold.desc(&self.normal)
+    // Get bold italic font description
+    pub fn bold_italic(&self) -> FontDescription {
+        self.bold_italic.desc(&self.normal)
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
It’s perfectly reasonable to combine bold and italic.

I also normalised the ordering of the four variants, which was inconsistent in some places (including also the doc comment not matching the code in one place), to this: regular, bold, italic, bold italic.

This may functionally be a slight regression for fonts that don’t have a bold italic variant, because I suppose it’ll pick some other variant, I know not which, rather than the bold font. If we care about that enough, we can fiddle it in config::font to fall back to bold rather than normal, and in renderer to fall back to bold rather than I know not what. I didn’t do that due to the (very) mild complexity involved, because of the rareness I expect of manually setting a bold font that differs materially from the normal font, and because I naively expect the renderer fallback to do a sane thing out of the box.

----

Untested because I’m on Windows and italics aren’t working there (#2745). It builds and runs, but I can’t definitely say further than that.