### PR TITLE
Fix minimize on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Direct escape input on Windows using alt
 - Incorrect window size on X11 when waking up from suspend
 - Incorrect width of Unicode 11/12 emojis
+- Minimize on windows causing layout issues
 
 ## 0.4.0
 


### PR DESCRIPTION
This is a potential solution for #3047.

Both WinPTY and ConPTY backends have issues when minimizing because a winit `Resize` event fires which sets the size to zero (and for various reasons both backends don't like this).

Alternative solutions:
- Change winit to not emit a `Resize` event when minimizing. (Perhaps emit some other event.)
- Add an API to winit to check if the window is minimized, and use that instead of checking `lsize.width` and `lsize.height`.

(Closes #3047)