### PR TITLE
Remove unneeded NamedPipe::connect() calls

### DIFF
--- a/alacritty_terminal/src/tty/windows/winpty.rs
+++ b/alacritty_terminal/src/tty/windows/winpty.rs
@@ -81,20 +81,6 @@ pub fn new<C>(config: &Config<C>, size: &SizeInfo, _window_id: Option<usize>) ->
         );
     };
 
-    if let Some(err) = conout_pipe.connect().err() {
-        if err.kind() != io::ErrorKind::WouldBlock {
-            panic!(err);
-        }
-    }
-    assert!(conout_pipe.take_error().unwrap().is_none());
-
-    if let Some(err) = conin_pipe.connect().err() {
-        if err.kind() != io::ErrorKind::WouldBlock {
-            panic!(err);
-        }
-    }
-    assert!(conin_pipe.take_error().unwrap().is_none());
-
     agent.spawn(&spawnconfig).unwrap();
 
     let child_watcher = ChildExitWatcher::new(agent.raw_handle()).unwrap();


### PR DESCRIPTION
In the way the code was set up, these calls would always do nothing and return `io::ErrorKind::WouldBlock`, so they can be safely removed.

([See source for connect](https://docs.rs/mio-named-pipes/0.1.6/x86_64-pc-windows-msvc/src/mio_named_pipes/lib.rs.html#186) if you wish to confirm this yourself)

In a more Windows API minded sense, calling `ConnectNamedPipe` is not about establishing a pipe connection; opening the file already does that. `ConnectNamedPipe` allows the pipe server to wait for a client to connect.

`ConnectNamedPipe` also expects to be called with the pipe server handle, not a client pipe handle, so I think that calling `.connect()` in this fashion would actually return Windows API errors if it ever got past the initial check that makes `.connect()` return `WouldBlock`.

