### PR TITLE
fix #1465 hide on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,8 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc_id 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_tools_util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -31,6 +31,10 @@ rustc_tools_util = "0.2.0"
 [target.'cfg(not(windows))'.dependencies]
 xdg = "2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2.2"
+objc_id = "0.1.1"
+
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 image = "0.22.3"
 

--- a/alacritty/src/input.rs
+++ b/alacritty/src/input.rs
@@ -18,6 +18,7 @@
 //! In order to figure that out, state about which modifier keys are pressed
 //! needs to be tracked. Additionally, we need a bit of a state machine to
 //! determine what to do when a non-modifier key is pressed.
+#![allow(clippy::let_unit_value)]
 use std::borrow::Cow;
 use std::cmp::min;
 use std::cmp::Ordering;


### PR DESCRIPTION
Fix #1465 by hiding the application using NSApplication.sharedApplication().hide(nil) on macOS rather than just hiding the window. I ran into this issue because tmux mouse mode no longer worked for me after pressing command-H and re-activating alacritty.