### PR TITLE
Remove bindings with action `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extra bindings for F13-F20
 - Terminal escape bindings with combined modifiers
 - Bindings for ScrollToTop and ScrollToBottom actions
-- `ReceiveChar` action to allow receiving chars after processing a binding
+- `ReceiveChar` key binding action to insert the key's text character
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extra bindings for F13-F20
 - Terminal escape bindings with combined modifiers
 - Bindings for ScrollToTop and ScrollToBottom actions
+- `ReceiveChar` action to allow receiving chars after processing a binding
 
 ### Changed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -496,8 +496,8 @@ mouse_bindings:
 #   - ToggleFullscreen
 #   - SpawnNewInstance
 #   - ClearLogNotice
-#   - None
 #   - ReceiveChar
+#   - None
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -497,6 +497,7 @@ mouse_bindings:
 #   - SpawnNewInstance
 #   - ClearLogNotice
 #   - None
+#   - ReceiveChar
 #
 #   (macOS only):
 #   - ToggleSimpleFullscreen: Enters fullscreen without occupying another space
@@ -536,7 +537,8 @@ mouse_bindings:
 #
 # Bindings are always filled by default, but will be replaced when a new
 # binding with the same triggers is defined. To unset a default binding, it can
-# be mapped to the `None` action.
+# be mapped to the `ReceiveChar` action. Alternatively, you can use `None` for
+# a no-op if you do not wish to receive input characters for that binding.
 key_bindings:
   # (Windows/Linux only)
   #- { key: V,        mods: Control|Shift, action: Paste            }

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -269,6 +269,7 @@ where
 {
     let mut bindings: Vec<Binding<T>> = failure_default(deserializer)?;
 
+    // Remove matching default bindings
     for binding in bindings.iter() {
         default.retain(|b| !b.triggers_match(binding));
     }

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -930,7 +930,10 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 // Don't suppress when there has been a `ReceiveChar` action
                 Some(suppress_chars.unwrap_or(true) && binding.action != Action::ReceiveChar)
             })
-            .unwrap_or(false);
+            .unwrap_or_else(|| {
+                // Do not suppress char if no bindings were triggered
+                false
+            });
     }
 
     /// Attempt to find a binding and execute its action.

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -930,10 +930,7 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 // Don't suppress when there has been a `ReceiveChar` action
                 Some(suppress_chars.unwrap_or(true) && binding.action != Action::ReceiveChar)
             })
-            .unwrap_or_else(|| {
-                // Do not suppress char if no bindings were triggered
-                false
-            });
+            .unwrap_or(false); // Don't suppress char if no bindings were triggered
     }
 
     /// Attempt to find a binding and execute its action.

--- a/alacritty_terminal/src/input.rs
+++ b/alacritty_terminal/src/input.rs
@@ -906,8 +906,6 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
     ///
     /// The provided mode, mods, and key must match what is allowed by a binding
     /// for its action to be executed.
-    ///
-    /// Return true if chars should be suppressed.
     fn process_key_bindings(&mut self, input: KeyboardInput) {
         let mode = *self.ctx.terminal().mode();
 
@@ -930,7 +928,8 @@ impl<'a, A: ActionContext + 'a> Processor<'a, A> {
                 // Don't suppress when there has been a `ReceiveChar` action
                 Some(suppress_chars.unwrap_or(true) && binding.action != Action::ReceiveChar)
             })
-            .unwrap_or(false); // Don't suppress char if no bindings were triggered
+            // Don't suppress char if no bindings were triggered
+            .unwrap_or(false);
     }
 
     /// Attempt to find a binding and execute its action.


### PR DESCRIPTION
Currently, there is no option to disable default key bindings while keep receiving pressed keys. It's because specifying action `None` is actually a no-op and does not result in an unset binding. This pull request aims to overcome this limitation.