### PR TITLE
Use proper path logging formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash when trying to start on X11 with a Wayland compositor running
 - Crash with a virtual display connected on X11
 - GPU memory usage has been decreased by disabling allocation of depth and stencil buffers
-- Fix path logging on Windows
+- Use `\` instead of `\\` as path separators on Windows for logging config file location
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash when trying to start on X11 with a Wayland compositor running
 - Crash with a virtual display connected on X11
 - GPU memory usage has been decreased by disabling allocation of depth and stencil buffers
+- Fix path logging on Windows
 
 ### Removed
 

--- a/alacritty/src/logging.rs
+++ b/alacritty/src/logging.rs
@@ -45,8 +45,8 @@ pub fn initialize(
 
     // Use env_logger if RUST_LOG environment variable is defined. Otherwise,
     // use the alacritty-only logger.
-    if ::std::env::var("RUST_LOG").is_ok() {
-        ::env_logger::try_init()?;
+    if std::env::var("RUST_LOG").is_ok() {
+        env_logger::try_init()?;
         Ok(None)
     } else {
         let logger = Logger::new(event_proxy);
@@ -172,7 +172,7 @@ impl OnDemandLogFile {
                 Ok(file) => {
                     self.file = Some(io::LineWriter::new(file));
                     self.created.store(true, Ordering::Relaxed);
-                    let _ = writeln!(io::stdout(), "Created log file at {:?}", self.path);
+                    let _ = writeln!(io::stdout(), "Created log file at \"{}\"", self.path.display());
                 },
                 Err(e) => {
                     let _ = writeln!(io::stdout(), "Unable to create log file: {}", e);

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
     // Clean up logfile
     if let Some(log_file) = log_file {
         if !persistent_logging && fs::remove_file(&log_file).is_ok() {
-            let _ = writeln!(io::stdout(), "Deleted log file at {:?}", log_file);
+            let _ = writeln!(io::stdout(), "Deleted log file at \"{}\"", log_file.display());
         }
     }
 }
@@ -123,7 +123,7 @@ fn main() {
 fn run(window_event_loop: GlutinEventLoop<Event>, config: Config) -> Result<(), Box<dyn Error>> {
     info!("Welcome to Alacritty");
     if let Some(config_path) = &config.config_path {
-        info!("Configuration loaded from {:?}", config_path.display());
+        info!("Configuration loaded from \"{}\"", config_path.display());
     };
 
     // Set environment variables


### PR DESCRIPTION
It was discovered that we were logging path with `\\` instead of `\` as
separators on Windows due to use of Debug formatting instead of Display
for paths.