### PR TITLE
Add Xembed support.

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -134,7 +134,7 @@ impl Options {
                 Arg::with_name("embed")
                     .long("embed")
                     .takes_value(true)
-                    .help("Defines the X11 window ID (as a decimal integer) to embed Alacritty within."),
+                    .help("Defines the X11 window ID (as a decimal integer) to embed Alacritty within"),
             )
             .arg(
                 Arg::with_name("q")

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -71,106 +71,104 @@ impl Options {
 
         let mut options = Options::default();
 
-        let matches = App::new(crate_name!())
-            .version(version.as_str())
-            .author(crate_authors!("\n"))
-            .about(crate_description!())
-            .arg(Arg::with_name("ref-test").long("ref-test").help("Generates ref test"))
-            .arg(
-                Arg::with_name("live-config-reload")
-                    .long("live-config-reload")
-                    .help("Enable automatic config reloading"),
-            )
-            .arg(
-                Arg::with_name("no-live-config-reload")
-                    .long("no-live-config-reload")
-                    .help("Disable automatic config reloading")
-                    .conflicts_with("live-config-reload"),
-            )
-            .arg(
-                Arg::with_name("print-events")
-                    .long("print-events")
-                    .help("Print all events to stdout"),
-            )
-            .arg(
-                Arg::with_name("persistent-logging")
-                    .long("persistent-logging")
-                    .help("Keep the log file after quitting Alacritty"),
-            )
-            .arg(
-                Arg::with_name("dimensions")
-                    .long("dimensions")
-                    .short("d")
-                    .value_names(&["columns", "lines"])
-                    .help(
-                        "Defines the window dimensions. Falls back to size specified by window \
-                         manager if set to 0x0 [default: 0x0]",
-                    ),
-            )
-            .arg(
-                Arg::with_name("position")
-                    .long("position")
-                    .allow_hyphen_values(true)
-                    .value_names(&["x-pos", "y-pos"])
-                    .help(
-                        "Defines the window position. Falls back to position specified by window \
-                         manager if unset [default: unset]",
-                    ),
-            )
-            .arg(
-                Arg::with_name("title")
-                    .long("title")
-                    .short("t")
-                    .takes_value(true)
-                    .help(&format!("Defines the window title [default: {}]", DEFAULT_NAME)),
-            )
-            .arg(
-                Arg::with_name("class")
-                    .long("class")
-                    .takes_value(true)
-                    .help(&format!("Defines window class on Linux [default: {}]", DEFAULT_NAME)),
-            )
-            .arg(
-                Arg::with_name("embed")
-                    .long("embed")
-                    .takes_value(true)
-                    .help("Defines the X11 window ID (as a decimal integer) to embed Alacritty within"),
-            )
-            .arg(
-                Arg::with_name("q")
-                    .short("q")
-                    .multiple(true)
-                    .conflicts_with("v")
-                    .help("Reduces the level of verbosity (the min level is -qq)"),
-            )
-            .arg(
-                Arg::with_name("v")
-                    .short("v")
-                    .multiple(true)
-                    .conflicts_with("q")
-                    .help("Increases the level of verbosity (the max level is -vvv)"),
-            )
-            .arg(
-                Arg::with_name("working-directory")
-                    .long("working-directory")
-                    .takes_value(true)
-                    .help("Start the shell in the specified working directory"),
-            )
-            .arg(Arg::with_name("config-file").long("config-file").takes_value(true).help(
-                "Specify alternative configuration file [default: \
-                 $XDG_CONFIG_HOME/alacritty/alacritty.yml]",
-            ))
-            .arg(
-                Arg::with_name("command")
-                    .long("command")
-                    .short("e")
-                    .multiple(true)
-                    .takes_value(true)
-                    .min_values(1)
-                    .allow_hyphen_values(true)
-                    .help("Command and args to execute (must be last argument)"),
-            )
-            .get_matches();
+        let matches =
+            App::new(crate_name!())
+                .version(version.as_str())
+                .author(crate_authors!("\n"))
+                .about(crate_description!())
+                .arg(Arg::with_name("ref-test").long("ref-test").help("Generates ref test"))
+                .arg(
+                    Arg::with_name("live-config-reload")
+                        .long("live-config-reload")
+                        .help("Enable automatic config reloading"),
+                )
+                .arg(
+                    Arg::with_name("no-live-config-reload")
+                        .long("no-live-config-reload")
+                        .help("Disable automatic config reloading")
+                        .conflicts_with("live-config-reload"),
+                )
+                .arg(
+                    Arg::with_name("print-events")
+                        .long("print-events")
+                        .help("Print all events to stdout"),
+                )
+                .arg(
+                    Arg::with_name("persistent-logging")
+                        .long("persistent-logging")
+                        .help("Keep the log file after quitting Alacritty"),
+                )
+                .arg(
+                    Arg::with_name("dimensions")
+                        .long("dimensions")
+                        .short("d")
+                        .value_names(&["columns", "lines"])
+                        .help(
+                            "Defines the window dimensions. Falls back to size specified by \
+                             window manager if set to 0x0 [default: 0x0]",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("position")
+                        .long("position")
+                        .allow_hyphen_values(true)
+                        .value_names(&["x-pos", "y-pos"])
+                        .help(
+                            "Defines the window position. Falls back to position specified by \
+                             window manager if unset [default: unset]",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("title")
+                        .long("title")
+                        .short("t")
+                        .takes_value(true)
+                        .help(&format!("Defines the window title [default: {}]", DEFAULT_NAME)),
+                )
+                .arg(
+                    Arg::with_name("class").long("class").takes_value(true).help(&format!(
+                        "Defines window class on Linux [default: {}]",
+                        DEFAULT_NAME
+                    )),
+                )
+                .arg(Arg::with_name("embed").long("embed").takes_value(true).help(
+                    "Defines the X11 window ID (as a decimal integer) to embed Alacritty within",
+                ))
+                .arg(
+                    Arg::with_name("q")
+                        .short("q")
+                        .multiple(true)
+                        .conflicts_with("v")
+                        .help("Reduces the level of verbosity (the min level is -qq)"),
+                )
+                .arg(
+                    Arg::with_name("v")
+                        .short("v")
+                        .multiple(true)
+                        .conflicts_with("q")
+                        .help("Increases the level of verbosity (the max level is -vvv)"),
+                )
+                .arg(
+                    Arg::with_name("working-directory")
+                        .long("working-directory")
+                        .takes_value(true)
+                        .help("Start the shell in the specified working directory"),
+                )
+                .arg(Arg::with_name("config-file").long("config-file").takes_value(true).help(
+                    "Specify alternative configuration file [default: \
+                     $XDG_CONFIG_HOME/alacritty/alacritty.yml]",
+                ))
+                .arg(
+                    Arg::with_name("command")
+                        .long("command")
+                        .short("e")
+                        .multiple(true)
+                        .takes_value(true)
+                        .min_values(1)
+                        .allow_hyphen_values(true)
+                        .help("Command and args to execute (must be last argument)"),
+                )
+                .get_matches();
 
         if matches.is_present("ref-test") {
             options.ref_test = true;

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -134,7 +134,7 @@ impl Options {
                 Arg::with_name("embed")
                     .long("embed")
                     .takes_value(true)
-                    .help("Defines an X window ID (as a decimal integer) which will serve as the parent when embedding Alacritty within other applications."),
+                    .help("Defines the X11 window ID (as a decimal integer) to embed Alacritty within."),
             )
             .arg(
                 Arg::with_name("q")

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -134,7 +134,7 @@ impl Options {
                 Arg::with_name("embed")
                     .long("embed")
                     .takes_value(true)
-                    .help("Sets the XEmbed parent window ID (as a long value)"),
+                    .help("Defines an X window ID (as a decimal integer) which will serve as the parent when embedding Alacritty within other applications."),
             )
             .arg(
                 Arg::with_name("q")

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -134,7 +134,7 @@ impl Options {
                 Arg::with_name("embed")
                     .long("embed")
                     .takes_value(true)
-                    .help("Defines a parent window ID for XEmbed on Linux"),
+                    .help("Sets the XEmbed parent window ID (as a long value)"),
             )
             .arg(
                 Arg::with_name("q")

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -32,6 +32,7 @@ pub struct Options {
     pub position: Option<Delta<i32>>,
     pub title: Option<String>,
     pub class: Option<String>,
+    pub embed: Option<String>,
     pub log_level: LevelFilter,
     pub command: Option<Shell<'static>>,
     pub working_dir: Option<PathBuf>,
@@ -49,6 +50,7 @@ impl Default for Options {
             position: None,
             title: None,
             class: None,
+            embed: None,
             log_level: LevelFilter::Warn,
             command: None,
             working_dir: None,
@@ -129,6 +131,12 @@ impl Options {
                     .help(&format!("Defines window class on Linux [default: {}]", DEFAULT_NAME)),
             )
             .arg(
+                Arg::with_name("embed")
+                    .long("embed")
+                    .takes_value(true)
+                    .help("Defines a parent window ID for XEmbed on Linux"),
+            )
+            .arg(
                 Arg::with_name("q")
                     .short("q")
                     .multiple(true)
@@ -200,6 +208,7 @@ impl Options {
 
         options.class = matches.value_of("class").map(ToOwned::to_owned);
         options.title = matches.value_of("title").map(ToOwned::to_owned);
+        options.embed = matches.value_of("embed").map(ToOwned::to_owned);
 
         match matches.occurrences_of("q") {
             0 => {},
@@ -250,6 +259,7 @@ impl Options {
         config.window.dimensions = self.dimensions.unwrap_or(config.window.dimensions);
         config.window.position = self.position.or(config.window.position);
         config.window.title = self.title.or(config.window.title);
+        config.window.embed = self.embed.and_then(|embed| embed.parse().ok());
 
         if let Some(class) = self.class {
             let parts: Vec<_> = class.split(',').collect();

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -39,6 +39,10 @@ pub struct WindowConfig {
     #[serde(deserialize_with = "from_string_or_deserialize")]
     pub class: Class,
 
+    /// XEmbed parent
+    #[serde(deserialize_with = "failure_default")]
+    pub embed: Option<u64>,
+
     /// GTK theme variant
     #[serde(deserialize_with = "option_explicit_none")]
     pub gtk_theme_variant: Option<String>,

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -40,7 +40,7 @@ pub struct WindowConfig {
     pub class: Class,
 
     /// XEmbed parent
-    #[serde(deserialize_with = "failure_default")]
+    #[serde(skip_deserializing)]
     pub embed: Option<u64>,
 
     /// GTK theme variant

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -40,7 +40,7 @@ pub struct WindowConfig {
     pub class: Class,
 
     /// XEmbed parent
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     pub embed: Option<u64>,
 
     /// GTK theme variant

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -34,7 +34,7 @@ use glutin::{
 #[cfg(not(target_os = "macos"))]
 use image::ImageFormat;
 #[cfg(not(any(target_os = "macos", windows)))]
-use x11_dl::xlib::{PropModeReplace, Xlib};
+use x11_dl::xlib::PropModeReplace;
 
 use crate::config::{Config, Decorations, StartupMode, WindowConfig};
 use crate::gl;
@@ -432,7 +432,7 @@ fn x_embed_window(window: &GlutinWindow, parent_id: u64) {
         _ => return,
     };
 
-    let xlib = Xlib::open().expect("get xlib");
+    let xlib = &window.get_xlib_xconnection().expect("no xlib connection").xlib;
 
     unsafe {
         let atom = (xlib.XInternAtom)(xlib_display as *mut _, "_XEMBED".as_ptr() as *const _, 0);

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::convert::From;
+#[cfg(not(any(target_os = "macos", windows)))]
 use std::process;
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::ffi::c_void;

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -446,15 +446,16 @@ fn x_embed_window(window: &GlutinWindow, parent_window_id: u64) {
             2,
         );
         
-        // set a handler to deal with unsuccessful reparenting
+        // set a handler before verifying target window existence
         let old_handler = (xlib.XSetErrorHandler)(Some(ctx_error_handler));
-        // reparent the window with a specific handler in-place
-        (xlib.XReparentWindow)(xlib_display as _, xlib_window as _, parent_window_id, 0, 0);
         // XReparentWindow doesn't give helpful results, so poke the window here
         let mut attribs = std::mem::MaybeUninit::<x11_dl::xlib::XWindowAttributes>::uninit();
-        (xlib.XGetWindowAttributes)(xlib_display as _, xlib_window as _, attribs.as_mut_ptr());
+        (xlib.XGetWindowAttributes)(xlib_display as _, parent_window_id, attribs.as_mut_ptr());
         // restore the original handler
         (xlib.XSetErrorHandler)(std::mem::transmute(old_handler));
+
+        // reparent the window with a specific handler in-place
+        (xlib.XReparentWindow)(xlib_display as _, xlib_window as _, parent_window_id, 0, 0);
     }
 }
 

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -446,26 +446,15 @@ fn x_embed_window(window: &GlutinWindow, parent_window_id: u64) {
             2,
         );
         
-        // set a handler before verifying target window existence
-        let old_handler = (xlib.XSetErrorHandler)(Some(ctx_error_handler));
-        // XReparentWindow doesn't give helpful results, so poke the window here
+        // Check for the existence of the target before attempting reparenting
         let mut attribs = std::mem::MaybeUninit::<x11_dl::xlib::XWindowAttributes>::uninit();
-        (xlib.XGetWindowAttributes)(xlib_display as _, parent_window_id, attribs.as_mut_ptr());
-        // restore the original handler
-        (xlib.XSetErrorHandler)(std::mem::transmute(old_handler));
-
-        // reparent the window with a specific handler in-place
-        (xlib.XReparentWindow)(xlib_display as _, xlib_window as _, parent_window_id, 0, 0);
+        if (xlib.XGetWindowAttributes)(xlib_display as _, parent_window_id, attribs.as_mut_ptr()) == 0 {
+            eprintln!("Could not embed into specified window.");
+            process::exit(1);
+        } else {
+            (xlib.XReparentWindow)(xlib_display as _, xlib_window as _, parent_window_id, 0, 0);
+        }
     }
-}
-
-#[cfg(not(any(target_os = "macos", windows)))]
-unsafe extern "C" fn ctx_error_handler(
-        _dpy: *mut x11_dl::xlib::Display,
-        _ev: *mut x11_dl::xlib::XErrorEvent
-        ) -> i32 {
-    eprintln!("Could not embed into specified window.");
-    process::exit(1);
 }
 
 impl Proxy {

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -32,7 +32,7 @@ use glutin::{
 #[cfg(not(target_os = "macos"))]
 use image::ImageFormat;
 #[cfg(not(any(target_os = "macos", windows)))]
-use x11_dl::xlib::{Display as XDisplay, PropModeReplace, XErrorEvent};
+use x11_dl::xlib::{Xlib, Display as XDisplay, PropModeReplace, XErrorEvent};
 
 use crate::config::{Config, Decorations, StartupMode, WindowConfig};
 use crate::gl;
@@ -430,7 +430,7 @@ fn x_embed_window(window: &GlutinWindow, parent_id: u64) {
         _ => return,
     };
 
-    let xlib = &window.get_xlib_xconnection().expect("no xlib connection").xlib;
+    let xlib = Xlib::open().expect("get xlib");
 
     unsafe {
         let atom = (xlib.XInternAtom)(xlib_display as *mut _, "_XEMBED".as_ptr() as *const _, 0);

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -23,14 +23,16 @@ use glutin::os::macos::WindowExt;
 use glutin::os::unix::{EventsLoopExt, WindowExt};
 #[cfg(not(target_os = "macos"))]
 use glutin::Icon;
+#[cfg(not(any(target_os = "macos", windows)))]
+use glutin::Window as GlutinWindow;
 use glutin::{
     self, ContextBuilder, ControlFlow, Event, EventsLoop, MouseCursor, PossiblyCurrent,
-    Window as GlutinWindow, WindowBuilder,
+    WindowBuilder,
 };
 #[cfg(not(target_os = "macos"))]
 use image::ImageFormat;
 #[cfg(not(any(target_os = "macos", windows)))]
-use x11_dl::xlib::{PropModeReplace, Display as XDisplay, XErrorEvent};
+use x11_dl::xlib::{Display as XDisplay, PropModeReplace, XErrorEvent};
 
 use crate::config::{Config, Decorations, StartupMode, WindowConfig};
 use crate::gl;
@@ -455,9 +457,9 @@ fn x_embed_window(window: &GlutinWindow, parent_id: u64) {
     }
 }
 
+#[cfg(not(any(target_os = "macos", windows)))]
 unsafe extern "C" fn xembed_error_handler(_: *mut XDisplay, _: *mut XErrorEvent) -> i32 {
-    eprintln!("Could not embed into specified window.");
-    std::process::exit(1);
+    die!("Could not embed into specified window.");
 }
 
 impl Proxy {

--- a/alacritty_terminal/src/window.rs
+++ b/alacritty_terminal/src/window.rs
@@ -172,8 +172,10 @@ impl Window {
         // On X11, embed the window inside another if the parent ID has been set
         #[cfg(not(any(target_os = "macos", windows)))]
         {
-            if let Some(parent_window_id) = config.window.embed {
-                x_embed_window(window, parent_window_id);
+            if event_loop.is_x11() {
+                if let Some(parent_window_id) = config.window.embed {
+                    x_embed_window(window, parent_window_id);
+                }
             }
         }
 

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -57,6 +57,9 @@ Defines the window position. Falls back to position specified by window manager 
 \fB\-t\fR, \fB\-\-title\fR <title>
 Defines the window title [default: Alacritty]
 .TP
+\fB\-\-embed\fR <parent>
+Sets the XEmbed parent window
+.TP
 \fB\-\-working\-directory\fR <working\-directory>
 Start the shell in the specified working directory
 .SH "SEE ALSO"

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -58,7 +58,7 @@ Defines the window position. Falls back to position specified by window manager 
 Defines the window title [default: Alacritty]
 .TP
 \fB\-\-embed\fR <parent>
-Sets the XEmbed parent window ID (as a long value)
+Defines an X window ID (as a decimal integer) which will serve as the parent when embedding Alacritty within other applications.
 .TP
 \fB\-\-working\-directory\fR <working\-directory>
 Start the shell in the specified working directory

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -58,7 +58,7 @@ Defines the window position. Falls back to position specified by window manager 
 Defines the window title [default: Alacritty]
 .TP
 \fB\-\-embed\fR <parent>
-Defines the X11 window ID (as a decimal integer) to embed Alacritty within.
+Defines the X11 window ID (as a decimal integer) to embed Alacritty within
 .TP
 \fB\-\-working\-directory\fR <working\-directory>
 Start the shell in the specified working directory

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -58,7 +58,7 @@ Defines the window position. Falls back to position specified by window manager 
 Defines the window title [default: Alacritty]
 .TP
 \fB\-\-embed\fR <parent>
-Sets the XEmbed parent window
+Sets the XEmbed parent window ID (as a long value)
 .TP
 \fB\-\-working\-directory\fR <working\-directory>
 Start the shell in the specified working directory

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -58,7 +58,7 @@ Defines the window position. Falls back to position specified by window manager 
 Defines the window title [default: Alacritty]
 .TP
 \fB\-\-embed\fR <parent>
-Defines an X window ID (as a decimal integer) which will serve as the parent when embedding Alacritty within other applications.
+Defines the X11 window ID (as a decimal integer) to embed Alacritty within.
 .TP
 \fB\-\-working\-directory\fR <working\-directory>
 Start the shell in the specified working directory

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -14,7 +14,7 @@ _arguments \
   '(-q)'{-v,-vv,-vvv}"[increase the level of verbosity (max is -vvv)]" \
   "$ign(-)"{-V,--version}"[print version information]" \
   "--class=[define the window class]:class" \
-  "--embed=[define an X window ID (as a decimal integer) which will serve as the parent when embedding Alacritty within other applications]:windowId" \
+  "--embed=[define the X11 window ID (as a decimal integer) to embed Alacritty within]:windowId" \
   "(-e --command)"{-e,--command}"[execute command (must be last arg)]:program: _command_names -e:*::program arguments: _normal" \
   "--config-file=[specify an alternative config file]:file:_files" \
   "(-d --dimensions)"{-d,--dimensions}"[specify window dimensions]:columns: :lines" \

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -14,7 +14,7 @@ _arguments \
   '(-q)'{-v,-vv,-vvv}"[increase the level of verbosity (max is -vvv)]" \
   "$ign(-)"{-V,--version}"[print version information]" \
   "--class=[define the window class]:class" \
-  "--embed=[set the XEmbed parent window ID (as a long value)]:window" \
+  "--embed=[define an X window ID (as a decimal integer) which will serve as the parent when embedding Alacritty within other applications]:windowId" \
   "(-e --command)"{-e,--command}"[execute command (must be last arg)]:program: _command_names -e:*::program arguments: _normal" \
   "--config-file=[specify an alternative config file]:file:_files" \
   "(-d --dimensions)"{-d,--dimensions}"[specify window dimensions]:columns: :lines" \

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -14,6 +14,7 @@ _arguments \
   '(-q)'{-v,-vv,-vvv}"[increase the level of verbosity (max is -vvv)]" \
   "$ign(-)"{-V,--version}"[print version information]" \
   "--class=[define the window class]:class" \
+  "--embed=[define the XEmbed parent]:class" \
   "(-e --command)"{-e,--command}"[execute command (must be last arg)]:program: _command_names -e:*::program arguments: _normal" \
   "--config-file=[specify an alternative config file]:file:_files" \
   "(-d --dimensions)"{-d,--dimensions}"[specify window dimensions]:columns: :lines" \

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -14,7 +14,7 @@ _arguments \
   '(-q)'{-v,-vv,-vvv}"[increase the level of verbosity (max is -vvv)]" \
   "$ign(-)"{-V,--version}"[print version information]" \
   "--class=[define the window class]:class" \
-  "--embed=[define the XEmbed parent]:class" \
+  "--embed=[set the XEmbed parent window ID (as a long value)]:window" \
   "(-e --command)"{-e,--command}"[execute command (must be last arg)]:program: _command_names -e:*::program arguments: _normal" \
   "--config-file=[specify an alternative config file]:file:_files" \
   "(-d --dimensions)"{-d,--dimensions}"[specify window dimensions]:columns: :lines" \

--- a/extra/completions/alacritty.bash
+++ b/extra/completions/alacritty.bash
@@ -11,7 +11,7 @@ _alacritty()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     prevprev="${COMP_WORDS[COMP_CWORD-2]}"
-    opts="-h --help -V --version --live-config-reload --no-live-config-reload --persistent-logging --print-events -q -qq -v -vv -vvv --ref-test -e --command --config-file -d --dimensions --position -t --title --class --working-directory"
+    opts="-h --help -V --version --live-config-reload --no-live-config-reload --persistent-logging --print-events -q -qq -v -vv -vvv --ref-test -e --command --config-file -d --dimensions --position -t --title --embed --class --working-directory"
 
     # If `--command` or `-e` is used, stop completing
     for i in "${!COMP_WORDS[@]}"; do

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -30,6 +30,9 @@ complete -c alacritty \
   -l "class" \
   -d "Defines the window class"
 complete -c alacritty \
+  -l "embed" \
+  -d "Defines the XEmbed parent"
+complete -c alacritty \
   -x \
   -a '(__fish_complete_directories (commandline -ct))' \
   -l "working-directory" \

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -31,7 +31,7 @@ complete -c alacritty \
   -d "Defines the window class"
 complete -c alacritty \
   -l "embed" \
-  -d "Defines the XEmbed parent"
+  -d "Defines the X11 window ID (as a decimal integer) to embed Alacritty within."
 complete -c alacritty \
   -x \
   -a '(__fish_complete_directories (commandline -ct))' \

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -31,7 +31,7 @@ complete -c alacritty \
   -d "Defines the window class"
 complete -c alacritty \
   -l "embed" \
-  -d "Defines the X11 window ID (as a decimal integer) to embed Alacritty within."
+  -d "Defines the X11 window ID (as a decimal integer) to embed Alacritty within"
 complete -c alacritty \
   -x \
   -a '(__fish_complete_directories (commandline -ct))' \


### PR DESCRIPTION
This is a basic implementation of XEmbed.  Please go easy on me.  I'm a Java developer, and haven't seen rust code until about 3 days ago.  Nevertheless, my interest in XEmbed for this application is to allow it to be used in conjunction with Suckless tabbed - which seems to work fine with not too much effort.

I normally run a basic terminal in tabbed in dwm, but here's what it looks like in Xfce:
![image](https://user-images.githubusercontent.com/5728376/64483357-9680c380-d1ce-11e9-9011-00d7799982f7.png)
