### PR TITLE
Send resize messages through the event loop

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -308,20 +308,18 @@ pub struct Processor<N> {
     suppress_chars: bool,
     modifiers: ModifiersState,
     config: Config,
-    pty_resize_handle: Box<dyn OnResize>,
     message_buffer: MessageBuffer,
     display: Display,
     font_size: Size,
 }
 
-impl<N: Notify> Processor<N> {
+impl<N: Notify + OnResize> Processor<N> {
     /// Create a new event processor
     ///
     /// Takes a writer which is expected to be hooked up to the write end of a
     /// pty.
     pub fn new(
         notifier: N,
-        pty_resize_handle: Box<dyn OnResize>,
         message_buffer: MessageBuffer,
         config: Config,
         display: Display,
@@ -334,7 +332,6 @@ impl<N: Notify> Processor<N> {
             modifiers: Default::default(),
             font_size: config.font.size,
             config,
-            pty_resize_handle,
             message_buffer,
             display,
         }
@@ -405,7 +402,7 @@ impl<N: Notify> Processor<N> {
             if !display_update_pending.is_empty() {
                 self.display.handle_update(
                     &mut terminal,
-                    self.pty_resize_handle.as_mut(),
+                    &mut self.notifier,
                     &self.message_buffer,
                     &self.config,
                     display_update_pending,

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -80,15 +80,13 @@ impl event::Notify for Notifier {
             return;
         }
 
-        self.0.send(Msg::Input(bytes))
-            .expect("send event loop msg");
+        self.0.send(Msg::Input(bytes)).expect("send event loop msg");
     }
 }
 
 impl event::OnResize for Notifier {
     fn on_resize(&mut self, size: &SizeInfo) {
-        self.0.send(Msg::Resize(*size))
-            .expect("expected send event loop msg");
+        self.0.send(Msg::Resize(*size)).expect("expected send event loop msg");
     }
 }
 

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -79,17 +79,16 @@ impl event::Notify for Notifier {
         if bytes.len() == 0 {
             return;
         }
-        if self.0.send(Msg::Input(bytes)).is_err() {
-            panic!("expected send event loop msg");
-        }
+
+        self.0.send(Msg::Input(bytes))
+            .expect("send event loop msg");
     }
 }
 
 impl event::OnResize for Notifier {
     fn on_resize(&mut self, size: &SizeInfo) {
-        if self.0.send(Msg::Resize(*size)).is_err() {
-            panic!("expected send event loop msg");
-        }
+        self.0.send(Msg::Resize(*size))
+            .expect("expected send event loop msg");
     }
 }
 

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -16,7 +16,7 @@ use crate::ansi;
 use crate::config::Config;
 use crate::event::{self, Event, EventListener};
 use crate::sync::FairMutex;
-use crate::term::Term;
+use crate::term::{SizeInfo, Term};
 use crate::tty;
 use crate::util::thread;
 
@@ -31,6 +31,9 @@ pub enum Msg {
 
     /// Indicates that the `EventLoop` should shut down, as Alacritty is shutting down
     Shutdown,
+
+    /// Instruction to resize the pty
+    Resize(SizeInfo),
 }
 
 /// The main event!.. loop.
@@ -77,6 +80,14 @@ impl event::Notify for Notifier {
             return;
         }
         if self.0.send(Msg::Input(bytes)).is_err() {
+            panic!("expected send event loop msg");
+        }
+    }
+}
+
+impl event::OnResize for Notifier {
+    fn on_resize(&mut self, size: &SizeInfo) {
+        if self.0.send(Msg::Resize(*size)).is_err() {
             panic!("expected send event loop msg");
         }
     }
@@ -141,7 +152,7 @@ impl Writing {
 
 impl<T, U> EventLoop<T, U>
 where
-    T: tty::EventedPty + Send + 'static,
+    T: tty::EventedPty + event::OnResize + Send + 'static,
     U: EventListener + Send + 'static,
 {
     /// Create a new event loop
@@ -171,11 +182,12 @@ where
     // Drain the channel
     //
     // Returns `false` when a shutdown message was received.
-    fn drain_recv_channel(&self, state: &mut State) -> bool {
+    fn drain_recv_channel(&mut self, state: &mut State) -> bool {
         while let Ok(msg) = self.rx.try_recv() {
             match msg {
                 Msg::Input(input) => state.write_list.push_back(input),
                 Msg::Shutdown => return false,
+                Msg::Resize(size) => self.pty.on_resize(&size),
             }
         }
 

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -242,7 +242,7 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, _window_id: Option<usize>) ->
     let conpty = Conpty { handle: pty_handle, api };
 
     Some(Pty {
-        inner: super::PtyImpl::Conpty(conpty),
+        backend: super::PtyBackend::Conpty(conpty),
         conout: super::EventedReadablePipe::Anonymous(conout),
         conin: super::EventedWritablePipe::Anonymous(conin),
         read_token: 0.into(),

--- a/alacritty_terminal/src/tty/windows/conpty.rs
+++ b/alacritty_terminal/src/tty/windows/conpty.rs
@@ -17,7 +17,6 @@ use std::io::Error;
 use std::mem;
 use std::os::windows::io::IntoRawHandle;
 use std::ptr;
-use std::sync::Arc;
 
 use dunce::canonicalize;
 use mio_anonymous_pipes::{EventedAnonRead, EventedAnonWrite};
@@ -85,9 +84,6 @@ pub struct Conpty {
     api: ConptyApi,
 }
 
-/// Handle can be cloned freely and moved between threads.
-pub type ConptyHandle = Arc<Conpty>;
-
 impl Drop for Conpty {
     fn drop(&mut self) {
         // XXX: This will block until the conout pipe is drained. Will cause a deadlock if the
@@ -98,9 +94,8 @@ impl Drop for Conpty {
     }
 }
 
-// The Conpty API can be accessed from multiple threads.
+// The Conpty handle can be sent between threads.
 unsafe impl Send for Conpty {}
-unsafe impl Sync for Conpty {}
 
 pub fn new<C>(config: &Config<C>, size: &SizeInfo, _window_id: Option<usize>) -> Option<Pty> {
     if !config.enable_experimental_conpty_backend {
@@ -244,10 +239,10 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, _window_id: Option<usize>) ->
     let conout = EventedAnonRead::new(conout);
 
     let child_watcher = ChildExitWatcher::new(proc_info.hProcess).unwrap();
-    let agent = Conpty { handle: pty_handle, api };
+    let conpty = Conpty { handle: pty_handle, api };
 
     Some(Pty {
-        handle: super::PtyHandle::Conpty(ConptyHandle::new(agent)),
+        inner: super::PtyImpl::Conpty(conpty),
         conout: super::EventedReadablePipe::Anonymous(conout),
         conin: super::EventedWritablePipe::Anonymous(conin),
         read_token: 0.into(),
@@ -262,7 +257,7 @@ fn panic_shell_spawn() {
     panic!("Unable to spawn shell: {}", Error::last_os_error());
 }
 
-impl OnResize for ConptyHandle {
+impl OnResize for Conpty {
     fn on_resize(&mut self, sizeinfo: &SizeInfo) {
         if let Some(coord) = coord_from_sizeinfo(sizeinfo) {
             let result = unsafe { (self.api.ResizePseudoConsole)(self.handle, coord) };

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -38,16 +38,15 @@ pub fn is_conpty() -> bool {
     IS_CONPTY.load(Ordering::Relaxed)
 }
 
-#[derive(Clone)]
-pub enum PtyHandle {
-    Winpty(winpty::WinptyHandle),
-    Conpty(conpty::ConptyHandle),
+enum PtyImpl {
+    Winpty(winpty::Agent),
+    Conpty(conpty::Conpty),
 }
 
 pub struct Pty {
-    // XXX: Handle is required to be the first field, to ensure correct drop order. Dropping
-    // `conout` before `handle` will cause a deadlock.
-    handle: PtyHandle,
+    // XXX: Inner is required to be the first field, to ensure correct drop order. Dropping
+    // `conout` before `inner` will cause a deadlock.
+    inner: PtyImpl,
     // TODO: It's on the roadmap for the Conpty API to support Overlapped I/O.
     // See https://github.com/Microsoft/console/issues/262
     // When support for that lands then it should be possible to use
@@ -58,12 +57,6 @@ pub struct Pty {
     write_token: mio::Token,
     child_event_token: mio::Token,
     child_watcher: ChildExitWatcher,
-}
-
-impl Pty {
-    pub fn resize_handle(&self) -> impl OnResize {
-        self.handle.clone()
-    }
 }
 
 pub fn new<C>(config: &Config<C>, size: &SizeInfo, window_id: Option<usize>) -> Pty {
@@ -189,18 +182,6 @@ impl Write for EventedWritablePipe {
     }
 }
 
-impl OnResize for PtyHandle {
-    fn on_resize(&mut self, sizeinfo: &SizeInfo) {
-        match self {
-            PtyHandle::Winpty(w) => w.resize(sizeinfo),
-            PtyHandle::Conpty(c) => {
-                let mut handle = c.clone();
-                handle.on_resize(sizeinfo)
-            },
-        }
-    }
-}
-
 impl EventedReadWrite for Pty {
     type Reader = EventedReadablePipe;
     type Writer = EventedWritablePipe;
@@ -305,6 +286,15 @@ impl EventedPty for Pty {
             Ok(ev) => Some(ev),
             Err(TryRecvError::Empty) => None,
             Err(TryRecvError::Disconnected) => Some(ChildEvent::Exited),
+        }
+    }
+}
+
+impl OnResize for Pty {
+    fn on_resize(&mut self, size: &SizeInfo) {
+        match &mut self.inner {
+            PtyImpl::Winpty(w) => w.on_resize(size),
+            PtyImpl::Conpty(c) => c.on_resize(size),
         }
     }
 }

--- a/alacritty_terminal/src/tty/windows/mod.rs
+++ b/alacritty_terminal/src/tty/windows/mod.rs
@@ -38,15 +38,15 @@ pub fn is_conpty() -> bool {
     IS_CONPTY.load(Ordering::Relaxed)
 }
 
-enum PtyImpl {
+enum PtyBackend {
     Winpty(winpty::Agent),
     Conpty(conpty::Conpty),
 }
 
 pub struct Pty {
-    // XXX: Inner is required to be the first field, to ensure correct drop order. Dropping
-    // `conout` before `inner` will cause a deadlock.
-    inner: PtyImpl,
+    // XXX: Backend is required to be the first field, to ensure correct drop order. Dropping
+    // `conout` before `backend` will cause a deadlock.
+    backend: PtyBackend,
     // TODO: It's on the roadmap for the Conpty API to support Overlapped I/O.
     // See https://github.com/Microsoft/console/issues/262
     // When support for that lands then it should be possible to use
@@ -292,9 +292,9 @@ impl EventedPty for Pty {
 
 impl OnResize for Pty {
     fn on_resize(&mut self, size: &SizeInfo) {
-        match &mut self.inner {
-            PtyImpl::Winpty(w) => w.on_resize(size),
-            PtyImpl::Conpty(c) => c.on_resize(size),
+        match &mut self.backend {
+            PtyBackend::Winpty(w) => w.on_resize(size),
+            PtyBackend::Conpty(c) => c.on_resize(size),
         }
     }
 }

--- a/alacritty_terminal/src/tty/windows/winpty.rs
+++ b/alacritty_terminal/src/tty/windows/winpty.rs
@@ -100,7 +100,7 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, _window_id: Option<usize>) ->
     let child_watcher = ChildExitWatcher::new(agent.raw_handle()).unwrap();
 
     Pty {
-        inner: super::PtyImpl::Winpty(agent),
+        backend: super::PtyBackend::Winpty(agent),
         conout: super::EventedReadablePipe::Named(conout_pipe),
         conin: super::EventedWritablePipe::Named(conin_pipe),
         read_token: 0.into(),


### PR DESCRIPTION
Closes #3086 

This turned out to be a great idea! I was able to leverage the existing `OnResize` trait and use it to plumb through the messages in a couple places.

I was also able to completely delete the `tty::winpty::Agent` type and just re-export `pub use winpty::Winpty as Agent`.