### PR TITLE
Colored emojis on Linux/BSD with freetype.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Terminal escape bindings with combined modifiers for Delete and Insert
 - /Applications symlink into OS X DMG for easier installation
+- Colored emojis on Linux/BSD
 
 ### Fixed
 

--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -18,7 +18,7 @@ use std::cmp;
 
 use alacritty_terminal::ansi::CursorStyle;
 
-use font::{Metrics, RasterizedGlyph};
+use font::{BitmapBuffer, Metrics, RasterizedGlyph};
 
 /// Width/Height of the cursor relative to the font width
 pub const CURSOR_WIDTH_PERCENTAGE: i32 = 15;
@@ -61,8 +61,7 @@ pub fn get_underline_cursor_glyph(width: i32, line_width: i32) -> RasterizedGlyp
         left: 0,
         height: line_width,
         width,
-        colored: false,
-        buf,
+        buf: BitmapBuffer::RGB(buf),
     }
 }
 
@@ -72,7 +71,14 @@ pub fn get_beam_cursor_glyph(height: i32, line_width: i32) -> RasterizedGlyph {
     let buf = vec![255u8; (line_width * height * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
-    RasterizedGlyph { c: ' ', top: height, left: 0, height, width: line_width, colored: false, buf }
+    RasterizedGlyph {
+        c: ' ',
+        top: height,
+        left: 0,
+        height,
+        width: line_width,
+        buf: BitmapBuffer::RGB(buf),
+    }
 }
 
 // Returns a custom box cursor character
@@ -94,7 +100,7 @@ pub fn get_box_cursor_glyph(height: i32, width: i32, line_width: i32) -> Rasteri
     }
 
     // Create a custom glyph with the rectangle data attached to it
-    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, colored: false, buf }
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, buf: BitmapBuffer::RGB(buf) }
 }
 
 // Returns a custom block cursor character
@@ -103,5 +109,5 @@ pub fn get_block_cursor_glyph(height: i32, width: i32) -> RasterizedGlyph {
     let buf = vec![255u8; (width * height * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
-    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, colored: false, buf }
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, buf: BitmapBuffer::RGB(buf) }
 }

--- a/alacritty/src/cursor.rs
+++ b/alacritty/src/cursor.rs
@@ -55,7 +55,15 @@ pub fn get_underline_cursor_glyph(width: i32, line_width: i32) -> RasterizedGlyp
     let buf = vec![255u8; (width * line_width * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
-    RasterizedGlyph { c: ' ', top: line_width, left: 0, height: line_width, width, buf }
+    RasterizedGlyph {
+        c: ' ',
+        top: line_width,
+        left: 0,
+        height: line_width,
+        width,
+        colored: false,
+        buf,
+    }
 }
 
 // Returns a custom beam cursor character
@@ -64,7 +72,7 @@ pub fn get_beam_cursor_glyph(height: i32, line_width: i32) -> RasterizedGlyph {
     let buf = vec![255u8; (line_width * height * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
-    RasterizedGlyph { c: ' ', top: height, left: 0, height, width: line_width, buf }
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width: line_width, colored: false, buf }
 }
 
 // Returns a custom box cursor character
@@ -86,7 +94,7 @@ pub fn get_box_cursor_glyph(height: i32, width: i32, line_width: i32) -> Rasteri
     }
 
     // Create a custom glyph with the rectangle data attached to it
-    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, buf }
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, colored: false, buf }
 }
 
 // Returns a custom block cursor character
