### PR TITLE
Resolve race between DPI change and resize events.

### DIFF
--- a/alacritty_terminal/src/display.rs
+++ b/alacritty_terminal/src/display.rs
@@ -397,13 +397,9 @@ impl Display {
         let message_bar_changed = self.last_message != terminal.message_buffer_mut().message();
 
         if font_changed || message_bar_changed {
-            if new_size == None {
-                // Force a resize to refresh things
-                new_size = Some(PhysicalSize::new(
-                    f64::from(self.size_info.width) / self.size_info.dpr * dpr,
-                    f64::from(self.size_info.height) / self.size_info.dpr * dpr,
-                ));
-            }
+            // Force a resize to refresh things. Ask the window directly for its size to avoid
+            // potential races between resize & DPI change events.
+            new_size = self.window.inner_size_pixels().map(|ls| ls.to_physical(dpr));
 
             self.font_size = terminal.font_size;
             self.last_message = terminal.message_buffer_mut().message();


### PR DESCRIPTION
On windows, when the DPI changes, alacritty updates the terminal dimensions as part of the `handle_resize` callback. However, the `PhysicalSize` with which alacritty does the calculation can occasionally be the wrong DPI, depending on the order in which the DPI change and resize events are sent.

I suggest working around this race by asking the window for its current DPI and size when we detect a DPI change.

The race problem seems to occur on [event.rs line 369](https://github.com/davidhewitt/alacritty/blob/d1b08c02d8a670fa163ce6de399d8621289d0735/alacritty_terminal/src/event.rs#L369) when we convert the `LogicalSize` to a `PhysicalSize`. Sometimes the DPR used is correct, but for me the DPR is wrong when I switch back and forth from my laptop display to an external monitor. The result is that the pty has the wrong dimensions (either has loads of empty space or overflows the window, depending on whether the DPR went up or down).

I experimented with delaying the conversion from `LogicalSize` to `PhysicalSize` into the `handle_resize` callback, which also fixed the issue for me, but I couldn't guarantee that it's race free. If you prefer that solution rather than asking the `Window` directly for its size I can change this PR to do that.

Fixes #2456.
Fixes #2334.