### PR TITLE
Add libxcb-xfixes0-dev as travis dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: rust
 services:
   - docker
 
+addons:
+  apt:
+    packages:
+    - libxcb-xfixes0-dev
+
 git:
   depth: 1
 


### PR DESCRIPTION
Currently on Linux the CI is not building since it cannot fint xcb for
linking. Installing it in the pre-install hook should make sure it's
available when linking.