### PR TITLE
Improve error handling for Winpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Width of Unicode 11/12 emojis
 - Minimize on windows causing layout issues
 - Performance bottleneck when clearing colored rows
-- Lack of error message explaining why shell could not start on Windows (when using Winpty backend)
+- Vague startup crash messages on Windows with WinPTY backend
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Width of Unicode 11/12 emojis
 - Minimize on windows causing layout issues
 - Performance bottleneck when clearing colored rows
+- Lack of error message explaining why shell could not start on Windows (when using Winpty backend)
 
 ## 0.4.0
 

--- a/winpty/src/windows.rs
+++ b/winpty/src/windows.rs
@@ -20,7 +20,7 @@ pub enum ErrorCode {
     AgentDied,
     AgentTimeout,
     AgentCreationFailed,
-    UnknownError(u32)
+    UnknownError(u32),
 }
 
 pub enum MouseMode {

--- a/winpty/src/windows.rs
+++ b/winpty/src/windows.rs
@@ -94,6 +94,7 @@ impl Config {
         let mut err = null_mut() as *mut winpty_error_t;
         let config = unsafe { winpty_config_new(flags.bits(), &mut err) };
         check_err(err)?;
+
         Ok(Self(config))
     }
 
@@ -152,6 +153,7 @@ impl Winpty {
         let mut err = null_mut() as *mut winpty_error_t;
         let winpty = unsafe { winpty_open(cfg.0, &mut err) };
         check_err(err)?;
+
         Ok(Self(winpty))
     }
 
@@ -223,6 +225,7 @@ impl Winpty {
         }
 
         check_err(err)?;
+
         Ok(process_list)
     }
 
@@ -304,6 +307,7 @@ impl SpawnConfig {
         };
 
         check_err(err)?;
+
         Ok(Self(spawn_config))
     }
 }

--- a/winpty/src/windows.rs
+++ b/winpty/src/windows.rs
@@ -291,8 +291,7 @@ impl SpawnConfig {
         let cwd = cwd.map(to_wstring);
         let end = end.map(to_wstring);
 
-        let wstring_ptr =
-            |opt: &Option<WideCString>| opt.as_ref().map_or(null(), |ws| ws.as_ptr());
+        let wstring_ptr = |opt: &Option<WideCString>| opt.as_ref().map_or(null(), |ws| ws.as_ptr());
         let spawn_config = unsafe {
             winpty_spawn_config_new(
                 spawnflags.bits(),


### PR DESCRIPTION
Closes #2344

I've managed to make it such that failures to spawn the shell now result in a proper error message being displayed. Turns out the `winpty` crate had a TODO item to plumb through the appropriate error in the `Winpty::spawn` method :smile:

Crashes on the Winpty backend now also display error descriptions such as `SpawnCreateProcessFailed` instead of the Winpty internal error codes (e.g. `2`).