### PR TITLE
Fix division by zero when minimizing on Windows

### DIFF
--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -186,14 +186,15 @@ impl Display {
         info!("Cell Size: {} x {}", cell_width, cell_height);
         info!("Padding: {} x {}", padding_x, padding_y);
 
+        // Create new size with at least one column and row
         let size_info = SizeInfo {
             dpr,
-            width: viewport_size.width as f32,
-            height: viewport_size.height as f32,
-            cell_width: cell_width as f32,
-            cell_height: cell_height as f32,
-            padding_x: padding_x as f32,
-            padding_y: padding_y as f32,
+            width: (viewport_size.width as f32).max(cell_width + 2. * padding_x),
+            height: (viewport_size.height as f32).max(cell_height + 2. * padding_y),
+            cell_width,
+            cell_height,
+            padding_x,
+            padding_y,
         };
 
         // Update OpenGL projection
@@ -302,25 +303,24 @@ impl Display {
             self.update_glyph_cache(config, font);
         }
 
-        // Update the window dimensions
-        if let Some(size) = update_pending.dimensions {
-            self.size_info.width = size.width as f32;
-            self.size_info.height = size.height as f32;
-        }
-
-        let dpr = self.size_info.dpr;
-        let width = self.size_info.width;
-        let height = self.size_info.height;
         let cell_width = self.size_info.cell_width;
         let cell_height = self.size_info.cell_height;
 
         // Recalculate padding
-        let mut padding_x = f32::from(config.window.padding.x) * dpr as f32;
-        let mut padding_y = f32::from(config.window.padding.y) * dpr as f32;
+        let mut padding_x = f32::from(config.window.padding.x) * self.size_info.dpr as f32;
+        let mut padding_y = f32::from(config.window.padding.y) * self.size_info.dpr as f32;
 
+        // Update the window dimensions
+        if let Some(size) = update_pending.dimensions {
+            // Ensure we have at least one column and row
+            self.size_info.width = (size.width as f32).max(cell_width + 2. * padding_x);
+            self.size_info.height = (size.height as f32).max(cell_height + 2. * padding_y);
+        }
+
+        // Distribute excess padding equally on all sides
         if config.window.dynamic_padding {
-            padding_x = dynamic_padding(padding_x, width, cell_width);
-            padding_y = dynamic_padding(padding_y, height, cell_height);
+            padding_x = dynamic_padding(padding_x, self.size_info.width, cell_width);
+            padding_y = dynamic_padding(padding_y, self.size_info.height, cell_height);
         }
 
         self.size_info.padding_x = padding_x.floor() as f32;
@@ -494,7 +494,7 @@ fn compute_cell_size(config: &Config, metrics: &font::Metrics) -> (f32, f32) {
     let offset_x = f64::from(config.font.offset.x);
     let offset_y = f64::from(config.font.offset.y);
     (
-        f32::max(1., ((metrics.average_advance + offset_x) as f32).floor()),
-        f32::max(1., ((metrics.line_height + offset_y) as f32).floor()),
+        ((metrics.average_advance + offset_x) as f32).floor().max(1.),
+        ((metrics.line_height + offset_y) as f32).floor().max(1.),
     )
 }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1023,13 +1023,6 @@ impl<T> Term<T> {
 
     /// Resize terminal to new dimensions
     pub fn resize(&mut self, size: &SizeInfo) {
-        // Bounds check; lots of math assumes width and height are > 0
-        if size.width as usize <= 2 * size.padding_x as usize
-            || size.height as usize <= 2 * size.padding_y as usize
-        {
-            return;
-        }
-
         let old_cols = self.grid.num_cols();
         let old_lines = self.grid.num_lines();
         let mut num_cols = size.cols();


### PR DESCRIPTION
I keep getting the following error from latest master every time I minimize Alacritty on Windows:

```
---------------------------
Alacritty: Runtime Error
---------------------------
panicked at 'attempt to calculate the remainder with a divisor of zero', C:\Users\byk\Documents\Projects\alacritty\alacritty_terminal\src\index.rs:53:52

Press Ctrl-C to Copy
---------------------------
OK   
---------------------------
```

Looks like we expect `num_cols` to never be `0` but when minimizing, it becomes zero. I thought about protecting against this lower in the URL update code but it makes sense to skip drawing completely if we have `0` columns, right?

_Disclaimer: this is one of my first Rust patches and certainly the very first one against Alacritty so assume I have no idea what I'm doing. Pretty open to guidance and fix ups._