### PR TITLE
Fix cases where config's "window" is not defined

### DIFF
--- a/alacritty/src/cli.rs
+++ b/alacritty/src/cli.rs
@@ -301,8 +301,7 @@ mod test {
 
     #[test]
     fn dynamic_title_ignoring_options_by_default() {
-        let mut config = Config::default();
-        config.window.title = "Alacritty".to_string();
+        let config = Config::default();
         let old_dynamic_title = config.dynamic_title();
 
         let config = Options::default().into_config(config);

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -9,7 +9,7 @@ use crate::index::{Column, Line};
 pub const DEFAULT_NAME: &str = "Alacritty";
 
 #[serde(default)]
-#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct WindowConfig {
     /// Initial dimensions
     #[serde(deserialize_with = "failure_default")]
@@ -65,6 +65,24 @@ impl WindowConfig {
         match self.start_maximized {
             Some(true) => StartupMode::Maximized,
             _ => self.startup_mode,
+        }
+    }
+}
+
+impl Default for WindowConfig {
+    fn default() -> WindowConfig {
+        WindowConfig {
+            dimensions: Default::default(),
+            position: Default::default(),
+            padding: Default::default(),
+            decorations: Default::default(),
+            dynamic_padding: Default::default(),
+            startup_mode: Default::default(),
+            title: DEFAULT_NAME.into(),
+            class: Default::default(),
+            embed: Default::default(),
+            gtk_theme_variant: Default::default(),
+            start_maximized: Default::default(),
         }
     }
 }


### PR DESCRIPTION
In the config, if `window` is undefined, the derived `Default` for the String `title` is used, which is an empty String. This was unintended, and causes issues in gnome-shell (e.g. in the alt-tab dialog) when the window title is an empty string.

This commit adds a manually implemented default for the `WindowConfig`, it's the same as the derived `Default`, except for the `title`, which will now always be "Alacritty" as originally intended.

Fixes #2887 