@@ -95,5 +103,5 @@ pub fn get_block_cursor_glyph(height: i32, width: i32) -> RasterizedGlyph {
     let buf = vec![255u8; (width * height * 3) as usize];
 
     // Create a custom glyph with the rectangle data attached to it
-    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, buf }
+    RasterizedGlyph { c: ' ', top: height, left: 0, height, width, colored: false, buf }
 }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -370,6 +370,7 @@ impl GlyphCache {
             // FIXME
             // Assume that all emojis are 2 width for now.
             let h = metrics.line_height as i32;
+
             if rasterized.colored && rasterized.width > h && rasterized.height > h {
                 rasterized = Self::downsample_bitmap(rasterized, h, h);
             }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -336,7 +336,7 @@ impl GlyphCache {
             n_j += 1;
         }
         // FIXME: better top setting.
-        bitmap_glyph.top = bitmap_glyph.top / ratio as i32;
+        bitmap_glyph.top /= ratio as i32;
         bitmap_glyph.width = width as i32;
         bitmap_glyph.height = height as i32;
         bitmap_glyph.buf = scaled_buffer;

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -336,7 +336,8 @@ impl GlyphCache {
             n_j += 1;
         }
         // FIXME: better top setting.
-        bitmap_glyph.top /= ratio as i32;
+        let b_top = bitmap_glyph.top as f32;
+        bitmap_glyph.top = ((b_top / factor + b_top / ratio as f32) / 2.0)  as i32;
         bitmap_glyph.width = width as i32;
         bitmap_glyph.height = height as i32;
         bitmap_glyph.buf = scaled_buffer;

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -139,6 +139,7 @@ pub struct RectShaderProgram {
 #[derive(Copy, Debug, Clone)]
 pub struct Glyph {
     tex_id: GLuint,
+    colored: bool,
     top: f32,
     left: f32,
     width: f32,
@@ -462,9 +463,15 @@ impl Batch {
         Batch { tex: 0, instances: Vec::with_capacity(BATCH_MAX) }
     }
 
-    pub fn add_item(&mut self, cell: RenderableCell, glyph: &Glyph) {
+    pub fn add_item(&mut self, mut cell: RenderableCell, glyph: &Glyph) {
         if self.is_empty() {
             self.tex = glyph.tex_id;
+        }
+
+        if glyph.colored {
+            cell.fg.r = 255;
+            cell.fg.g = 255;
+            cell.fg.b = 255;
         }
 
         self.instances.push(InstanceData {
@@ -1091,6 +1098,7 @@ fn load_glyph(
         },
         Err(AtlasInsertError::GlyphTooLarge) => Glyph {
             tex_id: atlas[*current_atlas].id,
+            colored: false,
             top: 0.0,
             left: 0.0,
             width: 0.0,
@@ -1608,6 +1616,7 @@ impl Atlas {
 
         Glyph {
             tex_id: self.id,
+            colored: glyph.colored,
             top: glyph.top as f32,
             width: width as f32,
             height: height as f32,

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -472,13 +472,7 @@ impl Batch {
 
         if glyph.colored {
             // XXX Temporary workaround to prevent emojis being rendered with a wrong colors on, at
-            // least, dark backgrounds. To resolve this issue properly we should have a separate
-            // rendering pass for colored glyphs. For more info see #1864.
-            //
-            // The 255 is not a color, it'll be a part of forming an alpha mask later on. So a
-            // proper color of emojis could be achieved by setting fg to #ffffff and bg
-            // to #000000, however we can't change bg here, because it actually "changes
-            // bg" of a cell.
+            // least, dark backgrounds. For more info see #1864.
             cell.fg.r = 255;
             cell.fg.g = 255;
             cell.fg.b = 255;
@@ -1597,9 +1591,15 @@ impl Atlas {
             gl::BindTexture(gl::TEXTURE_2D, self.id);
 
             // Load data into OpenGL
-            let (format, buf, _) = match &glyph.buf {
-                BitmapBuffer::RGB(buf) => (gl::RGB, buf, colored = false),
-                BitmapBuffer::RGBA(buf) => (gl::RGBA, buf, colored = true),
+            let (format, buf) = match &glyph.buf {
+                BitmapBuffer::RGB(buf) => {
+                    colored = false;
+                    (gl::RGB, buf)
+                },
+                BitmapBuffer::RGBA(buf) => {
+                    colored = true;
+                    (gl::RGBA, buf)
+                },
             };
 
             gl::TexSubImage2D(

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -471,6 +471,13 @@ impl Batch {
         }
 
         if glyph.colored {
+            // XXX Temporary workaround to prevent emojis being rendered with a wrong colors on
+            // dark backgrounds. To resolve this issue properly we should have a separate rendering
+            // pass for colored glyphs. For more info #1864.
+            //
+            // The 255 is not a color, it'll be an alpha mask later on. So a proper color of
+            // emojis could be achieved by setting fg to #ffffff and bg to #000000, however we
+            // can't change bg here, because it actually "changes bg" of a cell.
             cell.fg.r = 255;
             cell.fg.g = 255;
             cell.fg.b = 255;

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -471,13 +471,14 @@ impl Batch {
         }
 
         if glyph.colored {
-            // XXX Temporary workaround to prevent emojis being rendered with a wrong colors on
-            // dark backgrounds. To resolve this issue properly we should have a separate rendering
-            // pass for colored glyphs. For more info #1864.
+            // XXX Temporary workaround to prevent emojis being rendered with a wrong colors on, at
+            // least, dark backgrounds. To resolve this issue properly we should have a separate
+            // rendering pass for colored glyphs. For more info see #1864.
             //
-            // The 255 is not a color, it'll be an alpha mask later on. So a proper color of
-            // emojis could be achieved by setting fg to #ffffff and bg to #000000, however we
-            // can't change bg here, because it actually "changes bg" of a cell.
+            // The 255 is not a color, it'll be a part of forming an alpha mask later on. So a
+            // proper color of emojis could be achieved by setting fg to #ffffff and bg
+            // to #000000, however we can't change bg here, because it actually "changes
+            // bg" of a cell.
             cell.fg.r = 255;
             cell.fg.g = 255;
             cell.fg.b = 255;

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -272,6 +272,77 @@ impl GlyphCache {
         Ok((regular, bold, italic, bold_italic))
     }
 
+    // TODO: - take a look on what options we have besides this simple algo.
+    //
+    // area-averaging algorithm to downsample a colored bitmap.
+    fn downsample_bitmap(
+        mut bitmap_glyph: RasterizedGlyph,
+        width: i32,
+        height: i32,
+    ) -> RasterizedGlyph {
+        let width = width as usize;
+        let height = height as usize;
+        let b_width = bitmap_glyph.width as usize;
+        let b_height = bitmap_glyph.height as usize;
+        let b_buf = &bitmap_glyph.buf;
+        let factor = (b_width as f32 / width as f32).max(b_height as f32 / height as f32);
+        let ratio = (factor + 1.) as usize;
+        let mut scaled_buffer = Vec::with_capacity(width * height * 3);
+
+        // Index into new image.
+        let mut n_j = 0;
+        let mut s_j = 0;
+
+        while n_j < height {
+            let mut n_i = 0;
+            let mut s_i = 0;
+            while n_i < width {
+                let mut r: u32 = 0;
+                let mut g: u32 = 0;
+                let mut b: u32 = 0;
+                let mut pixels_picked: u32 = 0;
+
+                let cap_y = std::cmp::min(s_j + ratio, b_height);
+                let cap_x = std::cmp::min(s_i + ratio, b_width);
+
+                let mut s_j = s_j;
+                while s_j < cap_y {
+                    let cur_pixel_index = s_j * b_width * 3;
+                    let mut s_i = s_i;
+                    while s_i < cap_x {
+                        r += b_buf[cur_pixel_index + s_i * 3] as u32;
+                        g += b_buf[cur_pixel_index + s_i * 3 + 1] as u32;
+                        b += b_buf[cur_pixel_index + s_i * 3 + 2] as u32;
+                        s_i += 1;
+                        pixels_picked += 1;
+                    }
+                    s_j += 1;
+                }
+
+                if pixels_picked == 0 {
+                    scaled_buffer.push(0);
+                    scaled_buffer.push(0);
+                    scaled_buffer.push(0);
+                } else {
+                    scaled_buffer.push((r / pixels_picked) as u8);
+                    scaled_buffer.push((g / pixels_picked) as u8);
+                    scaled_buffer.push((b / pixels_picked) as u8);
+                }
+
+                s_i += ratio;
+                n_i += 1;
+            }
+            s_j += ratio;
+            n_j += 1;
+        }
+        // FIXME: better top setting.
+        bitmap_glyph.top = bitmap_glyph.top / ratio as i32;
+        bitmap_glyph.width = width as i32;
+        bitmap_glyph.height = height as i32;
+        bitmap_glyph.buf = scaled_buffer;
+        bitmap_glyph
+    }
+
     fn make_desc(
         desc: &config::FontDescription,
         slant: font::Slant,
@@ -295,6 +366,13 @@ impl GlyphCache {
         self.cache.entry(glyph_key).or_insert_with(|| {
             let mut rasterized =
                 rasterizer.get_glyph(glyph_key).unwrap_or_else(|_| Default::default());
+
+            // FIXME
+            // Assume that all emojis are 2 width for now.
+            let h = metrics.line_height as i32;
+            if rasterized.colored && rasterized.width > h && rasterized.height > h {
+                rasterized = Self::downsample_bitmap(rasterized, h, h);
+            }
 
             rasterized.left += i32::from(glyph_offset.x);
             rasterized.top += i32::from(glyph_offset.y);

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -1589,36 +1589,22 @@ impl Atlas {
             gl::BindTexture(gl::TEXTURE_2D, self.id);
 
             // Load data into OpenGL
-            match &glyph.buf {
-                BitmapBuffer::RGB(buf) => {
-                    gl::TexSubImage2D(
-                        gl::TEXTURE_2D,
-                        0,
-                        offset_x,
-                        offset_y,
-                        width,
-                        height,
-                        gl::RGB,
-                        gl::UNSIGNED_BYTE,
-                        buf.as_ptr() as *const _,
-                    );
-                    colored = false;
-                },
-                BitmapBuffer::RGBA(buf) => {
-                    gl::TexSubImage2D(
-                        gl::TEXTURE_2D,
-                        0,
-                        offset_x,
-                        offset_y,
-                        width,
-                        height,
-                        gl::RGBA,
-                        gl::UNSIGNED_BYTE,
-                        buf.as_ptr() as *const _,
-                    );
-                    colored = true;
-                },
-            }
+            let (format, buf, _) = match &glyph.buf {
+                BitmapBuffer::RGB(buf) => (gl::RGB, buf, colored = false),
+                BitmapBuffer::RGBA(buf) => (gl::RGBA, buf, colored = true),
+            };
+
+            gl::TexSubImage2D(
+                gl::TEXTURE_2D,
+                0,
+                offset_x,
+                offset_y,
+                width,
+                height,
+                format,
+                gl::UNSIGNED_BYTE,
+                buf.as_ptr() as *const _,
+            );
 
             gl::BindTexture(gl::TEXTURE_2D, 0);
             *active_tex = 0;

--- a/font/src/darwin/byte_order.rs
+++ b/font/src/darwin/byte_order.rs
@@ -38,6 +38,27 @@ pub fn extract_rgb(bytes: &[u8]) -> Vec<u8> {
     rgb
 }
 
+#[cfg(target_endian = "little")]
+pub fn extract_rgba(bytes: &[u8]) -> Vec<u8> {
+    let pixels = bytes.len() / 4;
+    let mut rgb = Vec::with_capacity(pixels * 3);
+
+    for i in 0..pixels {
+        let offset = i * 4;
+        rgb.push(bytes[offset + 2]);
+        rgb.push(bytes[offset + 1]);
+        rgb.push(bytes[offset]);
+        rgb.push(bytes[offset + 3]);
+    }
+
+    rgb
+}
+
+#[cfg(target_endian = "big")]
+pub fn extract_rgba(bytes: Vec<u8>) -> Vec<u8> {
+    bytes
+}
+
 #[cfg(target_endian = "big")]
 pub fn extract_rgb(bytes: Vec<u8>) -> Vec<u8> {
     bytes

--- a/font/src/darwin/byte_order.rs
+++ b/font/src/darwin/byte_order.rs
@@ -41,7 +41,7 @@ pub fn extract_rgb(bytes: &[u8]) -> Vec<u8> {
 #[cfg(target_endian = "little")]
 pub fn extract_rgba(bytes: &[u8]) -> Vec<u8> {
     let pixels = bytes.len() / 4;
-    let mut rgb = Vec::with_capacity(pixels * 3);
+    let mut rgb = Vec::with_capacity(pixels * 4);
 
     for i in 0..pixels {
         let offset = i * 4;

--- a/font/src/darwin/byte_order.rs
+++ b/font/src/darwin/byte_order.rs
@@ -24,21 +24,6 @@ pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Little;
 pub const kCGBitmapByteOrder32Host: u32 = kCGBitmapByteOrder32Big;
 
 #[cfg(target_endian = "little")]
-pub fn extract_rgb(bytes: &[u8]) -> Vec<u8> {
-    let pixels = bytes.len() / 4;
-    let mut rgb = Vec::with_capacity(pixels * 3);
-
-    for i in 0..pixels {
-        let offset = i * 4;
-        rgb.push(bytes[offset + 2]);
-        rgb.push(bytes[offset + 1]);
-        rgb.push(bytes[offset]);
-    }
-
-    rgb
-}
-
-#[cfg(target_endian = "little")]
 pub fn extract_rgba(bytes: &[u8]) -> Vec<u8> {
     let pixels = bytes.len() / 4;
     let mut rgb = Vec::with_capacity(pixels * 4);
@@ -57,6 +42,21 @@ pub fn extract_rgba(bytes: &[u8]) -> Vec<u8> {
 #[cfg(target_endian = "big")]
 pub fn extract_rgba(bytes: Vec<u8>) -> Vec<u8> {
     bytes
+}
+
+#[cfg(target_endian = "little")]
+pub fn extract_rgb(bytes: &[u8]) -> Vec<u8> {
+    let pixels = bytes.len() / 4;
+    let mut rgb = Vec::with_capacity(pixels * 3);
+
+    for i in 0..pixels {
+        let offset = i * 4;
+        rgb.push(bytes[offset + 2]);
+        rgb.push(bytes[offset + 1]);
+        rgb.push(bytes[offset]);
+    }
+
+    rgb
 }
 
 #[cfg(target_endian = "big")]

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -45,7 +45,6 @@ use euclid::{Point2D, Rect, Size2D};
 use super::{BitmapBuffer, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph};
 
 pub mod byte_order;
-use self::byte_order;
 use self::byte_order::kCGBitmapByteOrder32Host;
 
 use super::Size;
@@ -525,8 +524,8 @@ impl Font {
 
         let rasterized_pixels = cg_context.data().to_vec();
 
-        let buf = if font.is_colored() {
-            BitmapBuffer::RGBA(byte_order::extract_rgba(&rasterized_pixel))
+        let buf = if self.is_colored() {
+            BitmapBuffer::RGBA(byte_order::extract_rgba(&rasterized_pixels))
         } else {
             BitmapBuffer::RGB(byte_order::extract_rgb(&rasterized_pixels))
         };
@@ -573,6 +572,9 @@ impl Font {
 
 #[cfg(test)]
 mod tests {
+
+    use super::BitmapBuffer;
+
     #[test]
     fn get_family_names() {
         let names = super::get_family_names();
@@ -594,11 +596,16 @@ mod tests {
             for c in &['a', 'b', 'c', 'd'] {
                 let glyph = font.get_glyph(*c, 72., false).unwrap();
 
+                let buf = match &glyph.buf {
+                    BitmapBuffer::RGB(buf) => buf,
+                    BitmapBuffer::RGBA(buf) => buf,
+                };
+
                 // Debug the glyph.. sigh
                 for row in 0..glyph.height {
                     for col in 0..glyph.width {
                         let index = ((glyph.width * 3 * row) + (col * 3)) as usize;
-                        let value = glyph.buf[index];
+                        let value = buf[index];
                         let c = match value {
                             0..=50 => ' ',
                             51..=100 => '.',

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -572,7 +572,6 @@ impl Font {
 
 #[cfg(test)]
 mod tests {
-
     use super::BitmapBuffer;
 
     #[test]

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -246,7 +246,7 @@ impl Rasterizer {
         font: &Font,
     ) -> Option<Result<RasterizedGlyph, Error>> {
         let scaled_size = self.device_pixel_ratio * glyph.size.as_f32_pts();
-        font.get_glyph(glyph.c, f64::from(scaled_size), font.is_colored(), self.use_thin_strokes)
+        font.get_glyph(glyph.c, f64::from(scaled_size), self.use_thin_strokes)
             .map(|r| Some(Ok(r)))
             .unwrap_or_else(|e| match e {
                 Error::MissingGlyph(_) => None,
@@ -455,7 +455,6 @@ impl Font {
         &self,
         character: char,
         _size: f64,
-        colored: bool,
         use_thin_strokes: bool,
     ) -> Result<RasterizedGlyph, Error> {
         let glyph_index =
@@ -535,7 +534,7 @@ impl Font {
             top: (bounds.size.height + bounds.origin.y).ceil() as i32,
             width: rasterized_width as i32,
             height: rasterized_height as i32,
-            colored,
+            colored: self.is_colored(),
             buf,
         })
     }
@@ -591,7 +590,7 @@ mod tests {
         for font in fonts {
             // Get a glyph
             for c in &['a', 'b', 'c', 'd'] {
-                let glyph = font.get_glyph(*c, 72., false, false).unwrap();
+                let glyph = font.get_glyph(*c, 72., false).unwrap();
 
                 // Debug the glyph.. sigh
                 for row in 0..glyph.height {

--- a/font/src/darwin/mod.rs
+++ b/font/src/darwin/mod.rs
@@ -42,10 +42,10 @@ use core_text::font_descriptor::{CTFontDescriptor, CTFontOrientation};
 
 use euclid::{Point2D, Rect, Size2D};
 
-use super::{FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph};
+use super::{BitmapBuffer, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph};
 
 pub mod byte_order;
-use self::byte_order::extract_rgb;
+use self::byte_order;
 use self::byte_order::kCGBitmapByteOrder32Host;
 
 use super::Size;
@@ -476,8 +476,7 @@ impl Font {
                 height: 0,
                 top: 0,
                 left: 0,
-                colored: false,
-                buf: Vec::new(),
+                buf: BitmapBuffer::RGB(Vec::new()),
             });
         }
 
@@ -526,7 +525,11 @@ impl Font {
 
         let rasterized_pixels = cg_context.data().to_vec();
 
-        let buf = extract_rgb(&rasterized_pixels);
+        let buf = if font.is_colored() {
+            BitmapBuffer::RGBA(byte_order::extract_rgba(&rasterized_pixel))
+        } else {
+            BitmapBuffer::RGB(byte_order::extract_rgb(&rasterized_pixels))
+        };
 
         Ok(RasterizedGlyph {
             c: character,
@@ -534,7 +537,6 @@ impl Font {
             top: (bounds.size.height + bounds.origin.y).ceil() as i32,
             width: rasterized_width as i32,
             height: rasterized_height as i32,
-            colored: self.is_colored(),
             buf,
         })
     }

--- a/font/src/directwrite/mod.rs
+++ b/font/src/directwrite/mod.rs
@@ -18,7 +18,9 @@ use self::dwrote::{
     FontCollection, FontStretch, FontStyle, FontWeight, GlyphOffset, GlyphRunAnalysis,
 };
 
-use super::{FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph, Size, Slant, Style, Weight};
+use super::{
+    BitmapBuffer, FontDesc, FontKey, GlyphKey, Metrics, RasterizedGlyph, Size, Slant, Style, Weight,
+};
 
 pub struct DirectWriteRasterizer {
     fonts: Vec<dwrote::FontFace>,
@@ -173,8 +175,7 @@ impl crate::Rasterize for DirectWriteRasterizer {
             height: (bounds.bottom - bounds.top) as i32,
             top: -bounds.top,
             left: bounds.left,
-            colored: false,
-            buf,
+            buf: BitmapBuffer::RGB(buf),
         })
     }
 

--- a/font/src/directwrite/mod.rs
+++ b/font/src/directwrite/mod.rs
@@ -173,6 +173,7 @@ impl crate::Rasterize for DirectWriteRasterizer {
             height: (bounds.bottom - bounds.top) as i32,
             top: -bounds.top,
             left: bounds.left,
+            colored: false,
             buf,
         })
     }

--- a/font/src/ft/fc/pattern.rs
+++ b/font/src/ft/fc/pattern.rs
@@ -420,6 +420,7 @@ impl PatternRef {
         size() => b"size\0",
         aspect() => b"aspect\0",
         pixelsize() => b"pixelsize\0",
+        pixelsizefixupfactor() => b"pixelsizefixupfactor\0",
         scale() => b"scale\0",
         dpi() => b"dpi\0"
     }

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -369,8 +369,8 @@ impl FreeTypeRasterizer {
         if face.has_color {
             let fixup_factor = if face.pixelsize_fixup_factor == 0. {
                 // Fallback
-                self.pixel_size as f64
-                    / face.ft_face.size_metrics().map_or(bitmap.height as f64, |s| s.y_ppem as f64)
+                let metrics = face.ft_face.size_metrics().ok_or(Error::MissingSizeMetrics)?;
+                self.pixel_size as f64 / metrics.y_ppem as f64
             } else {
                 face.pixelsize_fixup_factor
             };

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -361,7 +361,7 @@ impl FreeTypeRasterizer {
             face.load_flags
         };
 
-        face.ft_face.load_glyph(index as u32, flags);
+        face.ft_face.load_glyph(index as u32, flags)?;
 
         let glyph = face.ft_face.glyph();
         glyph.render_glyph(face.render_mode)?;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -525,7 +525,7 @@ impl FreeTypeRasterizer {
                 while i < buf_size {
                     // Convert BGRA to RGB
                     //
-                    // XXX our rendring works in rgb and doens't care about urers alpha.
+                    // XXX our rendring works in rgb now and doens't care about urers alpha
                     packed.push(buf[i + 2]);
                     packed.push(buf[i + 1]);
                     packed.push(buf[i]);
@@ -643,7 +643,6 @@ fn downsample_bitmap(mut bitmap_glyph: RasterizedGlyph, fixup_factor: f64) -> Ra
         s_j += ratio;
         n_j += 1;
     }
-    // FIXME: better top setting.
     let b_top = bitmap_glyph.top as f32;
     bitmap_glyph.top = ((b_top / factor + b_top / ratio as f32) / 2.0) as i32;
     bitmap_glyph.width = width as i32;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -600,15 +600,13 @@ fn downsample_bitmap(mut bitmap_glyph: RasterizedGlyph, fixup_factor: f64) -> Ra
 
     for line_index in 0..target_height {
         let line_index = line_index as f64;
-        let source_line_start = (line_index * downsampling_step).floor() as usize;
-        let source_line_end =
-            min(((line_index + 1.) * downsampling_step).floor() as usize, bitmap_height);
+        let source_line_start = (line_index * downsampling_step).round() as usize;
+        let source_line_end = ((line_index + 1.) * downsampling_step).round() as usize;
 
         for column_index in 0..target_width {
             let column_index = column_index as f64;
-            let source_column_start = (column_index * downsampling_step).floor() as usize;
-            let source_column_end =
-                min(((column_index + 1.) * downsampling_step).floor() as usize, bitmap_width);
+            let source_column_start = (column_index * downsampling_step).round() as usize;
+            let source_column_end = ((column_index + 1.) * downsampling_step).round() as usize;
 
             let (mut r, mut g, mut b, mut a) = (0u32, 0u32, 0u32, 0u32);
             let mut pixels_picked: u32 = 0;

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -618,8 +618,7 @@ fn downsample_bitmap(mut bitmap_glyph: RasterizedGlyph, fixup_factor: f64) -> Ra
             let (mut r, mut g, mut b, mut a) = (0u32, 0u32, 0u32, 0u32);
             let mut pixels_picked: u32 = 0;
 
-            // Consolidate all pixels within the source line and column ranges into a single
-            // averaged pixel
+            // Consolidate all pixels within the source rectangle into a single averaged pixel
             for source_line in source_line_start..source_line_end {
                 let source_pixel_index = source_line * bitmap_width;
 
@@ -633,8 +632,7 @@ fn downsample_bitmap(mut bitmap_glyph: RasterizedGlyph, fixup_factor: f64) -> Ra
                 }
             }
 
-            // Add a single pixel for the downscaled rectangle of the source bitmap into the output
-            // buffer
+            // Add a single pixel to the output buffer for the downscaled source rectangle
             downsampled_buffer.push((r / pixels_picked) as u8);
             downsampled_buffer.push((g / pixels_picked) as u8);
             downsampled_buffer.push((b / pixels_picked) as u8);

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -236,11 +236,7 @@ impl FreeTypeRasterizer {
         })
     }
 
-    fn get_specific_face(
-        &mut self,
-        desc: &FontDesc,
-        style: &str,
-    ) -> Result<FontKey, Error> {
+    fn get_specific_face(&mut self, desc: &FontDesc, style: &str) -> Result<FontKey, Error> {
         let mut pattern = fc::Pattern::new();
         pattern.add_family(&desc.name);
         pattern.add_style(style);

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -597,22 +597,22 @@ fn downsample_bitmap(mut bitmap_glyph: RasterizedGlyph, fixup_factor: f64) -> Ra
     let downsampling_step = (1.0 / fixup_factor).ceil() as usize;
     let mut downsampled_buffer = Vec::<u8>::with_capacity(target_width * target_height * 4);
 
-    let mut source_line_index = 0;
+    let mut source_line_start = 0;
 
     for _ in 0..target_height {
-        let mut source_column_index = 0;
+        let mut source_column_start = 0;
 
         for _ in 0..target_width {
             let (mut r, mut g, mut b, mut a) = (0u32, 0u32, 0u32, 0u32);
             let mut pixels_picked: u32 = 0;
 
-            let source_end_line = min(source_line_index + downsampling_step, bitmap_height);
-            let source_end_column = min(source_column_index + downsampling_step, bitmap_width);
+            let source_end_line = min(source_line_start + downsampling_step, bitmap_height);
+            let source_end_column = min(source_column_start + downsampling_step, bitmap_width);
 
-            for source_line in source_line_index..source_end_line {
+            for source_line in source_line_start..source_end_line {
                 let source_pixel_index = source_line * bitmap_width;
 
-                for source_column in source_column_index..source_end_column {
+                for source_column in source_column_start..source_end_column {
                     let offset = (source_pixel_index + source_column) * 4;
                     r += bitmap_buffer[offset] as u32;
                     g += bitmap_buffer[offset + 1] as u32;
@@ -634,9 +634,9 @@ fn downsample_bitmap(mut bitmap_glyph: RasterizedGlyph, fixup_factor: f64) -> Ra
                 downsampled_buffer.push((a / pixels_picked) as u8);
             }
 
-            source_column_index += downsampling_step;
+            source_column_start += downsampling_step;
         }
-        source_line_index += downsampling_step;
+        source_line_start += downsampling_step;
     }
 
     // This top computation performs better with the scaling algorithm we use. The approach of

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -220,12 +220,21 @@ pub struct RasterizedGlyph {
     pub height: i32,
     pub top: i32,
     pub left: i32,
+    pub colored: bool,
     pub buf: Vec<u8>,
 }
 
 impl Default for RasterizedGlyph {
     fn default() -> RasterizedGlyph {
-        RasterizedGlyph { c: ' ', width: 0, height: 0, top: 0, left: 0, buf: Vec::new() }
+        RasterizedGlyph {
+            c: ' ',
+            width: 0,
+            height: 0,
+            top: 0,
+            left: 0,
+            colored: false,
+            buf: Vec::new(),
+        }
     }
 }
 

--- a/font/src/lib.rs
+++ b/font/src/lib.rs
@@ -220,8 +220,13 @@ pub struct RasterizedGlyph {
     pub height: i32,
     pub top: i32,
     pub left: i32,
-    pub colored: bool,
-    pub buf: Vec<u8>,
+    pub buf: BitmapBuffer,
+}
+
+#[derive(Clone, Debug)]
+pub enum BitmapBuffer {
+    RGB(Vec<u8>),
+    RGBA(Vec<u8>),
 }
 
 impl Default for RasterizedGlyph {
@@ -232,17 +237,8 @@ impl Default for RasterizedGlyph {
             height: 0,
             top: 0,
             left: 0,
-            colored: false,
-            buf: Vec::new(),
+            buf: BitmapBuffer::RGB(Vec::new()),
         }
-    }
-}
-
-struct BufDebugger<'a>(&'a [u8]);
-
-impl<'a> fmt::Debug for BufDebugger<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("GlyphBuffer").field("len", &self.0.len()).field("bytes", &self.0).finish()
     }
 }
 
@@ -254,7 +250,7 @@ impl fmt::Debug for RasterizedGlyph {
             .field("height", &self.height)
             .field("top", &self.top)
             .field("left", &self.left)
-            .field("buf", &BufDebugger(&self.buf[..]))
+            .field("buf", &self.buf)
             .finish()
     }
 }


### PR DESCRIPTION
This PR implements colored emojis support on Linux/BSD with freetype.

The Linux/BSD part of it is working fine, however the implementation requires some discussion, since integration is not that simple in the current structure and I don't want to tight the other platforms on how Linux/BSD operates here.


![picture](https://user-images.githubusercontent.com/27620401/69481137-810b5500-0e1f-11ea-8c39-2b0a8e5a44b6.png)


~P.s. I'll fix macOS/Windows builds when we agree on integration.~