### PR TITLE
Follow zsh conventions in zsh completion

### DIFF
--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -1,26 +1,22 @@
 #compdef alacritty
 
-_alacritty() {
-    local context curcontext="$curcontext" state line
-    typeset -A opt_args
+local ign
 
-    _arguments \
-        "(-h --help)"{-h,--help}"[Prints help information]" \
-        "(-V --version)"{-V,--version}"[Prints version information]" \
-        "(--no-live-config-reload)--live-config-reload[Enable automatic config reloading]" \
-        "(--live-config-reload)--no-live-config-reload[Disable automatic config reloading]" \
-        "(--persistent-logging)--persistent-logging[Keep the log file after quitting Alacritty]" \
-        "--print-events[Print all events to stdout]" \
-        {-q,-qq}"[Reduces the level of verbosity (min is -qq)]" \
-        {-v,-vv,-vvv}"[Increases the level of verbosity (max is -vvv)]" \
-        "--ref-test[Generates ref test]" \
-        "--config-file[Specify an alternative config file]:file:_files" \
-        "(-d --dimensions)"{-d,--dimensions}"[Window dimensions]:dimensions:_guard '<->' width: :_guard '<->' length" \
-        "--position[Window position]:position:_guard '<->' x-pos: :_guard '<->' y-pos" \
-        "(-t --title)"{-t,--title}"[Defines the window title]:title:" \
-        "--class[Defines the window class]:class:" \
-        "--working-directory[Start shell in specified directory]:directory:_dir_list" \
-        "(-e --command)"{-e,--command}"[Execute command (must be last arg)]:program: _command_names -e:*::program arguments: _normal"
-}
-
-_alacritty "$@"
+(( $#words > 2 )) && ign='!'
+_arguments \
+  "$ign(-)"{-h,--help}"[print help information]" \
+  "(--no-live-config-reload)--live-config-reload[enable automatic config reloading]" \
+  "(--live-config-reload)--no-live-config-reload[disable automatic config reloading]" \
+  "(--persistent-logging)--persistent-logging[keep the log file after quitting Alacritty]" \
+  "--print-events[print all events to stdout]" \
+  '(-v)'{-q,-qq}"[reduce the level of verbosity (min is -qq)]" \
+  "--ref-test[generate ref test]" \
+  '(-q)'{-v,-vv,-vvv}"[increase the level of verbosity (max is -vvv)]" \
+  "$ign(-)"{-V,--version}"[print version information]" \
+  "--class=[define the window class]:class" \
+  "(-e --command)"{-e,--command}"[execute command (must be last arg)]:program: _command_names -e:*::program arguments: _normal" \
+  "--config-file=[specify an alternative config file]:file:_files" \
+  "(-d --dimensions)"{-d,--dimensions}"[specify window dimensions]:columns: :lines" \
+  "--position[specify window position]:x position: :y position" \
+  "(-t --title)"{-t+,--title=}"[define the window title]:title" \
+  "--working-directory=[start shell in specified directory]:directory:_directories"


### PR DESCRIPTION
This also encompasses some functional improvements like handling = between options and their arguments and reflecting some cases of option mutual exclusion.

Declaring curcontext etc local is superfluous as _arguments states are not used. It is also superfluous to include an outer function definition syntax in zsh autoloadable functions: _alacritty() { ... } is implied.

Zsh convention is not to capitalize descriptions.

We also generally use the imperative mood verb form for descriptions as this allows them to start with the shortest form of the verb - e.g. "reduce" instead of "reduces" and
results in better grammar in the absence of an explicit sentence subject. I'd
recommend this in the --help output too.

Using _guard for the position and dimensions was unnecessary given that the values are not mixed with other matches.