### PR TITLE
Fix deadlock with closing on Windows using Conpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimize on windows causing layout issues
 - Performance bottleneck when clearing colored rows
 - Vague startup crash messages on Windows with WinPTY backend
+- Deadlock on Windows when closing Alacritty using the title bar "X" button (ConPTY backend)
 
 ## 0.4.0
 

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -232,7 +232,7 @@ fn run(window_event_loop: GlutinEventLoop<Event>, config: Config) -> Result<(), 
     // The fix is to ensure that processor is dropped first. That way, when io_thread (i.e. pty)
     // is dropped, it can ensure Conpty is dropped before the conout pipe in the pty drop order.
     //
-    // TODO: refactor the Windows codebase and remove this horrendous workaround!
+    // FIXME: Change PTY API to enforce the correct drop order with the typesystem.
     drop(processor);
 
     // Shutdown PTY parser event loop

--- a/alacritty/src/main.rs
+++ b/alacritty/src/main.rs
@@ -226,8 +226,8 @@ fn run(window_event_loop: GlutinEventLoop<Event>, config: Config) -> Result<(), 
     // The cause:
     //   - Drop for Conpty will deadlock if the conout pipe has already been dropped.
     //   - The conout pipe is dropped when the io_thread is joined below (io_thread owns pty).
-    //   - Conpty is dropped when the last of processor and io_thread are dropped, because
-    //     both of them own an Arc<Conpty>.
+    //   - Conpty is dropped when the last of processor and io_thread are dropped, because both of
+    //     them own an Arc<Conpty>.
     //
     // The fix is to ensure that processor is dropped first. That way, when io_thread (i.e. pty)
     // is dropped, it can ensure Conpty is dropped before the conout pipe in the pty drop order.

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -90,7 +90,7 @@ pub type ConptyHandle = Arc<Conpty>;
 
 impl Drop for Conpty {
     fn drop(&mut self) {
-        // Caution! This will block until the conout pipe is drained. May cause deadlocks if the
+        // XXX: This will block until the conout pipe is drained. Will cause a deadlock if the
         // conout pipe has already been dropped by this point.
         //
         // See PR #3084 and https://docs.microsoft.com/en-us/windows/console/closepseudoconsole

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -90,6 +90,10 @@ pub type ConptyHandle = Arc<Conpty>;
 
 impl Drop for Conpty {
     fn drop(&mut self) {
+        // Caution! This will block until the conout pipe is drained. May cause deadlocks if the
+        // conout pipe has already been dropped by this point.
+        //
+        // See PR #3084 and https://docs.microsoft.com/en-us/windows/console/closepseudoconsole
         unsafe { (self.api.ClosePseudoConsole)(self.handle) }
     }
 }

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -45,8 +45,8 @@ pub enum PtyHandle {
 }
 
 pub struct Pty {
-    // It is important for drop order that this handle is defined before conout. Drop for Conpty
-    // will deadlock if the conout pipe has already been dropped.
+    // XXX: Handle is required to be the first field, to ensure correct drop order. Dropping
+    // `conout` before `handle` will cause a deadlock.
     handle: PtyHandle,
     // TODO: It's on the roadmap for the Conpty API to support Overlapped I/O.
     // See https://github.com/Microsoft/console/issues/262

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -45,6 +45,8 @@ pub enum PtyHandle {
 }
 
 pub struct Pty {
+    // It is important for drop order that this handle is defined before conout. Drop for Conpty
+    // will deadlock if the conout pipe has already been dropped.
     handle: PtyHandle,
     // TODO: It's on the roadmap for the Conpty API to support Overlapped I/O.
     // See https://github.com/Microsoft/console/issues/262


### PR DESCRIPTION
This follows on one more attempt from #3054 and #3074.

This time we're implementing the correct drop order in `Drop for Pty`. To ensure the pseudoconsole is properly closed, I've added a `debug_assert!` to `Drop for Conpty`.

Fingers crossed that this implementation now looks passable :smile:

Fixes #3042