### PR TITLE
Dont redraw the screen when moving the mouse, if it is not needed

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1241,8 +1241,10 @@ impl<T> Term<T> {
 
     #[inline]
     pub fn reset_url_highlight(&mut self) {
-        self.grid.url_highlight = None;
-        self.dirty = true;
+        if self.grid.url_highlight.is_some() {
+            self.grid.url_highlight = None;
+            self.dirty = true;
+        }
     }
 
     pub fn clipboard(&mut self) -> &mut Clipboard {


### PR DESCRIPTION
On high resolution monitors connected to laptops, reducing the amount of needles redraws of the window helps reducing the battery usage. And when turning on the config option debug.render_time I noticed alacritty redrawing constantly when moving the mouse across the window.
When moving the mouse across the screen, alacritty currently checks if the mouse changes cells before doing anything. This includes setting and resetting the url underline status in the terminal, causing it to always get set to dirty, even in the following cases:
1) no url is highlighted before and after the mouse movement
2) the same url is highlighted before and after

Both cases obviously require no redraw of the Terminal.

This pull request only fixes 1), since it was simpler and I guess the much more common situation.
