### PR TITLE
Fix XEmbed compilation error on 32-bit platforms

### DIFF
--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -15,6 +15,7 @@ use std::convert::From;
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::ffi::c_void;
 use std::fmt;
+use std::os::raw::c_ulong;
 
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use glutin::event_loop::EventLoop;
@@ -392,7 +393,7 @@ impl Window {
 }
 
 #[cfg(not(any(target_os = "macos", windows)))]
-fn x_embed_window(window: &GlutinWindow, parent_id: u64) {
+fn x_embed_window(window: &GlutinWindow, parent_id: c_ulong) {
     let (xlib_display, xlib_window) = match (window.xlib_display(), window.xlib_window()) {
         (Some(display), Some(window)) => (display, window),
         _ => return,

--- a/alacritty_terminal/src/config/window.rs
+++ b/alacritty_terminal/src/config/window.rs
@@ -1,3 +1,5 @@
+use std::os::raw::c_ulong;
+
 use serde::Deserialize;
 
 use crate::config::{
@@ -45,7 +47,7 @@ pub struct WindowConfig {
 
     /// XEmbed parent
     #[serde(skip)]
-    pub embed: Option<u64>,
+    pub embed: Option<c_ulong>,
 
     /// GTK theme variant
     #[serde(deserialize_with = "option_explicit_none")]


### PR DESCRIPTION
Compilation is broken on 32-bit X11 platforms since c1f089970fd3d4b9137d07647f8cd028b2b5b3a9:

```
error[E0308]: mismatched types
   --> alacritty/src/window.rs:420:69
    |
420 |         (xlib.XReparentWindow)(xlib_display as _, xlib_window as _, parent_id, 0, 0);
    |                                                                     ^^^^^^^^^ expected u32, found u64
help: you can convert an `u64` to `u32` and panic if the converted value wouldn't fit
    |
420 |         (xlib.XReparentWindow)(xlib_display as _, xlib_window as _, parent_id.try_into().unwrap(), 0, 0);
```

The XID of the XEmbed parent needs to be an unsigned long, as seen here: [xlib.rs#L623](https://github.com/erlepereira/x11-rs/blob/7d81595d630f03ced06747f3e214c59eda438df8/src/xlib.rs#L623).