### PR TITLE
Initialize only visible characters

### DIFF
--- a/alacritty_terminal/src/renderer/mod.rs
+++ b/alacritty_terminal/src/renderer/mod.rs
@@ -223,7 +223,7 @@ impl GlyphCache {
 
     fn load_glyphs_for_font<L: LoadGlyph>(&mut self, font: FontKey, loader: &mut L) {
         let size = self.font_size;
-        for i in 32u8..=128u8 {
+        for i in 32u8..=126u8 {
             self.get(GlyphKey { font_key: font, c: i as char, size }, loader);
         }
     }


### PR DESCRIPTION
This fixes an off-by-two error in the renderer which initializes
characters 32 until 128 (inclusive) for each font whenever it is loaded.
The ascii visible range however just goes from 32 until 126 (inclusive).