### PR TITLE
Fix #1165 - Implement the "hold" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bindings for ScrollToTop and ScrollToBottom actions
 - `ReceiveChar` key binding action to insert the key's text character
 - Live reload font size from config
-- New CLI flag `--hold` for keeping Alacritty opened after its child process exits.
+- New CLI flag `--hold` for keeping Alacritty opened after its child process exits
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bindings for ScrollToTop and ScrollToBottom actions
 - `ReceiveChar` key binding action to insert the key's text character
 - Live reload font size from config
+- New CLI flag `--hold` for keeping Alacritty opened after its child process exits.
 
 ### Changed
 

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -36,6 +36,7 @@ pub struct Options {
     pub embed: Option<String>,
     pub log_level: LevelFilter,
     pub command: Option<Shell<'static>>,
+    pub hold: bool,
     pub working_dir: Option<PathBuf>,
     pub config: Option<PathBuf>,
     pub persistent_logging: bool,
@@ -54,6 +55,7 @@ impl Default for Options {
             embed: None,
             log_level: LevelFilter::Warn,
             command: None,
+            hold: false,
             working_dir: None,
             config: None,
             persistent_logging: false,
@@ -169,6 +171,7 @@ impl Options {
                         .allow_hyphen_values(true)
                         .help("Command and args to execute (must be last argument)"),
                 )
+                .arg(Arg::with_name("hold").long("hold").help("Remain open after child process exits"))
                 .get_matches();
 
         if matches.is_present("ref-test") {
@@ -239,6 +242,10 @@ impl Options {
             options.command = Some(Shell::new_with_args(command, args));
         }
 
+        if matches.is_present("hold") {
+            options.hold = true;
+        }
+
         options
     }
 
@@ -277,6 +284,7 @@ impl Options {
         if config.debug.print_events {
             config.debug.log_level = max(config.debug.log_level, LevelFilter::Info);
         }
+        config.hold = self.hold;
 
         config
     }

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -171,7 +171,11 @@ impl Options {
                         .allow_hyphen_values(true)
                         .help("Command and args to execute (must be last argument)"),
                 )
-                .arg(Arg::with_name("hold").long("hold").help("Remain open after child process exits"))
+                .arg(
+                    Arg::with_name("hold")
+                        .long("hold")
+                        .help("Remain open after child process exits")
+                )
                 .get_matches();
 
         if matches.is_present("ref-test") {
@@ -262,6 +266,8 @@ impl Options {
         );
         config.shell = self.command.or(config.shell);
 
+        config.hold = self.hold;
+
         config.window.dimensions = self.dimensions.unwrap_or(config.window.dimensions);
         config.window.position = self.position.or(config.window.position);
         config.window.title = self.title.or(config.window.title);
@@ -284,7 +290,6 @@ impl Options {
         if config.debug.print_events {
             config.debug.log_level = max(config.debug.log_level, LevelFilter::Info);
         }
-        config.hold = self.hold;
 
         config
     }

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -74,109 +74,106 @@ impl Options {
 
         let mut options = Options::default();
 
-        let matches =
-            App::new(crate_name!())
-                .version(version.as_str())
-                .author(crate_authors!("\n"))
-                .about(crate_description!())
-                .arg(Arg::with_name("ref-test").long("ref-test").help("Generates ref test"))
-                .arg(
-                    Arg::with_name("live-config-reload")
-                        .long("live-config-reload")
-                        .help("Enable automatic config reloading"),
-                )
-                .arg(
-                    Arg::with_name("no-live-config-reload")
-                        .long("no-live-config-reload")
-                        .help("Disable automatic config reloading")
-                        .conflicts_with("live-config-reload"),
-                )
-                .arg(
-                    Arg::with_name("print-events")
-                        .long("print-events")
-                        .help("Print all events to stdout"),
-                )
-                .arg(
-                    Arg::with_name("persistent-logging")
-                        .long("persistent-logging")
-                        .help("Keep the log file after quitting Alacritty"),
-                )
-                .arg(
-                    Arg::with_name("dimensions")
-                        .long("dimensions")
-                        .short("d")
-                        .value_names(&["columns", "lines"])
-                        .help(
-                            "Defines the window dimensions. Falls back to size specified by \
-                             window manager if set to 0x0 [default: 0x0]",
-                        ),
-                )
-                .arg(
-                    Arg::with_name("position")
-                        .long("position")
-                        .allow_hyphen_values(true)
-                        .value_names(&["x-pos", "y-pos"])
-                        .help(
-                            "Defines the window position. Falls back to position specified by \
-                             window manager if unset [default: unset]",
-                        ),
-                )
-                .arg(
-                    Arg::with_name("title")
-                        .long("title")
-                        .short("t")
-                        .takes_value(true)
-                        .help(&format!("Defines the window title [default: {}]", DEFAULT_NAME)),
-                )
-                .arg(
-                    Arg::with_name("class").long("class").takes_value(true).help(&format!(
-                        "Defines window class on Linux [default: {}]",
-                        DEFAULT_NAME
-                    )),
-                )
-                .arg(Arg::with_name("embed").long("embed").takes_value(true).help(
+        let matches = App::new(crate_name!())
+            .version(version.as_str())
+            .author(crate_authors!("\n"))
+            .about(crate_description!())
+            .arg(Arg::with_name("ref-test").long("ref-test").help("Generates ref test"))
+            .arg(
+                Arg::with_name("live-config-reload")
+                    .long("live-config-reload")
+                    .help("Enable automatic config reloading"),
+            )
+            .arg(
+                Arg::with_name("no-live-config-reload")
+                    .long("no-live-config-reload")
+                    .help("Disable automatic config reloading")
+                    .conflicts_with("live-config-reload"),
+            )
+            .arg(
+                Arg::with_name("print-events")
+                    .long("print-events")
+                    .help("Print all events to stdout"),
+            )
+            .arg(
+                Arg::with_name("persistent-logging")
+                    .long("persistent-logging")
+                    .help("Keep the log file after quitting Alacritty"),
+            )
+            .arg(
+                Arg::with_name("dimensions")
+                    .long("dimensions")
+                    .short("d")
+                    .value_names(&["columns", "lines"])
+                    .help(
+                        "Defines the window dimensions. Falls back to size specified by window \
+                         manager if set to 0x0 [default: 0x0]",
+                    ),
+            )
+            .arg(
+                Arg::with_name("position")
+                    .long("position")
+                    .allow_hyphen_values(true)
+                    .value_names(&["x-pos", "y-pos"])
+                    .help(
+                        "Defines the window position. Falls back to position specified by window \
+                         manager if unset [default: unset]",
+                    ),
+            )
+            .arg(
+                Arg::with_name("title")
+                    .long("title")
+                    .short("t")
+                    .takes_value(true)
+                    .help(&format!("Defines the window title [default: {}]", DEFAULT_NAME)),
+            )
+            .arg(
+                Arg::with_name("class")
+                    .long("class")
+                    .takes_value(true)
+                    .help(&format!("Defines window class on Linux [default: {}]", DEFAULT_NAME)),
+            )
+            .arg(
+                Arg::with_name("embed").long("embed").takes_value(true).help(
                     "Defines the X11 window ID (as a decimal integer) to embed Alacritty within",
-                ))
-                .arg(
-                    Arg::with_name("q")
-                        .short("q")
-                        .multiple(true)
-                        .conflicts_with("v")
-                        .help("Reduces the level of verbosity (the min level is -qq)"),
-                )
-                .arg(
-                    Arg::with_name("v")
-                        .short("v")
-                        .multiple(true)
-                        .conflicts_with("q")
-                        .help("Increases the level of verbosity (the max level is -vvv)"),
-                )
-                .arg(
-                    Arg::with_name("working-directory")
-                        .long("working-directory")
-                        .takes_value(true)
-                        .help("Start the shell in the specified working directory"),
-                )
-                .arg(Arg::with_name("config-file").long("config-file").takes_value(true).help(
-                    "Specify alternative configuration file [default: \
-                     $XDG_CONFIG_HOME/alacritty/alacritty.yml]",
-                ))
-                .arg(
-                    Arg::with_name("command")
-                        .long("command")
-                        .short("e")
-                        .multiple(true)
-                        .takes_value(true)
-                        .min_values(1)
-                        .allow_hyphen_values(true)
-                        .help("Command and args to execute (must be last argument)"),
-                )
-                .arg(
-                    Arg::with_name("hold")
-                        .long("hold")
-                        .help("Remain open after child process exits")
-                )
-                .get_matches();
+                ),
+            )
+            .arg(
+                Arg::with_name("q")
+                    .short("q")
+                    .multiple(true)
+                    .conflicts_with("v")
+                    .help("Reduces the level of verbosity (the min level is -qq)"),
+            )
+            .arg(
+                Arg::with_name("v")
+                    .short("v")
+                    .multiple(true)
+                    .conflicts_with("q")
+                    .help("Increases the level of verbosity (the max level is -vvv)"),
+            )
+            .arg(
+                Arg::with_name("working-directory")
+                    .long("working-directory")
+                    .takes_value(true)
+                    .help("Start the shell in the specified working directory"),
+            )
+            .arg(Arg::with_name("config-file").long("config-file").takes_value(true).help(
+                "Specify alternative configuration file [default: \
+                 $XDG_CONFIG_HOME/alacritty/alacritty.yml]",
+            ))
+            .arg(
+                Arg::with_name("command")
+                    .long("command")
+                    .short("e")
+                    .multiple(true)
+                    .takes_value(true)
+                    .min_values(1)
+                    .allow_hyphen_values(true)
+                    .help("Command and args to execute (must be last argument)"),
+            )
+            .arg(Arg::with_name("hold").long("hold").help("Remain open after child process exits"))
+            .get_matches();
 
         if matches.is_present("ref-test") {
             options.ref_test = true;

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -188,12 +188,7 @@ fn run(window_event_loop: GlutinEventLoop<Event>, config: Config) -> Result<(), 
     // renderer and input processing. Note that access to the terminal state is
     // synchronized since the I/O loop updates the state, and the display
     // consumes it periodically.
-    let event_loop = EventLoop::new(
-        Arc::clone(&terminal),
-        event_proxy.clone(),
-        pty,
-        &config,
-    );
+    let event_loop = EventLoop::new(Arc::clone(&terminal), event_proxy.clone(), pty, &config);
 
     // The event loop channel allows write requests from the event processor
     // to be sent to the pty loop and ultimately written to the pty.

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -188,8 +188,13 @@ fn run(window_event_loop: GlutinEventLoop<Event>, config: Config) -> Result<(), 
     // renderer and input processing. Note that access to the terminal state is
     // synchronized since the I/O loop updates the state, and the display
     // consumes it periodically.
-    let event_loop =
-        EventLoop::new(Arc::clone(&terminal), event_proxy.clone(), pty, config.debug.ref_test);
+    let event_loop = EventLoop::new(
+        Arc::clone(&terminal),
+        event_proxy.clone(),
+        pty,
+        config.hold,
+        config.debug.ref_test,
+    );
 
     // The event loop channel allows write requests from the event processor
     // to be sent to the pty loop and ultimately written to the pty.

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -192,8 +192,7 @@ fn run(window_event_loop: GlutinEventLoop<Event>, config: Config) -> Result<(), 
         Arc::clone(&terminal),
         event_proxy.clone(),
         pty,
-        config.hold,
-        config.debug.ref_test,
+        &config,
     );
 
     // The event loop channel allows write requests from the event processor

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -134,7 +134,7 @@ pub struct Config<T> {
     pub ui_config: T,
 
     /// Remain open after child process exits
-    #[serde(default, deserialize_with = "failure_default")]
+    #[serde(skip)]
     pub hold: bool,
 
     // TODO: DEPRECATED

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -133,6 +133,10 @@ pub struct Config<T> {
     #[serde(flatten)]
     pub ui_config: T,
 
+    /// Remain open after child process exits
+    #[serde(default, deserialize_with = "failure_default")]
+    pub hold: bool,
+
     // TODO: DEPRECATED
     #[serde(default, deserialize_with = "failure_default")]
     pub render_timer: Option<bool>,

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -43,6 +43,7 @@ pub struct EventLoop<T: tty::EventedPty, U: EventListener> {
     tx: Sender<Msg>,
     terminal: Arc<FairMutex<Term<U>>>,
     event_proxy: U,
+    hold: bool,
     ref_test: bool,
 }
 
@@ -147,6 +148,7 @@ where
         terminal: Arc<FairMutex<Term<U>>>,
         event_proxy: U,
         pty: T,
+        hold: bool,
         ref_test: bool,
     ) -> EventLoop<T, U> {
         let (tx, rx) = channel::channel();
@@ -157,6 +159,7 @@ where
             rx,
             terminal,
             event_proxy,
+            hold,
             ref_test,
         }
     }
@@ -327,7 +330,9 @@ where
                         #[cfg(unix)]
                         token if token == self.pty.child_event_token() => {
                             if let Some(tty::ChildEvent::Exited) = self.pty.next_child_event() {
-                                self.terminal.lock().handle_child_process_exit();
+                                if !self.hold {
+                                    self.terminal.lock().exit();
+                                }
                                 self.event_proxy.send_event(Event::Wakeup);
                                 break 'event_loop;
                             }

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -327,7 +327,7 @@ where
                         #[cfg(unix)]
                         token if token == self.pty.child_event_token() => {
                             if let Some(tty::ChildEvent::Exited) = self.pty.next_child_event() {
-                                self.terminal.lock().exit();
+                                self.terminal.lock().handle_child_process_exit();
                                 self.event_proxy.send_event(Event::Wakeup);
                                 break 'event_loop;
                             }

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -13,6 +13,7 @@ use mio::{self, Events, PollOpt, Ready};
 use mio_extras::channel::{self, Receiver, Sender};
 
 use crate::ansi;
+use crate::config::Config;
 use crate::event::{self, Event, EventListener};
 use crate::sync::FairMutex;
 use crate::term::Term;
@@ -144,12 +145,11 @@ where
     U: EventListener + Send + 'static,
 {
     /// Create a new event loop
-    pub fn new(
+    pub fn new<V>(
         terminal: Arc<FairMutex<Term<U>>>,
         event_proxy: U,
         pty: T,
-        hold: bool,
-        ref_test: bool,
+        config: &Config<V>,
     ) -> EventLoop<T, U> {
         let (tx, rx) = channel::channel();
         EventLoop {
@@ -159,8 +159,8 @@ where
             rx,
             terminal,
             event_proxy,
-            hold,
-            ref_test,
+            hold: config.hold,
+            ref_test: config.debug.ref_test,
         }
     }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -760,9 +760,6 @@ pub struct Term<T> {
 
     /// Terminal focus
     pub is_focused: bool,
-
-    /// Do not close Alacritty when handling child process exit
-    hold: bool,
 }
 
 /// Terminal size info
@@ -890,7 +887,6 @@ impl<T> Term<T> {
             clipboard,
             event_proxy,
             is_focused: true,
-            hold: config.hold,
         }
     }
 
@@ -1219,16 +1215,6 @@ impl<T> Term<T> {
         T: EventListener,
     {
         self.event_proxy.send_event(Event::Exit);
-    }
-
-    #[inline]
-    pub fn handle_child_process_exit(&mut self)
-    where
-        T: EventListener,
-    {
-        if !self.hold {
-            self.exit();
-        }
     }
 
     #[inline]
@@ -2141,7 +2127,6 @@ impl IndexMut<Column> for TabStops {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
     use std::mem;
 
     use serde_json;
@@ -2158,16 +2143,6 @@ mod tests {
     struct Mock;
     impl EventListener for Mock {
         fn send_event(&self, _event: Event) {}
-    }
-
-    struct EventSpy {
-        latest_event: RefCell<Option<Event>>,
-    }
-
-    impl EventListener for EventSpy {
-        fn send_event(&self, event: Event) {
-            *self.latest_event.borrow_mut() = Some(event);
-        }
     }
 
     #[test]
@@ -2325,52 +2300,6 @@ mod tests {
         let mut scrolled_grid = term.grid.clone();
         scrolled_grid.scroll_display(Scroll::Top);
         assert_eq!(term.grid, scrolled_grid);
-    }
-
-    #[test]
-    fn should_not_exit_if_hold() {
-        let size = SizeInfo {
-            width: 21.0,
-            height: 51.0,
-            cell_width: 3.0,
-            cell_height: 3.0,
-            padding_x: 0.0,
-            padding_y: 0.0,
-            dpr: 1.0,
-        };
-        let mut config = MockConfig::default();
-        config.hold = true;
-        let mut term = Term::new(
-            &config,
-            &size,
-            Clipboard::new_nop(),
-            EventSpy { latest_event: RefCell::new(None) },
-        );
-        term.handle_child_process_exit();
-        assert_eq!(term.event_proxy.latest_event.into_inner(), None);
-    }
-
-    #[test]
-    fn should_exit_if_not_hold() {
-        let size = SizeInfo {
-            width: 21.0,
-            height: 51.0,
-            cell_width: 3.0,
-            cell_height: 3.0,
-            padding_x: 0.0,
-            padding_y: 0.0,
-            dpr: 1.0,
-        };
-        let mut config = MockConfig::default();
-        config.hold = false;
-        let mut term = Term::new(
-            &config,
-            &size,
-            Clipboard::new_nop(),
-            EventSpy { latest_event: RefCell::new(None) },
-        );
-        term.handle_child_process_exit();
-        assert_eq!(term.event_proxy.latest_event.into_inner(), Some(Event::Exit));
     }
 }
 

--- a/extra/alacritty.man
+++ b/extra/alacritty.man
@@ -14,6 +14,9 @@ However, it does allow configuration of many aspects of the terminal.
 \fB\-h\fR, \fB\-\-help\fR
 Prints help information
 .TP
+\fB\-\-hold\fR
+Remain open after child process exits
+.TP
 \fB\-\-live\-config\-reload\fR
 Enable automatic config reloading
 .TP

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -11,6 +11,7 @@ _arguments \
   "--print-events[print all events to stdout]" \
   '(-v)'{-q,-qq}"[reduce the level of verbosity (min is -qq)]" \
   "--ref-test[generate ref test]" \
+  "--hold[Remain open after child process exits]" \
   '(-q)'{-v,-vv,-vvv}"[increase the level of verbosity (max is -vvv)]" \
   "$ign(-)"{-V,--version}"[print version information]" \
   "--class=[define the window class]:class" \

--- a/extra/completions/_alacritty
+++ b/extra/completions/_alacritty
@@ -11,7 +11,7 @@ _arguments \
   "--print-events[print all events to stdout]" \
   '(-v)'{-q,-qq}"[reduce the level of verbosity (min is -qq)]" \
   "--ref-test[generate ref test]" \
-  "--hold[Remain open after child process exits]" \
+  "--hold[remain open after child process exits]" \
   '(-q)'{-v,-vv,-vvv}"[increase the level of verbosity (max is -vvv)]" \
   "$ign(-)"{-V,--version}"[print version information]" \
   "--class=[define the window class]:class" \

--- a/extra/completions/alacritty.bash
+++ b/extra/completions/alacritty.bash
@@ -11,7 +11,7 @@ _alacritty()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     prevprev="${COMP_WORDS[COMP_CWORD-2]}"
-    opts="-h --help -V --version --live-config-reload --no-live-config-reload --persistent-logging --print-events -q -qq -v -vv -vvv --ref-test -e --command --config-file -d --dimensions --position -t --title --embed --class --working-directory"
+    opts="-h --help -V --version --live-config-reload --no-live-config-reload --persistent-logging --print-events -q -qq -v -vv -vvv --ref-test --hold -e --command --config-file -d --dimensions --position -t --title --embed --class --working-directory"
 
     # If `--command` or `-e` is used, stop completing
     for i in "${!COMP_WORDS[@]}"; do

--- a/extra/completions/alacritty.fish
+++ b/extra/completions/alacritty.fish
@@ -37,6 +37,9 @@ complete -c alacritty \
   -a '(__fish_complete_directories (commandline -ct))' \
   -l "working-directory" \
   -d "Start shell in specified directory"
+complete -c alacritty \
+  -l "hold" \
+  -d "Remain open after child process exits"
 
 # Output
 complete \


### PR DESCRIPTION
Hi there! Thanks a lot for your work on Alacritty, this project been helpful for me in countless ways, so I want to contribute something back. This PR implements `--hold` flag together with the `hold` configuration option which keeps Alacritty open after its child process exits.

Maybe I should clarify why I decided to put the `hold` flag in the `Term` struct instead of passing it directly to the `EventLoop` where the handling of child process exit happens. I've tried this approach first, but it turned out to be extremely hard to write a test for (at least for me, I'm a total noob in Rust). I've also tried ref-tests, but for some reason, even with just opening and closing Alacritty I get 60 megabytes of `grid.json`, and a generated ref test is always failing. I'm not sure why it happens as I'm not very familiar with how `Grid` works yet.

So I've taken the easy-to-test approach, I hope it's good enough :)
