### PR TITLE
Set stencil buffer to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash when resuming after suspension
 - Crash when trying to start on X11 with a Wayland compositor running
 - Crash with a virtual display connected on X11
-- GPU memory usage has been decreased by disabling allocation of depth and stencil buffers
+- GPU memory usage has been decreased by disabling allocation of depth
 
 ### Removed
 

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -118,7 +118,7 @@ fn create_gl_window(
         .with_srgb(srgb)
         .with_vsync(true)
         .with_depth_buffer(0)
-        .with_stencil_buffer(0)
+        .with_stencil_buffer(1)
         .with_hardware_acceleration(None)
         .build_windowed(window, event_loop)?;
 


### PR DESCRIPTION
It was discovered that on some GPUs (Rx 570 + amdgpu driver) this leads to artifacts during startup on X11.

The bug is presented with or without compositor running.

video
https://www.dropbox.com/s/5xcni3cs6p263lc/revert.mkv?dl=0

This reverts commit 3475e449870b382cda4ea6d48f980577cd8c929e.

cc @Jasu

P.s.
I've initially tested only my Wayland system, which is absolutely fine with this changes, however X11 don't like it at all.