### PR TITLE
Fix selection not inverting terminal background

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -289,6 +289,8 @@ impl RenderableCell {
                 // Invert cell fg and bg colors
                 mem::swap(&mut fg_rgb, &mut bg_rgb);
             }
+
+            bg_alpha = 1.0;
         }
 
         // Override selection text with config colors


### PR DESCRIPTION
Fixes a regression introduced in
9a0555bbba30c264f617ec9260ca00e0eab70870 where the terminal background
would not get inverted when selected.