### PR TITLE
Fix cell alpha setting on non NamedColor::Background cell's bg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Block URL highlight while a selection is active
 - Bindings for Alt + F1-F12
 - Discard scrolling region escape with bottom above top
-- Transparency when cell background color was equals to named background color
+- Opacity incorrectly applying to cells with their background color matching the teriminal background
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Block URL highlight while a selection is active
 - Bindings for Alt + F1-F12
 - Discard scrolling region escape with bottom above top
-- Opacity incorrectly applying to cells with their background color matching the teriminal background
+- Opacity always applying to cells with their background color matching the teriminal background
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Block URL highlight while a selection is active
 - Bindings for Alt + F1-F12
 - Discard scrolling region escape with bottom above top
+- Transparency when cell background color was equals to named background color
 
 ### Removed
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -273,11 +273,13 @@ impl RenderableCell {
         // Lookup RGB values
         let mut fg_rgb = Self::compute_fg_rgb(config, colors, cell.fg, cell.flags);
         let mut bg_rgb = Self::compute_bg_rgb(colors, cell.bg);
+        let mut bg_alpha = Self::compute_bg_alpha(cell.bg);
 
         let selection_background = config.colors.selection.background;
         if let (true, Some(col)) = (selected, selection_background) {
             // Override selection background with config colors
             bg_rgb = col;
+            bg_alpha = 1.0;
         } else if selected ^ cell.inverse() {
             if fg_rgb == bg_rgb && !cell.flags.contains(Flags::HIDDEN) {
                 // Reveal inversed text when fg/bg is the same
@@ -300,7 +302,7 @@ impl RenderableCell {
             inner: RenderableCellContent::Chars(cell.chars()),
             fg: fg_rgb,
             bg: bg_rgb,
-            bg_alpha: Self::compute_bg_alpha(colors, bg_rgb),
+            bg_alpha,
             flags: cell.flags,
         }
     }
@@ -343,8 +345,8 @@ impl RenderableCell {
     }
 
     #[inline]
-    fn compute_bg_alpha(colors: &color::List, bg: Rgb) -> f32 {
-        if colors[NamedColor::Background] == bg {
+    fn compute_bg_alpha(bg: Color) -> f32 {
+        if bg == Color::Named(NamedColor::Background) {
             0.
         } else {
             1.


### PR DESCRIPTION
Commit e964af8 introduced a regression, where if cell's bg color was
equal to NamedColor::Background rgb color it was rendered with transparent
background. However the correct behavior is to render bg transparent
only when bg color is actually a NamedColor::Background.

Fixes: #2814