### PR TITLE
Fix deadlock issue in Conpty drop implementation

### DIFF
--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -34,8 +34,8 @@ pub use self::windows::*;
 /// It defines an abstraction over mio's interface in order to allow either one
 /// read/write object or a separate read and write object.
 pub trait EventedReadWrite {
-    type Reader: io::Read;
-    type Writer: io::Write;
+    type Reader: io::Read + ?Sized;
+    type Writer: io::Write + ?Sized;
 
     fn register(
         &mut self,

--- a/alacritty_terminal/src/tty/windows/dynamic.rs
+++ b/alacritty_terminal/src/tty/windows/dynamic.rs
@@ -1,0 +1,110 @@
+use super::{EventedRead, EventedWrite, Pty, PtyImpl};
+use crate::event::OnResize;
+use crate::term::SizeInfo;
+use std::marker::PhantomData;
+
+// This trait is used to convert statically-dispatched Ptys into type-erased,
+// dynamically-dispatched ones.
+// This has to be done in two steps:
+//   1) The DynPtyImpl struct converts all the PtyImpl output types into
+//      dynamically-dispatched forms (e.g. Conout -> dyn EventedRead + 'a)
+//   2) The DynPty struct wraps a type-erased Box<DynPtyImpl>, thus enabling
+//      the type of the original PtyImpl to be erased.
+pub trait IntoDynamicPty<'a> {
+    fn into_dynamic_pty(self) -> Pty<DynPty<'a>>;
+}
+
+impl<'a, T> IntoDynamicPty<'a> for Pty<T>
+where
+    T: PtyImpl + Send + 'a,
+    <T as PtyImpl>::ResizeHandle: 'a,
+    <T as PtyImpl>::Conout: Sized + 'a,
+    <T as PtyImpl>::Conin: Sized + 'a,
+{
+    fn into_dynamic_pty(self) -> Pty<DynPty<'a>> {
+        Pty {
+            inner: DynPty(Box::new(DynPtyImpl(self.inner, PhantomData))),
+            read_token: self.read_token,
+            write_token: self.write_token,
+            child_event_token: self.child_event_token,
+            child_watcher: self.child_watcher,
+        }
+    }
+}
+
+pub struct DynPty<'a>(
+    Box<
+        dyn PtyImpl<
+                ResizeHandle = DynResizeHandle<'a>,
+                Conout = dyn EventedRead + 'a,
+                Conin = dyn EventedWrite + 'a,
+            > + Send
+            + 'a,
+    >,
+);
+
+pub struct DynResizeHandle<'a>(Box<dyn OnResize + 'a>);
+
+struct DynPtyImpl<'a, T>(T, PhantomData<Box<DynPty<'a>>>);
+
+impl<'a> OnResize for DynResizeHandle<'a> {
+    fn on_resize(&mut self, size: &SizeInfo) {
+        (*self.0).on_resize(size)
+    }
+}
+
+impl<'a, T, R, CO, CI> PtyImpl for DynPtyImpl<'a, T>
+where
+    T: PtyImpl<ResizeHandle = R, Conout = CO, Conin = CI> + 'a,
+    R: OnResize + 'a,
+    CO: EventedRead + Sized + 'a,
+    CI: EventedWrite + Sized + 'a,
+{
+    type ResizeHandle = DynResizeHandle<'a>;
+    type Conout = dyn EventedRead + 'a;
+    type Conin = dyn EventedWrite + 'a;
+
+    fn resize_handle(&self) -> DynResizeHandle<'a> {
+        DynResizeHandle(Box::new(self.0.resize_handle()))
+    }
+
+    fn conout(&self) -> &(dyn EventedRead + 'a) {
+        self.0.conout()
+    }
+
+    fn conout_mut(&mut self) -> &mut (dyn EventedRead + 'a) {
+        self.0.conout_mut()
+    }
+    fn conin(&self) -> &(dyn EventedWrite + 'a) {
+        self.0.conin()
+    }
+    fn conin_mut(&mut self) -> &mut (dyn EventedWrite + 'a) {
+        self.0.conin_mut()
+    }
+}
+
+impl<'a> PtyImpl for DynPty<'a> {
+    type ResizeHandle = DynResizeHandle<'a>;
+    type Conout = dyn EventedRead + 'a;
+    type Conin = dyn EventedWrite + 'a;
+
+    fn resize_handle(&self) -> Self::ResizeHandle {
+        self.0.resize_handle()
+    }
+
+    fn conout(&self) -> &Self::Conout {
+        self.0.conout()
+    }
+
+    fn conout_mut(&mut self) -> &mut Self::Conout {
+        self.0.conout_mut()
+    }
+
+    fn conin(&self) -> &Self::Conin {
+        self.0.conin()
+    }
+
+    fn conin_mut(&mut self) -> &mut Self::Conin {
+        self.0.conin_mut()
+    }
+}

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -146,11 +146,11 @@ impl EventedReadWrite for Pty {
             PtyInner::Winpty(w) => {
                 poll.register(&w.conout, self.read_token, ri, poll_opts)?;
                 poll.register(&w.conin, self.write_token, wi, poll_opts)?;
-            }
+            },
             PtyInner::Conpty(c) => {
                 poll.register(&c.conout, self.read_token, ri, poll_opts)?;
                 poll.register(&c.conin, self.write_token, wi, poll_opts)?;
-            }
+            },
         }
 
         self.child_event_token = token.next().unwrap();
