### PR TITLE
Add note about unstable setting

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -44,7 +44,7 @@
   #
   # Values for `decorations`:
   #     - full: Borders and title bar
-  #     - none: Neither borders nor title bar
+  #     - none: Neither borders nor title bar (currently unstable on Windows operating systems)
   #
   # Values for `decorations` (macOS only):
   #     - transparent: Title bar, transparent background and title bar buttons


### PR DESCRIPTION
When setting to "decorations: none" on Windows (observed on multiple machines), the Alacritty window fails to open. I added a note so that Windows users will be aware of the bug before making configuration changes.

I don't see an Issue related to this bug, but I haven't had a chance to figure out if the bug is truly with Alacritty or if it's with the Glutin crate that Alacritty uses. When I figure that out, I will submit an Issue to the appropriate repository. Though, if you prefer I submit an Issue to Alacritty right now, let me know and I can do that.