### PR TITLE
Fix colored row reset performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clipboard escape `OSC 52` not working with empty clipboard parameter
 - Direct escape input on Windows using alt
 - Incorrect window size on X11 when waking up from suspend
-- Incorrect width of Unicode 11/12 emojis
+- Width of Unicode 11/12 emojis
 - Minimize on windows causing layout issues
+- Performance bottleneck when clearing colored rows
 
 ## 0.4.0
 

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -70,6 +70,12 @@ pub trait GridCell {
     fn is_empty(&self) -> bool;
     fn is_wrap(&self) -> bool;
     fn set_wrap(&mut self, wrap: bool);
+
+    /// Fast equality approximation.
+    ///
+    /// This is a faster alternative to [`PartialEq`],
+    /// but might report inequal cells as equal.
+    fn fast_eq(&self, other: Self) -> bool;
 }
 
 /// Represents the terminal display contents
@@ -140,7 +146,7 @@ pub enum Scroll {
     Bottom,
 }
 
-impl<T: GridCell + Copy + Clone> Grid<T> {
+impl<T: GridCell + PartialEq + Copy> Grid<T> {
     pub fn new(lines: index::Line, cols: index::Column, scrollback: usize, template: T) -> Grid<T> {
         let raw = Storage::with_capacity(lines, Row::new(cols, &template));
         Grid {

--- a/alacritty_terminal/src/grid/row.rs
+++ b/alacritty_terminal/src/grid/row.rs
@@ -29,14 +29,10 @@ use crate::index::Column;
 pub struct Row<T> {
     inner: Vec<T>,
 
-    /// occupied entries
+    /// Maximum number of occupied entries.
     ///
-    /// Semantically, this value can be understood as the **end** of an
-    /// Exclusive Range. Thus,
-    ///
-    /// - Zero means there are no occupied entries
-    /// - 1 means there is a value at index zero, but nowhere else
-    /// - `occ == inner.len` means every value is occupied
+    /// This is the upper bound on the number of elements in the row, which have been modified
+    /// since the last reset. All cells after this point are guaranteed to be equal.
     pub(crate) occ: usize,
 }
 
@@ -85,21 +81,29 @@ impl<T: Copy> Row<T> {
         }
     }
 
-    /// Resets contents to the contents of `other`
+    /// Reset all cells in the row to the `template` cell.
+    #[inline]
     pub fn reset(&mut self, template: &T)
     where
-        T: GridCell,
+        T: GridCell + PartialEq + std::fmt::Debug,
     {
-        if template.is_empty() {
-            for item in &mut self.inner[..self.occ] {
-                *item = *template;
-            }
-            self.occ = 0;
-        } else {
-            let len = self.inner.len();
-            self.inner = vec![*template; len];
+        debug_assert!(!self.inner.is_empty());
+
+        let template = *template;
+
+        // Mark all cells as dirty if template cell changed
+        let len = self.inner.len();
+        if !self.inner[len - 1].fast_eq(template) {
             self.occ = len;
         }
+
+        // Reset every dirty in the row
+        // let template = *template;
+        for item in &mut self.inner[..self.occ] {
+            *item = template;
+        }
+
+        self.occ = 0;
     }
 }
 

--- a/alacritty_terminal/src/grid/row.rs
+++ b/alacritty_terminal/src/grid/row.rs
@@ -85,7 +85,7 @@ impl<T: Copy> Row<T> {
     #[inline]
     pub fn reset(&mut self, template: &T)
     where
-        T: GridCell + PartialEq + std::fmt::Debug,
+        T: GridCell + PartialEq,
     {
         debug_assert!(!self.inner.is_empty());
 

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -29,6 +29,10 @@ impl GridCell for usize {
     }
 
     fn set_wrap(&mut self, _wrap: bool) {}
+
+    fn fast_eq(&self, other: Self) -> bool {
+        self == &other
+    }
 }
 
 // Scroll up moves lines upwards

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -85,6 +85,11 @@ impl GridCell for Cell {
             self.flags.remove(Flags::WRAPLINE);
         }
     }
+
+    #[inline]
+    fn fast_eq(&self, other: Self) -> bool {
+        self.bg == other.bg
+    }
 }
 
 /// Get the length of occupied cells in a line


### PR DESCRIPTION
This fixes a bug where a row would always get reset completely if its
background does not equal the default terminal background. This leads to
big performance bottlenecks when running commands like `echo "\e[41m" &&
yes`.

Instead of resetting the entire row whenever the template cell is not
empty, the template cell is now compared to the last cell in the row.
The last cell will always be equal to the previous template cell when
`row.occ < row.inner.len()` and if `occ` is equal to the row's length,
the entire row is always reset anyways.

Fixes #2989.