### PR TITLE
Fix cut off full width glyphs in last column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Incorrect default config path in `--help` on Windows and macOS
+- Semantic selection stopping at full-width glyphs
+- Full-width glyphs cut off in last column
 
 ## 0.4.1
 

--- a/alacritty/src/url.rs
+++ b/alacritty/src/url.rs
@@ -42,7 +42,7 @@ impl Url {
     }
 
     pub fn end(&self) -> Point {
-        self.lines[self.lines.len() - 1].end.sub(self.num_cols, self.end_offset as usize)
+        self.lines[self.lines.len() - 1].end.sub(self.num_cols, self.end_offset as usize, false)
     }
 }
 
@@ -73,11 +73,6 @@ impl Urls {
 
     // Update tracked URLs
     pub fn update(&mut self, num_cols: usize, cell: RenderableCell) {
-        // Ignore double-width spacers to prevent reset
-        if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
-            return;
-        }
-
         // Convert cell to character
         let c = match cell.inner {
             RenderableCellContent::Chars(chars) => chars[0],
@@ -85,19 +80,27 @@ impl Urls {
         };
 
         let point: Point = cell.into();
-        let mut end = point;
+        let end = point;
 
         // Reset URL when empty cells have been skipped
-        if point != Point::default() && Some(point.sub(num_cols, 1)) != self.last_point {
+        if point != Point::default() && Some(point.sub(num_cols, 1, false)) != self.last_point {
             self.reset();
         }
 
-        // Extend by one cell for double-width characters
-        if cell.flags.contains(Flags::WIDE_CHAR) {
-            end.col += 1;
-        }
-
         self.last_point = Some(end);
+
+        // Extend current state if a wide char spacer is encountered
+        if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+            if let UrlLocation::Url(_, mut end_offset) = self.state {
+                if end_offset != 0 {
+                    end_offset += 1;
+                }
+
+                self.extend_url(point, end, cell.fg, end_offset);
+            }
+
+            return;
+        }
 
         // Advance parser
         let last_state = mem::replace(&mut self.state, self.locator.advance(c));

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -382,27 +382,23 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
             }
 
             loop {
-                let mut wrapped = row.shrink(cols);
-
-                // Insert spacer if a wide char would be wrapped into the last column
-                if row.len() >= cols.0 && row[cols - 1].flags().contains(Flags::WIDE_CHAR) {
-                    if let Some(wrapped) = &mut wrapped {
-                        wrapped.insert(0, row[cols - 1]);
-                    }
-
-                    let mut spacer = *template;
-                    spacer.flags_mut().insert(Flags::WIDE_CHAR_SPACER);
-                    row[cols - 1] = spacer;
-                }
-
                 // Check if reflowing shoud be performed
-                let mut wrapped = match wrapped {
+                let mut wrapped = match row.shrink(cols) {
                     Some(wrapped) if reflow => wrapped,
                     _ => {
                         new_raw.push(row);
                         break;
                     },
                 };
+
+                // Insert spacer if a wide char would be wrapped into the last column
+                if row.len() >= cols.0 && row[cols - 1].flags().contains(Flags::WIDE_CHAR) {
+                    wrapped.insert(0, row[cols - 1]);
+
+                    let mut spacer = *template;
+                    spacer.flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+                    row[cols - 1] = spacer;
+                }
 
                 // Remove wide char spacer before shrinking
                 let len = wrapped.len();

--- a/alacritty_terminal/src/grid/mod.rs
+++ b/alacritty_terminal/src/grid/mod.rs
@@ -288,8 +288,11 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
         let mut new_empty_lines = 0;
         let mut reversed: Vec<Row<T>> = Vec::with_capacity(self.raw.len());
         for (i, mut row) in self.raw.drain().enumerate().rev() {
-            let last_row = match reversed.last_mut() {
-                Some(last_row) if should_reflow(last_row) => last_row,
+            // FIXME: Rust 1.39.0+ allows moving in pattern guard here
+            // Check if reflowing shoud be performed
+            let mut last_row = reversed.last_mut();
+            let last_row = match last_row {
+                Some(ref mut last_row) if should_reflow(last_row) => last_row,
                 _ => {
                     reversed.push(row);
                     continue;
@@ -385,9 +388,11 @@ impl<T: GridCell + PartialEq + Copy> Grid<T> {
             }
 
             loop {
+                // FIXME: Rust 1.39.0+ allows moving in pattern guard here
                 // Check if reflowing shoud be performed
-                let mut wrapped = match row.shrink(cols) {
-                    Some(wrapped) if reflow => wrapped,
+                let wrapped = row.shrink(cols);
+                let mut wrapped = match wrapped {
+                    Some(_) if reflow => wrapped.unwrap(),
                     _ => {
                         new_raw.push(row);
                         break;

--- a/alacritty_terminal/src/grid/storage.rs
+++ b/alacritty_terminal/src/grid/storage.rs
@@ -330,17 +330,20 @@ mod test {
     use crate::grid::storage::Storage;
     use crate::grid::GridCell;
     use crate::index::{Column, Line};
+    use crate::term::cell::Flags;
 
     impl GridCell for char {
         fn is_empty(&self) -> bool {
             *self == ' ' || *self == '\t'
         }
 
-        fn is_wrap(&self) -> bool {
-            false
+        fn flags(&self) -> &Flags {
+            unimplemented!();
         }
 
-        fn set_wrap(&mut self, _wrap: bool) {}
+        fn flags_mut(&mut self) -> &mut Flags {
+            unimplemented!();
+        }
 
         fn fast_eq(&self, other: Self) -> bool {
             self == &other

--- a/alacritty_terminal/src/grid/tests.rs
+++ b/alacritty_terminal/src/grid/tests.rs
@@ -24,11 +24,13 @@ impl GridCell for usize {
         *self == 0
     }
 
-    fn is_wrap(&self) -> bool {
-        false
+    fn flags(&self) -> &Flags {
+        unimplemented!();
     }
 
-    fn set_wrap(&mut self, _wrap: bool) {}
+    fn flags_mut(&mut self) -> &mut Flags {
+        unimplemented!();
+    }
 
     fn fast_eq(&self, other: Self) -> bool {
         self == &other

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -44,24 +44,32 @@ impl<L> Point<L> {
 
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn sub(mut self, num_cols: usize, length: usize) -> Point<L>
+    pub fn sub(mut self, num_cols: usize, length: usize, absolute_indexing: bool) -> Point<L>
     where
-        L: Copy + Sub<usize, Output = L>,
+        L: Copy + Add<usize, Output = L> + Sub<usize, Output = L>,
     {
         let line_changes = f32::ceil(length.saturating_sub(self.col.0) as f32 / num_cols as f32);
-        self.line = self.line - line_changes as usize;
+        if absolute_indexing {
+            self.line = self.line + line_changes as usize;
+        } else {
+            self.line = self.line - line_changes as usize;
+        }
         self.col = Column((num_cols + self.col.0 - length % num_cols) % num_cols);
         self
     }
 
     #[inline]
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    pub fn add(mut self, num_cols: usize, length: usize) -> Point<L>
+    pub fn add(mut self, num_cols: usize, length: usize, absolute_indexing: bool) -> Point<L>
     where
-        L: Copy + Add<usize, Output = L>,
+        L: Copy + Add<usize, Output = L> + Sub<usize, Output = L>,
     {
-        let line_changes = length.saturating_sub(self.col.0) / num_cols;
-        self.line = self.line + line_changes;
+        let line_changes = (length + self.col.0) / num_cols;
+        if absolute_indexing {
+            self.line = self.line - line_changes;
+        } else {
+            self.line = self.line + line_changes;
+        }
         self.col = Column((self.col.0 + length) % num_cols);
         self
     }

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -478,7 +478,7 @@ mod test {
         assert_eq!(selection.to_span(&term(1, 1)).unwrap(), Span {
             start: location,
             end: location,
-            is_block: false,
+            is_block: false
         });
     }
 
@@ -496,7 +496,7 @@ mod test {
         assert_eq!(selection.to_span(&term(1, 1)).unwrap(), Span {
             start: location,
             end: location,
-            is_block: false,
+            is_block: false
         });
     }
 
@@ -619,7 +619,7 @@ mod test {
         assert_eq!(selection.to_span(&term(5, 10)).unwrap(), Span {
             start: Point::new(2, Column(4)),
             end: Point::new(0, Column(4)),
-            is_block: true,
+            is_block: true
         });
     }
 

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -244,7 +244,7 @@ impl Selection {
             }
 
             // Include all double-width cells and placeholders at bottom right of selection
-            if span.end.line != 0 && span.end.col + 1 <= num_cols {
+            if span.end.line != 0 || span.end.col < num_cols {
                 // Expand from wide char spacer for linewrapping to wide char
                 if (span.end.line + 1 != grid.len() || span.end.col.0 != 0)
                     && flag_at(span.end, Flags::WIDE_CHAR_SPACER)

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -77,17 +77,13 @@ impl GridCell for Cell {
     }
 
     #[inline]
-    fn is_wrap(&self) -> bool {
-        self.flags.contains(Flags::WRAPLINE)
+    fn flags(&self) -> &Flags {
+        &self.flags
     }
 
     #[inline]
-    fn set_wrap(&mut self, wrap: bool) {
-        if wrap {
-            self.flags.insert(Flags::WRAPLINE);
-        } else {
-            self.flags.remove(Flags::WRAPLINE);
-        }
+    fn flags_mut(&mut self) -> &mut Flags {
+        &mut self.flags
     }
 
     #[inline]

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -67,9 +67,13 @@ impl GridCell for Cell {
             && self.extra[0] == ' '
             && self.bg == Color::Named(NamedColor::Background)
             && self.fg == Color::Named(NamedColor::Foreground)
-            && !self
-                .flags
-                .intersects(Flags::INVERSE | Flags::UNDERLINE | Flags::STRIKEOUT | Flags::WRAPLINE | Flags::WIDE_CHAR_SPACER)
+            && !self.flags.intersects(
+                Flags::INVERSE
+                    | Flags::UNDERLINE
+                    | Flags::STRIKEOUT
+                    | Flags::WRAPLINE
+                    | Flags::WIDE_CHAR_SPACER,
+            )
     }
 
     #[inline]

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -69,7 +69,7 @@ impl GridCell for Cell {
             && self.fg == Color::Named(NamedColor::Foreground)
             && !self
                 .flags
-                .intersects(Flags::INVERSE | Flags::UNDERLINE | Flags::STRIKEOUT | Flags::WRAPLINE)
+                .intersects(Flags::INVERSE | Flags::UNDERLINE | Flags::STRIKEOUT | Flags::WRAPLINE | Flags::WIDE_CHAR_SPACER)
     }
 
     #[inline]

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1273,8 +1273,6 @@ impl<T: EventListener> Handler for Term<T> {
     /// A character to be displayed
     #[inline]
     fn input(&mut self, c: char) {
-        let num_cols = self.grid.num_cols();
-
         // If enabled, scroll to bottom when character is received
         if self.auto_scroll {
             self.scroll_display(Scroll::Bottom);
@@ -1302,7 +1300,9 @@ impl<T: EventListener> Handler for Term<T> {
             self.wrapline();
         }
 
-        // If in insert mode, first shift cells to the right.
+        let num_cols = self.grid.num_cols();
+
+        // If in insert mode, first shift cells to the right
         if self.mode.contains(TermMode::INSERT) && self.cursor.point.col + width < num_cols {
             let line = self.cursor.point.line;
             let col = self.cursor.point.col;
@@ -1317,7 +1317,7 @@ impl<T: EventListener> Handler for Term<T> {
 
         if width == 1 {
             self.write_at_cursor(c);
-        } else if width == 2 {
+        } else {
             // Insert extra placeholder before wide char if glyph doesn't fit in this row anymore
             if self.cursor.point.col + 1 >= num_cols {
                 self.write_at_cursor(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
@@ -1332,7 +1332,7 @@ impl<T: EventListener> Handler for Term<T> {
             self.write_at_cursor(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
         }
 
-        if (self.cursor.point.col + 1) < num_cols {
+        if self.cursor.point.col + 1 < num_cols {
             self.cursor.point.col += 1;
         } else {
             self.input_needs_wrap = true;

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1318,7 +1318,7 @@ impl<T: EventListener> Handler for Term<T> {
         if width == 1 {
             self.write_at_cursor(c);
         } else if width == 2 {
-            // Insert extra placeholder before wide char if glyph doesn't fit this row anymore
+            // Insert extra placeholder before wide char if glyph doesn't fit in this row anymore
             if self.cursor.point.col + 1 >= num_cols {
                 self.write_at_cursor(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
                 self.wrapline();

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1186,7 +1186,7 @@ impl<T> Term<T> {
         &mut self.clipboard
     }
 
-    /// TODO: Document
+    /// Insert a linebreak at the current cursor position.
     #[inline]
     fn wrapline(&mut self)
     where
@@ -1210,9 +1210,9 @@ impl<T> Term<T> {
         self.input_needs_wrap = false;
     }
 
-    /// TODO: Document, Naming?
+    /// Write `c` to the cell at the cursor position.
     #[inline]
-    fn write_cursor_cell(&mut self, c: char) -> &mut Cell
+    fn write_at_cursor(&mut self, c: char) -> &mut Cell
     where
         T: EventListener,
     {
@@ -1270,7 +1270,6 @@ impl<T: EventListener> Handler for Term<T> {
         }
     }
 
-    // TODO: Lots of duplicate code
     /// A character to be displayed
     #[inline]
     fn input(&mut self, c: char) {
@@ -1317,20 +1316,20 @@ impl<T: EventListener> Handler for Term<T> {
         }
 
         if width == 1 {
-            self.write_cursor_cell(c);
+            self.write_at_cursor(c);
         } else if width == 2 {
-            // Insert placeholder and linebreak if only one cell left for wide glyph
+            // Insert extra placeholder before wide char if glyph doesn't fit this row anymore
             if self.cursor.point.col + 1 >= num_cols {
-                self.write_cursor_cell(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
-
+                self.write_at_cursor(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
                 self.wrapline();
             }
 
-            // Write char to cell and set full width flag
-            self.write_cursor_cell(c).flags.insert(Flags::WIDE_CHAR);
+            // Write full width glyph to current cursor cell
+            self.write_at_cursor(c).flags.insert(Flags::WIDE_CHAR);
 
+            // Write spacer to cell following the wide glyph
             self.cursor.point.col += 1;
-            self.write_cursor_cell(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
+            self.write_at_cursor(' ').flags.insert(Flags::WIDE_CHAR_SPACER);
         }
 
         if (self.cursor.point.col + 1) < num_cols {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -69,7 +69,9 @@ impl<T> Search for Term<T> {
         let last_col = self.grid.num_cols() - Column(1);
 
         while let Some(cell) = iter.prev() {
-            if self.semantic_escape_chars.contains(cell.c) {
+            if !cell.flags.intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER)
+                && self.semantic_escape_chars.contains(cell.c)
+            {
                 break;
             }
 
@@ -91,7 +93,9 @@ impl<T> Search for Term<T> {
         let last_col = self.grid.num_cols() - 1;
 
         while let Some(cell) = iter.next() {
-            if self.semantic_escape_chars.contains(cell.c) {
+            if !cell.flags.intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER)
+                && self.semantic_escape_chars.contains(cell.c)
+            {
                 break;
             }
 
@@ -1181,6 +1185,30 @@ impl<T> Term<T> {
     pub fn clipboard(&mut self) -> &mut Clipboard {
         &mut self.clipboard
     }
+
+    /// TODO: Document
+    #[inline]
+    fn wrapline(&mut self)
+    where
+        T: EventListener,
+    {
+        if !self.mode.contains(TermMode::LINE_WRAP) {
+            return;
+        }
+
+        trace!("Wrapping input");
+
+        self.grid[&self.cursor.point].flags.insert(Flags::WRAPLINE);
+
+        if (self.cursor.point.line + 1) >= self.scroll_region.end {
+            self.linefeed();
+        } else {
+            self.cursor.point.line += 1;
+        }
+
+        self.cursor.point.col = Column(0);
+        self.input_needs_wrap = false;
+    }
 }
 
 impl<T> TermInfo for Term<T> {
@@ -1195,7 +1223,7 @@ impl<T> TermInfo for Term<T> {
     }
 }
 
-impl<T: EventListener> ansi::Handler for Term<T> {
+impl<T: EventListener> Handler for Term<T> {
     #[inline]
     #[cfg(not(windows))]
     fn set_title(&mut self, title: &str) {
@@ -1233,82 +1261,75 @@ impl<T: EventListener> ansi::Handler for Term<T> {
     /// A character to be displayed
     #[inline]
     fn input(&mut self, c: char) {
+        let num_cols = self.grid.num_cols();
+
         // If enabled, scroll to bottom when character is received
         if self.auto_scroll {
             self.scroll_display(Scroll::Bottom);
         }
 
-        if self.input_needs_wrap {
-            if !self.mode.contains(TermMode::LINE_WRAP) {
-                return;
-            }
-
-            trace!("Wrapping input");
-
-            {
-                let location = Point { line: self.cursor.point.line, col: self.cursor.point.col };
-
-                let cell = &mut self.grid[&location];
-                cell.flags.insert(Flags::WRAPLINE);
-            }
-
-            if (self.cursor.point.line + 1) >= self.scroll_region.end {
-                self.linefeed();
-            } else {
-                self.cursor.point.line += 1;
-            }
-
-            self.cursor.point.col = Column(0);
-            self.input_needs_wrap = false;
-        }
-
         // Number of cells the char will occupy
-        if let Some(width) = c.width() {
-            let num_cols = self.grid.num_cols();
+        let width = match c.width() {
+            Some(width) => width,
+            None => return,
+        };
 
-            // If in insert mode, first shift cells to the right.
-            if self.mode.contains(TermMode::INSERT) && self.cursor.point.col + width < num_cols {
-                let line = self.cursor.point.line;
-                let col = self.cursor.point.col;
-                let line = &mut self.grid[line];
-
-                let src = line[col..].as_ptr();
-                let dst = line[(col + width)..].as_mut_ptr();
-                unsafe {
-                    // memmove
-                    ptr::copy(src, dst, (num_cols - col - width).0);
-                }
+        // Handle zero-width characters
+        if width == 0 {
+            let mut col = self.cursor.point.col.0.saturating_sub(1);
+            let line = self.cursor.point.line;
+            if self.grid[line][Column(col)].flags.contains(Flags::WIDE_CHAR_SPACER) {
+                col = col.saturating_sub(1);
             }
+            self.grid[line][Column(col)].push_extra(c);
+            return;
+        }
 
-            // Handle zero-width characters
-            if width == 0 {
-                let mut col = self.cursor.point.col.0.saturating_sub(1);
-                let line = self.cursor.point.line;
-                if self.grid[line][Column(col)].flags.contains(Flags::WIDE_CHAR_SPACER) {
-                    col = col.saturating_sub(1);
-                }
-                self.grid[line][Column(col)].push_extra(c);
-                return;
-            }
+        // Move cursor to next line
+        if self.input_needs_wrap {
+            self.wrapline();
+        }
 
-            let cell = &mut self.grid[&self.cursor.point];
-            *cell = self.cursor.template;
-            cell.c = self.cursor.charsets[self.active_charset].map(c);
+        // If in insert mode, first shift cells to the right.
+        if self.mode.contains(TermMode::INSERT) && self.cursor.point.col + width < num_cols {
+            let line = self.cursor.point.line;
+            let col = self.cursor.point.col;
+            let line = &mut self.grid[line];
 
-            // Handle wide chars
-            if width == 2 {
-                cell.flags.insert(Flags::WIDE_CHAR);
-
-                if self.cursor.point.col + 1 < num_cols {
-                    self.cursor.point.col += 1;
-                    let spacer = &mut self.grid[&self.cursor.point];
-                    *spacer = self.cursor.template;
-                    spacer.flags.insert(Flags::WIDE_CHAR_SPACER);
-                }
+            let src = line[col..].as_ptr();
+            let dst = line[(col + width)..].as_mut_ptr();
+            unsafe {
+                ptr::copy(src, dst, (num_cols - col - width).0);
             }
         }
 
-        if (self.cursor.point.col + 1) < self.grid.num_cols() {
+        // Insert placeholder and linebreak if only one cell left for wide glyph
+        if width == 2 && self.cursor.point.col + 1 >= num_cols {
+            // TODO: Duplicate #1
+            let spacer = &mut self.grid[&self.cursor.point];
+            *spacer = self.cursor.template;
+            spacer.flags.insert(Flags::WIDE_CHAR_SPACER);
+
+            self.wrapline();
+        }
+
+        // Write char to cell
+        let cell = &mut self.grid[&self.cursor.point];
+        *cell = self.cursor.template;
+        cell.c = self.cursor.charsets[self.active_charset].map(c);
+
+        // Set wide char flag and insert placeholder
+        if width == 2 {
+            cell.flags.insert(Flags::WIDE_CHAR);
+
+            self.cursor.point.col += 1;
+            // TODO: Duplicate #2
+            let spacer = &mut self.grid[&self.cursor.point];
+            *spacer = self.cursor.template;
+            spacer.flags.insert(Flags::WIDE_CHAR_SPACER);
+        }
+
+        if (self.cursor.point.col + 1) < num_cols {
             self.cursor.point.col += 1;
         } else {
             self.input_needs_wrap = true;


### PR DESCRIPTION
This resolves the issue with full width glyphs getting rendered in the
last column. Since they need at least two glyphs, it is not possible to
properly render them in the last column.

Instead of rendering half of the glyph in the last column, with the
other half cut off, an additional spacer is now inserted before the wide
glyph. This means that the specific glyph in question is then three
cells wide.

Fixes #2385.