@@ -178,11 +178,11 @@ impl EventedReadWrite for Pty {
             PtyInner::Winpty(w) => {
                 poll.reregister(&w.conout, self.read_token, ri, poll_opts)?;
                 poll.reregister(&w.conin, self.write_token, wi, poll_opts)?;
-            }
+            },
             PtyInner::Conpty(c) => {
                 poll.reregister(&c.conout, self.read_token, ri, poll_opts)?;
                 poll.reregister(&c.conin, self.write_token, wi, poll_opts)?;
-            }
+            },
         }
 
         poll.reregister(
@@ -201,11 +201,11 @@ impl EventedReadWrite for Pty {
             PtyInner::Winpty(w) => {
                 poll.deregister(&w.conout)?;
                 poll.deregister(&w.conin)?;
-            }
+            },
             PtyInner::Conpty(c) => {
                 poll.deregister(&c.conout)?;
                 poll.deregister(&c.conin)?;
-            }
+            },
         }
 
         poll.deregister(self.child_watcher.event_rx())?;

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -51,7 +51,7 @@ impl Pty {
     pub fn resize_handle(&self) -> impl OnResize {
         match &self.inner {
             PtyInner::Winpty(w) => PtyResizeHandle::Winpty(w.resize_handle()),
-            PtyInner::Conpty(c) => PtyResizeHandle::Conpty(c.resize_handle())
+            PtyInner::Conpty(c) => PtyResizeHandle::Conpty(c.resize_handle()),
         }
     }
 }
@@ -146,7 +146,7 @@ impl EventedReadWrite for Pty {
             PtyInner::Winpty(w) => {
                 poll.register(&w.conout, self.read_token, ri, poll_opts)?;
                 poll.register(&w.conin, self.write_token, wi, poll_opts)?;
-            },
+            }
             PtyInner::Conpty(c) => {
                 poll.register(&c.conout, self.read_token, ri, poll_opts)?;
                 poll.register(&c.conin, self.write_token, wi, poll_opts)?;
@@ -178,7 +178,7 @@ impl EventedReadWrite for Pty {
             PtyInner::Winpty(w) => {
                 poll.reregister(&w.conout, self.read_token, ri, poll_opts)?;
                 poll.reregister(&w.conin, self.write_token, wi, poll_opts)?;
-            },
+            }
             PtyInner::Conpty(c) => {
                 poll.reregister(&c.conout, self.read_token, ri, poll_opts)?;
                 poll.reregister(&c.conin, self.write_token, wi, poll_opts)?;
@@ -201,7 +201,7 @@ impl EventedReadWrite for Pty {
             PtyInner::Winpty(w) => {
                 poll.deregister(&w.conout)?;
                 poll.deregister(&w.conin)?;
-            },
+            }
             PtyInner::Conpty(c) => {
                 poll.deregister(&c.conout)?;
                 poll.deregister(&c.conin)?;

--- a/alacritty_terminal/src/tty/windows/winpty.rs
+++ b/alacritty_terminal/src/tty/windows/winpty.rs
@@ -79,10 +79,10 @@ impl OnResize for WinptyResizeHandle {
     fn on_resize(&mut self, size: &SizeInfo) {
         let (cols, lines) = (size.cols().0, size.lines().0);
         if cols > 0 && cols <= u16::MAX as usize && lines > 0 && lines <= u16::MAX as usize {
-            let winpty: &mut Winpty = unsafe {
-                // This transmute is actually thread-safe since Winpty uses a mutex internally.
-                std::mem::transmute(&self.winpty as *const _ as *mut Winpty)
-            };
+            // This unsafe case from const to non-const is actually thread-safe because
+            // Winpty uses a mutex internally.
+            let winpty: *mut Winpty = &self.winpty as *const _ as *mut Winpty;
+            let winpty = unsafe { &mut *winpty };
 
             winpty
                 .set_size(cols as u16, lines as u16)

--- a/alacritty_terminal/src/tty/windows/winpty.rs
+++ b/alacritty_terminal/src/tty/windows/winpty.rs
@@ -145,13 +145,3 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, _window_id: Option<usize>) ->
         child_watcher,
     }
 }
-
-impl OnResize for Winpty {
-    fn on_resize(&mut self, sizeinfo: &SizeInfo) {
-        let (cols, lines) = (sizeinfo.cols().0, sizeinfo.lines().0);
-        if cols > 0 && cols <= u16::MAX as usize && lines > 0 && lines <= u16::MAX as usize {
-            self.set_size(cols as u16, lines as u16)
-                .unwrap_or_else(|_| info!("Unable to set winpty size, did it die?"));
-        }
-    }
-}

--- a/winpty/src/windows.rs
+++ b/winpty/src/windows.rs
@@ -47,7 +47,7 @@ pub struct Err {
 }
 
 // Check to see whether winpty gave us an error
-fn check_err<'a>(e: *mut winpty_error_t) -> Option<Err> {
+fn check_err(e: *mut winpty_error_t) -> Option<Err> {
     let err = unsafe {
         let raw = winpty_error_msg(e);
         Err {


### PR DESCRIPTION
Fixes #3042 

I also refactored some of the differences between winpty / conpty at the same time - resulting in more uniform interfaces and less code overall. Also got rid of the lifetime on the `Pty` type 😄 