### PR TITLE
Default to ConPTY instead of WinPTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - On Windows, query DirectWrite for recommended anti-aliasing settings
+- On Windows, the ConPTY backend will now be used by default if available; the `enable_experimental_conpty_backend` config option has been replaced with `use_winpty_backend`.
 
 ### Fixed
 

--- a/alacritty.yml
+++ b/alacritty.yml
@@ -337,16 +337,16 @@
 # directory of the parent process will be used.
 #working_directory: None
 
-# Windows 10 ConPTY backend (Windows only)
+# Windows 10 WinPTY backend (Windows only)
 #
-# This will enable better color support and may resolve other issues,
-# however this API and its implementation is still young and so is
-# disabled by default, as stability may not be as good as the winpty
-# backend.
+# Alacritty defaults to using the newer ConPTY backend if it is
+# available, since it provides better color support, resolves various
+# other minor rendering bugs and is quite a bit faster. If it is not
+# available, the the WinPTY backend will be used instead.
 #
-# Alacritty will fall back to the WinPTY automatically if the ConPTY
-# backend cannot be initialized.
-#enable_experimental_conpty_backend: false
+# Setting this option to true makes Alacritty use the WinPTY backend,
+# even if the ConPTY backend is available.
+#use_winpty_backend: false
 
 # Send ESC (\x1b) before characters when alt is pressed.
 #alt_send_esc: true

--- a/alacritty_terminal/src/config/mod.rs
+++ b/alacritty_terminal/src/config/mod.rs
@@ -108,11 +108,10 @@ pub struct Config<T> {
     #[serde(default, deserialize_with = "failure_default")]
     pub cursor: Cursor,
 
-    /// Enable experimental conpty backend instead of using winpty.
-    /// Will only take effect on Windows 10 Oct 2018 and later.
+    /// Disable conpty backend, and use winpty even if conpty is available.
     #[cfg(windows)]
     #[serde(default, deserialize_with = "failure_default")]
-    pub enable_experimental_conpty_backend: bool,
+    pub use_winpty_backend: bool,
 
     /// Send escape sequences using the alt key.
     #[serde(default, deserialize_with = "failure_default")]

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -104,7 +104,7 @@ pub fn new<'a, C>(
     size: &SizeInfo,
     _window_id: Option<usize>,
 ) -> Option<Pty<'a>> {
-    if !config.enable_experimental_conpty_backend {
+    if config.use_winpty_backend {
         return None;
     }
 


### PR DESCRIPTION
I’ve been using the ConPTY backend since I started using Alacritty, and I don’t think I have *ever* experienced a problem unique to the ConPTY backend. Whenever I disable it to test something on the WinPTY backend, I cringe at how buggy ConPTY’s rendering is. After a year of ConPTY’s existence, I see no compelling reason to stick with the old and inferior. I reckon it’s time to default to the new and improved.