### PR TITLE
Add error detail, when possible, on the event of an invalid config file

### DIFF
--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -429,7 +429,7 @@ where
     D: Deserializer<'a>,
     T: Deserialize<'a> + Default,
 {
-    Ok(T::deserialize(Value::deserialize(deserializer)?).unwrap_or_else(fallback_default))
+    Ok(T::deserialize(deserializer).unwrap_or_else(fallback_default))
 }
 
 pub fn option_explicit_none<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>


### PR DESCRIPTION
This PR aims to help with error descriptions (#2752) by removing the intermediate deserialization to `serde_yaml::Value` in the `failure_default` deserializer, which is used in the vast majority of fields, resulting in:

![explained-error](https://user-images.githubusercontent.com/4250565/65931894-d445c600-e3e1-11e9-9005-08b267c99bf5.png)

Instead of

![image](https://user-images.githubusercontent.com/4250565/65932020-5cc46680-e3e2-11e9-8361-16646be4b0b5.png)


This change has no effect in how errors are displayed for fields that use `from_string_or_deserialize` or `option_explicit_none`, as they would need to either require `Clone` on `D` or to be able to deserialize from a borrowed field, which I believe is not possible in serde_yaml as it stands.