### PR TITLE
Remove unused PackedVertex struct

### DIFF
--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -450,12 +450,6 @@ pub struct LoaderApi<'a> {
     current_atlas: &'a mut usize,
 }
 
-#[derive(Debug)]
-pub struct PackedVertex {
-    x: f32,
-    y: f32,
-}
-
 #[derive(Debug, Default)]
 pub struct Batch {
     tex: GLuint,


### PR DESCRIPTION
All references to `PackedVertex` were removed in #2066, so there is no
reason to keep it around.

---

I'm on a roll. From changing a few characters to completely removing a few lines!