### PR TITLE
Draw dirty terminal even when event queue is empty

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -426,10 +426,10 @@ impl<N: Notify> Processor<N> {
             }
 
             if terminal.dirty {
-                // Clear dirty flag
-                let animating = !terminal.visual_bell.completed();
-                terminal.dirty = animating;
-                if animating {
+                terminal.dirty = false;
+
+                // Request immediate re-draw if visual bell animation is not finished yet
+                if !terminal.visual_bell.completed() {
                     event_queue.push(GlutinEvent::UserEvent(Event::Wakeup));
                 }
 
@@ -444,7 +444,7 @@ impl<N: Notify> Processor<N> {
 
     /// Handle events from glutin
     ///
-    /// Doesn't take self mutably due to borrow checking. Kinda uggo but w/e.
+    /// Doesn't take self mutably due to borrow checking.
     fn handle_event<T>(
         event: GlutinEvent<Event>,
         processor: &mut input::Processor<T, ActionContext<N, T>>,

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -348,7 +348,6 @@ impl<N: Notify> Processor<N> {
                 info!("glutin event: {:?}", event);
             }
 
-
             match (&event, tty::process_should_exit()) {
                 // Check for shutdown
                 (GlutinEvent::UserEvent(Event::Exit), _) | (_, true) => {

--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -348,6 +348,8 @@ impl<N: Notify> Processor<N> {
                 info!("glutin event: {:?}", event);
             }
 
+            let mut terminal = terminal.lock();
+
             match (&event, tty::process_should_exit()) {
                 // Check for shutdown
                 (GlutinEvent::UserEvent(Event::Exit), _) | (_, true) => {
@@ -358,7 +360,7 @@ impl<N: Notify> Processor<N> {
                 (GlutinEvent::EventsCleared, _) => {
                     *control_flow = ControlFlow::Wait;
 
-                    if event_queue.is_empty() {
+                    if event_queue.is_empty() && !terminal.dirty {
                         return;
                     }
                 },
@@ -371,8 +373,6 @@ impl<N: Notify> Processor<N> {
                     return;
                 },
             }
-
-            let mut terminal = terminal.lock();
 
             let mut resize_pending = Resize::default();
 


### PR DESCRIPTION
If the event queue was empty, we would stop the event loop even if the terminal was dirty. This lead to the terminal not being drawn when running animations unless something else was causing events to queue, such as user input.

This change ensures that the terminal is always drawn on EventsCleared when dirty.

Fixes #2914.