### PR TITLE
Avoid unused import warning on macOS/Windows

### DIFF
--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -15,7 +15,6 @@ use std::convert::From;
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::ffi::c_void;
 use std::fmt;
-use std::os::raw::c_ulong;
 
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use glutin::event_loop::EventLoop;

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -15,6 +15,8 @@ use std::convert::From;
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::ffi::c_void;
 use std::fmt;
+#[cfg(target_os = "linux")]
+use std::os::raw::c_ulong;
 
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use glutin::event_loop::EventLoop;

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -15,7 +15,7 @@ use std::convert::From;
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::ffi::c_void;
 use std::fmt;
-#[cfg(target_os = "linux")]
+#[cfg(not(any(target_os = "macos", windows)))]
 use std::os::raw::c_ulong;
 
 use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};


### PR DESCRIPTION
Getting rid of an unused import for Windows/macOS.

My rustc version is 1.38.0.

<img width="1065" alt="Screen Shot 2019-10-22 at 17 31 23" src="https://user-images.githubusercontent.com/147051/67269775-48135400-f4f2-11e9-9fca-a939aa3f8717.png">
