### PR TITLE
Disable depth and stencil buffer allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash when resuming after suspension
 - Crash when trying to start on X11 with a Wayland compositor running
 - Crash with a virtual display connected on X11
+- GPU memory usage has been decreased by disabling allocation of depth and stencil buffers
 
 ### Removed
 

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -117,6 +117,8 @@ fn create_gl_window(
     let windowed_context = ContextBuilder::new()
         .with_srgb(srgb)
         .with_vsync(true)
+        .with_depth_buffer(0)
+        .with_stencil_buffer(0)
         .with_hardware_acceleration(None)
         .build_windowed(window, event_loop)?;
 


### PR DESCRIPTION
Disable allocation of depth and stencil buffers. This reduces active GPU memory consumption by almost a third, at least on Linux.

If I have a large number of terminals open and there is memory pressure, switching between terminals takes a while, presumably because some required GEM objects are swapped to disk. This change makes the number and size of required GEM objects smaller, hopefully alleviating the issue.

**I have only tested this on Linux (X11).** If passing 0 as the depth/stencil buffer size has different semantics on other platforms with glutin, things might break.

With this branch: Note that the amount of active objects is 27MB. (the inactive object count is higher, since I just ran vtebench)

```
archaea# cat i915_gem_objects|grep alacritty
alacritty: 32 objects, 79409152 bytes (27426816 active, 51798016 inactive, 0 global, 29360128 shared, 184320 unbound, 0 closed)
alacritty: 26 objects, 67796992 bytes (0 active, 67694592 inactive, 0 global, 29360128 shared, 102400 unbound, 0 closed)
```

With master, 47MB of active objects are needed.

```
archaea# cat i915_gem_objects|grep alacritty
alacritty: 31 objects, 79147008 bytes (0 active, 78962688 inactive, 0 global, 29360128 shared, 184320 unbound, 0 closed)
alacritty: 26 objects, 67796992 bytes (47620096 active, 20074496 inactive, 0 global, 29360128 shared, 102400 unbound, 0 closed)
```

This had no effect on vtebench results.