### PR TITLE
Continuously track visible URLs

### DIFF
--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -358,7 +358,7 @@ impl Display {
     /// This call may block if vsync is enabled
     pub fn draw<T>(
         &mut self,
-        terminal: MutexGuard<'_, Term<T>>,
+        mut terminal: MutexGuard<'_, Term<T>>,
         message_buffer: &MessageBuffer,
         config: &Config,
     ) {
@@ -372,6 +372,11 @@ impl Display {
         // Update IME position
         #[cfg(not(windows))]
         self.window.update_ime_position(&terminal, &self.size_info);
+
+        // Update visible URLs
+        if config.ui_config.mouse.url.launcher.is_some() {
+            terminal.update_urls();
+        }
 
         // Drop terminal as early as possible to free lock
         drop(terminal);

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -252,9 +252,9 @@ impl<'a, T: EventListener, A: ActionContext<T> + 'a> Processor<'a, T, A> {
         {
             let buffer_point = self.ctx.terminal().visible_to_buffer(point);
             if let Some(url) =
-                self.ctx.terminal().urls().drain(..).find(|url| url.contains(buffer_point))
+                self.ctx.terminal().urls().iter().find(|url| url.contains(buffer_point))
             {
-                return MouseState::Url(url);
+                return MouseState::Url(*url);
             }
         }
 


### PR DESCRIPTION
This PR scans for URLs every frame, and it will only go 4096 characters away from the current viewport. It starts scanning 4096 characters below the viewport, and it stops scanning either once the last URL that extends above the viewport ends, or once the last URL reaches 4096 characters.

I made sure to scan before events are processed but after they're gathered, so that the events always operate on the same lock as the URL scan.

Thanks, feedback welcome!