### PR TITLE
Support saving window title in a stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ReceiveChar` key binding action to insert the key's text character
 - Live reload font size from config
 - New CLI flag `--hold` for keeping Alacritty opened after its child process exits
-- Save and restore window title from stack
+- Escape sequence to save and restore window title from stack
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bindings for ScrollToTop and ScrollToBottom actions
 - `ReceiveChar` key binding action to insert the key's text character
 - Live reload font size from config
+- Save and restore window title from stack
 
 ### Changed
 

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -269,7 +269,7 @@ impl Options {
         config.window.embed = self.embed.and_then(|embed| embed.parse().ok());
 
         if let Some(title) = self.title {
-            config.window.set_title(title);
+            config.window.title = title.clone();
         }
 
         if let Some(class) = self.class {
@@ -280,7 +280,7 @@ impl Options {
             }
         }
 
-        config.set_dynamic_title(config.dynamic_title() && config.window.title() == DEFAULT_NAME);
+        config.set_dynamic_title(config.dynamic_title() && config.window.title == DEFAULT_NAME);
 
         config.debug.print_events = self.print_events || config.debug.print_events;
         config.debug.log_level = max(config.debug.log_level, self.log_level);
@@ -301,7 +301,8 @@ mod test {
 
     #[test]
     fn dynamic_title_ignoring_options_by_default() {
-        let config = Config::default();
+        let mut config = Config::default();
+        config.window.title = "Alacritty".to_string();
         let old_dynamic_title = config.dynamic_title();
 
         let config = Options::default().into_config(config);
@@ -324,7 +325,7 @@ mod test {
     fn dynamic_title_overridden_by_config() {
         let mut config = Config::default();
 
-        config.window.set_title("foo".to_owned());
+        config.window.title = "foo".to_owned();
         let config = Options::default().into_config(config);
 
         assert!(!config.dynamic_title());

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -256,7 +256,7 @@ impl Options {
 
         config.window.dimensions = self.dimensions.unwrap_or(config.window.dimensions);
         config.window.position = self.position.or(config.window.position);
-        config.window.title = self.title.or(config.window.title);
+        config.window.title = self.title.unwrap_or(config.window.title);
         config.window.embed = self.embed.and_then(|embed| embed.parse().ok());
 
         if let Some(class) = self.class {
@@ -267,7 +267,7 @@ impl Options {
             }
         }
 
-        config.set_dynamic_title(config.dynamic_title() && config.window.title.is_none());
+        config.set_dynamic_title(config.dynamic_title());
 
         config.debug.print_events = self.print_events || config.debug.print_events;
         config.debug.log_level = max(config.debug.log_level, self.log_level);
@@ -311,7 +311,7 @@ mod test {
     fn dynamic_title_overridden_by_config() {
         let mut config = Config::default();
 
-        config.window.title = Some("foo".to_owned());
+        config.window.title = "foo".to_owned();
         let config = Options::default().into_config(config);
 
         assert!(!config.dynamic_title());

--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -256,8 +256,11 @@ impl Options {
 
         config.window.dimensions = self.dimensions.unwrap_or(config.window.dimensions);
         config.window.position = self.position.or(config.window.position);
-        config.window.title = self.title.unwrap_or(config.window.title);
         config.window.embed = self.embed.and_then(|embed| embed.parse().ok());
+
+        if let Some(title) = self.title {
+            config.window.set_title(title);
+        }
 
         if let Some(class) = self.class {
             let parts: Vec<_> = class.split(',').collect();
@@ -267,7 +270,7 @@ impl Options {
             }
         }
 
-        config.set_dynamic_title(config.dynamic_title());
+        config.set_dynamic_title(config.dynamic_title() && config.window.title() == DEFAULT_NAME);
 
         config.debug.print_events = self.print_events || config.debug.print_events;
         config.debug.log_level = max(config.debug.log_level, self.log_level);
@@ -311,7 +314,7 @@ mod test {
     fn dynamic_title_overridden_by_config() {
         let mut config = Config::default();
 
-        config.window.title = "foo".to_owned();
+        config.window.set_title("foo".to_owned());
         let config = Options::default().into_config(config);
 
         assert!(!config.dynamic_title());

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -144,7 +144,7 @@ impl Window {
         config: &Config,
         logical: Option<LogicalSize>,
     ) -> Result<Window> {
-        let window_builder = Window::get_platform_window(&config.window.title, &config.window);
+        let window_builder = Window::get_platform_window(&config.window.title(), &config.window);
         let windowed_context =
             create_gl_window(window_builder.clone(), &event_loop, false, logical)
                 .or_else(|_| create_gl_window(window_builder, &event_loop, true, logical))?;

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -144,7 +144,7 @@ impl Window {
         config: &Config,
         logical: Option<LogicalSize>,
     ) -> Result<Window> {
-        let window_builder = Window::get_platform_window(&config.window.title(), &config.window);
+        let window_builder = Window::get_platform_window(&config.window.title, &config.window);
         let windowed_context =
             create_gl_window(window_builder.clone(), &event_loop, false, logical)
                 .or_else(|_| create_gl_window(window_builder, &event_loop, true, logical))?;

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -31,7 +31,7 @@ use image::ImageFormat;
 #[cfg(not(any(target_os = "macos", windows)))]
 use x11_dl::xlib::{Display as XDisplay, PropModeReplace, XErrorEvent, Xlib};
 
-use alacritty_terminal::config::{Decorations, StartupMode, WindowConfig, DEFAULT_NAME};
+use alacritty_terminal::config::{Decorations, StartupMode, WindowConfig};
 use alacritty_terminal::event::Event;
 use alacritty_terminal::gl;
 use alacritty_terminal::term::{SizeInfo, Term};
@@ -144,9 +144,7 @@ impl Window {
         config: &Config,
         logical: Option<LogicalSize>,
     ) -> Result<Window> {
-        let title = config.window.title.as_ref().map_or(DEFAULT_NAME, |t| t);
-
-        let window_builder = Window::get_platform_window(title, &config.window);
+        let window_builder = Window::get_platform_window(&config.window.title, &config.window);
         let windowed_context =
             create_gl_window(window_builder.clone(), &event_loop, false, logical)
                 .or_else(|_| create_gl_window(window_builder, &event_loop, true, logical))?;

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -328,6 +328,12 @@ pub trait Handler {
 
     /// Run the dectest routine
     fn dectest(&mut self) {}
+
+    /// Push a title onto the stack
+    fn push_title(&mut self) {}
+
+    /// Pop the last title from the stack
+    fn pop_title(&mut self) {}
 }
 
 /// Describes shape of cursor
@@ -991,6 +997,13 @@ where
                 handler.clear_line(mode);
             },
             ('S', None) => handler.scroll_up(Line(arg_or_default!(idx: 0, default: 1) as usize)),
+            ('t', None) => match arg_or_default!(idx: 0, default: 1) as usize {
+                22 => handler.push_title(),
+                23 => handler.pop_title(),
+                _ => {
+                    unhandled!();
+                },
+            },
             ('T', None) => handler.scroll_down(Line(arg_or_default!(idx: 0, default: 1) as usize)),
             ('L', None) => {
                 handler.insert_blank_lines(Line(arg_or_default!(idx: 0, default: 1) as usize))

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -418,7 +418,13 @@ impl Mode {
     /// Create mode from a primitive
     ///
     /// TODO lots of unhandled values..
-    pub fn from_primitive(private: bool, num: i64) -> Option<Mode> {
+    pub fn from_primitive(intermediate: Option<&u8>, num: i64) -> Option<Mode> {
+        let private = match intermediate {
+            Some(b'?') => true,
+            None => false,
+            _ => return None,
+        };
+
         if private {
             Some(match num {
                 1 => Mode::CursorKeys,
@@ -883,7 +889,6 @@ where
         }
     }
 
-    #[allow(clippy::cognitive_complexity)]
     #[inline]
     fn csi_dispatch(
         &mut self,
@@ -1008,17 +1013,8 @@ where
                 handler.insert_blank_lines(Line(arg_or_default!(idx: 0, default: 1) as usize))
             },
             ('l', intermediate) => {
-                let is_private_mode = match intermediate {
-                    Some(b'?') => true,
-                    None => false,
-                    _ => {
-                        unhandled!();
-                        return;
-                    },
-                };
                 for arg in args {
-                    let mode = Mode::from_primitive(is_private_mode, *arg);
-                    match mode {
+                    match Mode::from_primitive(intermediate, *arg) {
                         Some(mode) => handler.unset_mode(mode),
                         None => {
                             unhandled!();
@@ -1039,17 +1035,8 @@ where
                 handler.goto_line(Line(arg_or_default!(idx: 0, default: 1) as usize - 1))
             },
             ('h', intermediate) => {
-                let is_private_mode = match intermediate {
-                    Some(b'?') => true,
-                    None => false,
-                    _ => {
-                        unhandled!();
-                        return;
-                    },
-                };
                 for arg in args {
-                    let mode = Mode::from_primitive(is_private_mode, *arg);
-                    match mode {
+                    match Mode::from_primitive(intermediate, *arg) {
                         Some(mode) => handler.set_mode(mode),
                         None => {
                             unhandled!();

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -883,6 +883,7 @@ where
         }
     }
 
+    #[allow(clippy::cognitive_complexity)]
     #[inline]
     fn csi_dispatch(
         &mut self,
@@ -1000,9 +1001,7 @@ where
             ('t', None) => match arg_or_default!(idx: 0, default: 1) as usize {
                 22 => handler.push_title(),
                 23 => handler.pop_title(),
-                _ => {
-                    unhandled!();
-                },
+                _ => unhandled!(),
             },
             ('T', None) => handler.scroll_down(Line(arg_or_default!(idx: 0, default: 1) as usize)),
             ('L', None) => {

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -8,11 +8,6 @@ use crate::index::{Column, Line};
 /// Default Alacritty name, used for window title and class.
 pub const DEFAULT_NAME: &str = "Alacritty";
 
-/// Get the default title for the window
-fn default_title() -> String {
-    DEFAULT_NAME.to_string()
-}
-
 #[serde(default)]
 #[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct WindowConfig {
@@ -41,8 +36,8 @@ pub struct WindowConfig {
     startup_mode: StartupMode,
 
     /// Window title
-    #[serde(deserialize_with = "failure_default", default = "default_title")]
-    pub title: String,
+    #[serde(deserialize_with = "failure_default")]
+    title: Option<String>,
 
     /// Window class
     #[serde(deserialize_with = "from_string_or_deserialize")]
@@ -67,6 +62,14 @@ impl WindowConfig {
             Some(true) => StartupMode::Maximized,
             _ => self.startup_mode,
         }
+    }
+
+    pub fn set_title(&mut self, title: String) {
+        self.title = Some(title);
+    }
+
+    pub fn title(&self) -> String {
+        self.title.clone().unwrap_or_else(|| DEFAULT_NAME.to_owned())
     }
 }
 

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -8,6 +8,11 @@ use crate::index::{Column, Line};
 /// Default Alacritty name, used for window title and class.
 pub const DEFAULT_NAME: &str = "Alacritty";
 
+/// Get the default title for the window
+fn default_title() -> String {
+    DEFAULT_NAME.to_string()
+}
+
 #[serde(default)]
 #[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 pub struct WindowConfig {
@@ -36,8 +41,8 @@ pub struct WindowConfig {
     startup_mode: StartupMode,
 
     /// Window title
-    #[serde(deserialize_with = "failure_default")]
-    pub title: Option<String>,
+    #[serde(deserialize_with = "failure_default", default = "default_title")]
+    pub title: String,
 
     /// Window class
     #[serde(deserialize_with = "from_string_or_deserialize")]

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -36,8 +36,8 @@ pub struct WindowConfig {
     startup_mode: StartupMode,
 
     /// Window title
-    #[serde(deserialize_with = "failure_default")]
-    title: Option<String>,
+    #[serde(default = "default_title")]
+    pub title: String,
 
     /// Window class
     #[serde(deserialize_with = "from_string_or_deserialize")]
@@ -56,20 +56,16 @@ pub struct WindowConfig {
     pub start_maximized: Option<bool>,
 }
 
+pub fn default_title() -> String {
+    DEFAULT_NAME.to_string()
+}
+
 impl WindowConfig {
     pub fn startup_mode(&self) -> StartupMode {
         match self.start_maximized {
             Some(true) => StartupMode::Maximized,
             _ => self.startup_mode,
         }
-    }
-
-    pub fn set_title(&mut self, title: String) {
-        self.title = Some(title);
-    }
-
-    pub fn title(&self) -> String {
-        self.title.clone().unwrap_or_else(|| DEFAULT_NAME.to_owned())
     }
 }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1359,7 +1359,7 @@ impl<T: EventListener> ansi::Handler for Term<T> {
                 title.to_owned()
             };
 
-            self.title = title;
+            self.title = title.clone();
             self.event_proxy.send_event(Event::Title(title.to_owned()));
         }
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -897,7 +897,7 @@ impl<T> Term<T> {
             clipboard,
             event_proxy,
             is_focused: true,
-            title: config.window.title(),
+            title: config.window.title.clone(),
             title_stack: Vec::new(),
         }
     }
@@ -2362,14 +2362,14 @@ mod tests {
 
         // Title can be set
         {
-            term.set_title("Test");
+            term.title = "Test".to_string();
             assert_eq!(term.title, "Test");
         }
 
         // Title can be pushed onto stack
         {
             term.push_title();
-            term.set_title("Next");
+            term.title = "Next".to_string();
             assert_eq!(term.title, "Next");
             assert_eq!(term.title_stack.get(0).unwrap(), "Test");
         }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1355,7 +1355,7 @@ impl<T: EventListener> ansi::Handler for Term<T> {
             };
 
             self.title = title;
-            self.event_proxy.send_event(Event::Title(title));
+            self.event_proxy.send_event(Event::Title(title.to_owned()));
         }
     }
 

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -143,7 +143,7 @@ pub fn new<'a, C>(
 
     let mut startup_info_ex: STARTUPINFOEXW = Default::default();
 
-    let title = config.window.title.clone();
+    let title = config.window.title();
     let title = U16CString::from_str(title).unwrap();
     startup_info_ex.StartupInfo.lpTitle = title.as_ptr() as LPWSTR;
 

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -143,7 +143,7 @@ pub fn new<'a, C>(
 
     let mut startup_info_ex: STARTUPINFOEXW = Default::default();
 
-    let title = config.window.title.as_ref().map(String::as_str).unwrap_or("Alacritty");
+    let title = config.window.title.clone();
     let title = U16CString::from_str(title).unwrap();
     startup_info_ex.StartupInfo.lpTitle = title.as_ptr() as LPWSTR;
 

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -143,7 +143,7 @@ pub fn new<'a, C>(
 
     let mut startup_info_ex: STARTUPINFOEXW = Default::default();
 
-    let title = config.window.title();
+    let title = config.window.title.clone();
     let title = U16CString::from_str(title).unwrap();
     startup_info_ex.StartupInfo.lpTitle = title.as_ptr() as LPWSTR;
 


### PR DESCRIPTION
This commit adds the concept of a "title stack" to the terminal. Some programs (e.g. vim) send control sequences `CSI 22 ; 0` (push title) and `CSI 23 ; 0` (pop title). Clues on how to handles these were taken from a couple of other terminal emulators ([Gnome Terminal](https://github.com/GNOME/vte/commit/23c44f1f18b7985d9fba3205500d8873ecde51aa), [kitty](https://github.com/kovidgoyal/kitty/commit/3067103b188c55d594918d1525d397cb523f8fea)).

The title stack is mainly just a history of previous titles. Applications can push the current title onto the stack, and pop it back off (setting the window title in the process).

To implement this, the Alacritty `Term` must have two new pieces of state: `title` (the mirror of what is set in the Glutin window) and `title_stack` (the history of titles if pushed onto). When control sequence 22 is received, then a title is pushed, and 23 pops and sets the Glutin window title.

This fixes #2840