### PR TITLE
Fix `OSC 52` with empty clipboard param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - URLs not truncated with non-matching single quote
 - Absolute file URLs (`file:///home`) not recognized because of leading `/`
+- Clipboard escape `OSC 52` not working with empty clipboard parameter
 
 ## 0.4.0-dev
 

--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -849,13 +849,14 @@ where
 
             // Set clipboard
             b"52" => {
-                if params.len() < 3 || params[1].is_empty() {
+                if params.len() < 3 {
                     return unhandled(params);
                 }
 
+                let clipboard = params[1].get(0).unwrap_or(&b'c');
                 match params[2] {
-                    b"?" => self.handler.write_clipboard(params[1][0], writer),
-                    base64 => self.handler.set_clipboard(params[1][0], base64),
+                    b"?" => self.handler.write_clipboard(*clipboard, writer),
+                    base64 => self.handler.set_clipboard(*clipboard, base64),
                 }
             },
 


### PR DESCRIPTION
This fixes the behavior of the clipboard escape (`OSC 52`) when the
second parameter is not specified. If it is missing, the parameter is
now assumed to be `c`, defaulting to the default clipboard.

This has been fixed both for writing and reading.

Fixes #3037.