### PR TITLE
Add new issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,13 +2,13 @@ For bug reports, the following information can optionally help speed up the proc
 
 # System
 
-|                   |                               |
-|-------------------|-------------------------------|
-| Operating System  | [Linux/BSD/macOS/Windows]     |
-| Alacritty Version | [alacritty --version output]  |
-| Display Server    | [X11/Wayland] (only on Linux) |
-| Window Manager    | [i3/xfwm/...] (only on Linux) |
-| Compositor        | [compton/...] (only on Linux) |
+|                   |                                 |
+|-------------------|---------------------------------|
+| Operating System  | [Linux/BSD/macOS/Windows]       |
+| Alacritty Version | [`alacritty --version` output]  |
+| Display Server    | [X11/Wayland] (only on Linux)   |
+| Window Manager    | [i3/xfwm/...] (only on Linux)   |
+| Compositor        | [compton/...] (only on Linux)   |
 
 # Logs
 
@@ -17,5 +17,5 @@ Based on the issue at hand, some logs might be relevant:
 | Command                    | Issues                                              |
 |----------------------------|-----------------------------------------------------|
 | STDOUT, STDERR             | Crashes                                             |
-| `alacritty -vv`            | DPI, font Size, resize, terminal grid and cell size |
+| `alacritty -vv`            | DPI, font size, resize, terminal grid and cell size |
 | `alacritty --print-events` | Problems with keyboard and keybindings              |

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,21 @@
-Which operating system does the issue occur on?
+For bug reports, the following information can optionally help speed up the process:
 
-If on linux, are you using X11 or Wayland?
+# System
 
+|                   |                               |
+|-------------------|-------------------------------|
+| Operating System  | [Linux/BSD/macOS/Windows]     |
+| Alacritty Version | [alacritty --version output]  |
+| Display Server    | [X11/Wayland] (only on Linux) |
+| Window Manager    | [i3/xfwm/...] (only on Linux) |
+| Compositor        | [compton/...] (only on Linux) |
+
+# Logs
+
+Based on the issue at hand, some logs might be relevant:
+
+| Command                    | Issues                                              |
+|----------------------------|-----------------------------------------------------|
+| STDOUT, STDERR             | Crashes                                             |
+| `alacritty -vv`            | DPI, font Size, resize, terminal grid and cell size |
+| `alacritty --print-events` | Problems with keyboard and keybindings              |

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-For bug reports, the following information can optionally help speed up the process.
+For bug reports, the following information can help speed up the process.
 
 Please describe the bug that you have found and what you would expect to happen instead.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,6 @@
-For bug reports, the following information can optionally help speed up the process:
+For bug reports, the following information can optionally help speed up the process.
+
+Please describe the bug that you have found and what you would expect to happen instead.
 
 # System
 
@@ -20,3 +22,4 @@ Based on the issue at hand, some logs might be relevant:
 | STDOUT, STDERR             | Crashes                                             |
 | `alacritty -vv`            | DPI, font size, resize, terminal grid and cell size |
 | `alacritty --print-events` | Problems with keyboard and keybindings              |
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,13 +2,14 @@ For bug reports, the following information can optionally help speed up the proc
 
 # System
 
-|                   |                                 |
-|-------------------|---------------------------------|
-| Operating System  | [Linux/BSD/macOS/Windows]       |
-| Alacritty Version | [`alacritty --version` output]  |
-| Display Server    | [X11/Wayland] (only on Linux)   |
-| Window Manager    | [i3/xfwm/...] (only on Linux)   |
-| Compositor        | [compton/...] (only on Linux)   |
+|                   |                                   |
+|-------------------|-----------------------------------|
+| Operating System  | [Linux/BSD/macOS/Windows]         |
+| Alacritty Version | [`alacritty --version` output]    |
+| Display Server    | [X11/Wayland]   (only on Linux)   |
+| Window Manager    | [i3/xfwm/...]   (only on Linux)   |
+| Compositor        | [compton/...]   (only on Linux)   |
+| PTY Backend       | [WinPTY/ConPTY] (only on Windows) |
 
 # Logs
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+Please make sure to document all user-facing changes in the `CANGELOG.md` file.
+
+Please ensure the optional CI steps do not fail because of this PR. Unless otherwise requested, PRs
+are reviewed once CI succeeeds.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,6 @@
 Please make sure to document all user-facing changes in the `CANGELOG.md` file.
 
-Please ensure the optional CI steps do not fail because of this PR. Unless otherwise requested, PRs
-are reviewed once CI succeeeds.
+Please ensure the optional CI steps do not fail because of this PR.
+
+Draft PRs are always welcome, though unless otherwise requested PRs will not be reviewed until CI is
+successful and they have left the draft stage.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,40 +23,6 @@ Bug reports should be reported in the [Alacritty issue tracker](https://github.c
 
 If a bug was not present in a previous version of Alacritty, providing the exact commit which introduced the regression helps out a lot.
 
-Since a multitude of operating systems are supported by Alacritty, not all issues might apply to every OS. So make sure to specify on which OS the bug has been found. Since Linux has a variety of window managers, compositors and display servers, please also specify those when encountering an issue on Linux.
-
-Depending on the bug, it might also be useful to provide some of the following information:
- - Configuration file
- - `alacritty -v(vv)` output
- - `alacritty --print-events` output
- - `glxinfo` output
- - `xrandr` output
-
-Here's a template that you can use to file a bug, though it's not necessary to use it exactly:
-
-```
-# System
-|                  |                               |
-|------------------|-------------------------------|
-| Operating System | [Linux/BSD/macOS/Windows]     |
-| Rust Version     | [stable/beta/nightly/X.Y.Z]   |
-| Display Server   | [X11/Wayland] (only on Linux) |
-| Window Manager   | [i3/xfwm/...] (only on Linux) |
-| Compositor       | [compton/...] (only on Linux) |
-
-# Summary
-[Short summary of the Bug]
-
-# Behavior
-[Description of Alacritty's current behavior]
-
-# Expectation
-[Description of expected behavior]
-
-# Extra
-[Additional information like config or logs]
-```
-
 ## Patches / Pull Requests
 
 All patches have to be sent on Github as [pull requests](https://github.com/jwilm/alacritty/pulls).


### PR DESCRIPTION
This adds a PR template that should remind users to document their
changes in our CHANGELOG, without requiring too much direct interaction
from the user.

The issue template has also been reworked a bit, hopefully making it
easier for people to report bugs, without intruding on them if the
information is irrelevant or providing it is too much effort.

Fixes #3031.