### PR TITLE
remove terminfo from deb metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimum Rust version has been bumped to 1.36.0
 - Config is not generated anymore, please consider distributing the alacritty.yml as documentation
+- Removed Alacritty terminfo from .deb in favor of ncurses provided one
 
 ### Added
 

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -65,6 +65,5 @@ assets = [
     ["../extra/completions/alacritty.bash", "usr/share/bash-completion/completions/alacritty", "644"],
     ["../extra/completions/alacritty.fish", "usr/share/fish/completions/alacritty.fish", "644"],
     ["../extra/completions/_alacritty", "usr/share/zsh/vendor-completions/_alacritty", "644"],
-    ["../extra/alacritty.info", "usr/share/terminfo/a/alacritty", "644"],
 ]
 maintainer-scripts = "../extra/linux/debian"


### PR DESCRIPTION
delete the terminfo line from the .deb manifest to get rid of the related issue #2685 