### PR TITLE
Concatenate parameters of title OSC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bindings for Alt + F1-F12
 - Discard scrolling region escape with bottom above top
 - Opacity always applying to cells with their background color matching the teriminal background
+- Allow semicolons when setting titles using an OSC
 
 ### Removed
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -750,10 +750,13 @@ where
             // Set window title
             b"0" | b"2" => {
                 if params.len() >= 2 {
-                    if let Ok(utf8_title) = str::from_utf8(params[1]) {
-                        self.handler.set_title(utf8_title);
-                        return;
-                    }
+                    let title = params[1..]
+                        .iter()
+                        .flat_map(|x| str::from_utf8(x))
+                        .collect::<Vec<&str>>()
+                        .join(";");
+                    self.handler.set_title(&title);
+                    return;
                 }
                 unhandled(params);
             },


### PR DESCRIPTION
A semicolon in a title OSC should be interpreted literally, not as a parameter
separator, but the OSC parser is very simple and does not know about arities of
commands.

Therefore, this patch takes all the parameters returned by the OSC parser and
reconstructs the original string by interspersing semicolons. Now an OSC like
`\e]2;hello;world` will set the title to 'hello;world' and not 'hello' like
before.