### PR TITLE
Replace deprecated Error methods

### DIFF
--- a/alacritty/src/config/mod.rs
+++ b/alacritty/src/config/mod.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::fmt::{self, Display, Formatter};
+use std::fs;
 use std::io;
 use std::path::PathBuf;
 
@@ -21,7 +22,6 @@ pub use crate::config::bindings::{Action, Binding, Key, RelaxedEq};
 #[cfg(test)]
 pub use crate::config::mouse::{ClickHandler, Mouse};
 use crate::config::ui_config::UIConfig;
-use std::fs::read_to_string;
 
 pub type Config = TermConfig<UIConfig>;
 
@@ -147,7 +147,7 @@ pub fn reload_from(path: &PathBuf) -> Result<Config> {
 }
 
 fn read_config(path: &PathBuf) -> Result<Config> {
-    let mut contents = read_to_string(path)?;
+    let mut contents = fs::read_to_string(path)?;
 
     // Remove UTF-8 BOM
     if contents.chars().nth(0) == Some('\u{FEFF}') {

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -15,7 +15,7 @@
 //! The display subsystem including window management, font rasterization, and
 //! GPU drawing.
 use std::f64;
-use std::fmt;
+use std::fmt::{self, Formatter};
 use std::time::Instant;
 
 use glutin::dpi::{PhysicalPosition, PhysicalSize};
@@ -61,45 +61,45 @@ pub enum Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::Window(e) => e.source(),
-            Error::Font(e) => e.source(),
-            Error::Render(e) => e.source(),
-            Error::ContextError(e) => e.source(),
+            Error::Window(err) => err.source(),
+            Error::Font(err) => err.source(),
+            Error::Render(err) => err.source(),
+            Error::ContextError(err) => err.source(),
         }
     }
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Error::Window(ref err) => err.fmt(f),
-            Error::Font(ref err) => err.fmt(f),
-            Error::Render(ref err) => err.fmt(f),
-            Error::ContextError(ref err) => err.fmt(f),
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Window(err) => err.fmt(f),
+            Error::Font(err) => err.fmt(f),
+            Error::Render(err) => err.fmt(f),
+            Error::ContextError(err) => err.fmt(f),
         }
     }
 }
 
 impl From<window::Error> for Error {
-    fn from(val: window::Error) -> Error {
+    fn from(val: window::Error) -> Self {
         Error::Window(val)
     }
 }
 
 impl From<font::Error> for Error {
-    fn from(val: font::Error) -> Error {
+    fn from(val: font::Error) -> Self {
         Error::Font(val)
     }
 }
 
 impl From<renderer::Error> for Error {
-    fn from(val: renderer::Error) -> Error {
+    fn from(val: renderer::Error) -> Self {
         Error::Render(val)
     }
 }
 
 impl From<glutin::ContextError> for Error {
-    fn from(val: glutin::ContextError) -> Error {
+    fn from(val: glutin::ContextError) -> Self {
         Error::ContextError(val)
     }
 }
@@ -223,7 +223,7 @@ impl Display {
             _ => (),
         }
 
-        Ok(Display {
+        Ok(Self {
             window,
             renderer,
             glyph_cache,

--- a/alacritty/src/display.rs
+++ b/alacritty/src/display.rs
@@ -59,21 +59,12 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn (std::error::Error)> {
-        match *self {
-            Error::Window(ref err) => Some(err),
-            Error::Font(ref err) => Some(err),
-            Error::Render(ref err) => Some(err),
-            Error::ContextError(ref err) => Some(err),
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::Window(ref err) => err.description(),
-            Error::Font(ref err) => err.description(),
-            Error::Render(ref err) => err.description(),
-            Error::ContextError(ref err) => err.description(),
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Window(e) => e.source(),
+            Error::Font(e) => e.source(),
+            Error::Render(e) => e.source(),
+            Error::ContextError(e) => e.source(),
         }
     }
 }

--- a/alacritty/src/renderer/mod.rs
+++ b/alacritty/src/renderer/mod.rs
@@ -38,6 +38,7 @@ use alacritty_terminal::term::cell::{self, Flags};
 use alacritty_terminal::term::color::Rgb;
 use alacritty_terminal::term::{self, CursorKey, RenderableCell, RenderableCellContent, SizeInfo};
 use alacritty_terminal::util;
+use std::fmt::{self, Display, Formatter};
 
 pub mod rects;
 
@@ -80,13 +81,13 @@ pub enum Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::ShaderCreation(e) => e.source(),
+            Error::ShaderCreation(err) => err.source(),
         }
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "There was an error initializing the shaders: {}", self)
     }
 }
@@ -278,7 +279,7 @@ impl GlyphCache {
         FontDesc::new(desc.family.clone(), style)
     }
 
-    pub fn get<'a, L>(&'a mut self, glyph_key: GlyphKey, loader: &mut L) -> &'a Glyph
+    pub fn get<L>(&mut self, glyph_key: GlyphKey, loader: &mut L) -> &Glyph
     where
         L: LoadGlyph,
     {
@@ -1420,20 +1421,20 @@ pub enum ShaderCreationError {
 impl std::error::Error for ShaderCreationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            ShaderCreationError::Io(e) => e.source(),
+            ShaderCreationError::Io(err) => err.source(),
             _ => None,
         }
     }
 }
 
-impl std::fmt::Display for ShaderCreationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            ShaderCreationError::Io(ref err) => write!(f, "Couldn't read shader: {}", err),
-            ShaderCreationError::Compile(ref path, ref log) => {
+impl Display for ShaderCreationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ShaderCreationError::Io(err) => write!(f, "Couldn't read shader: {}", err),
+            ShaderCreationError::Compile(path, log) => {
                 write!(f, "Failed compiling shader at {}: {}", path.display(), log)
             },
-            ShaderCreationError::Link(ref log) => write!(f, "Failed linking shader: {}", log),
+            ShaderCreationError::Link(log) => write!(f, "Failed linking shader: {}", log),
         }
     }
 }

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -299,7 +299,7 @@ impl Window {
     }
 
     #[cfg(windows)]
-    pub const fn set_urgent(&self, _is_urgent: bool) {}
+    pub fn set_urgent(&self, _is_urgent: bool) {}
 
     pub fn set_outer_position(&self, pos: LogicalPosition) {
         self.window().set_outer_position(pos);

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -14,7 +14,7 @@
 use std::convert::From;
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::ffi::c_void;
-use std::fmt;
+use std::fmt::{self, Display, Formatter};
 #[cfg(not(any(target_os = "macos", windows)))]
 use std::os::raw::c_ulong;
 
@@ -66,19 +66,19 @@ type Result<T> = std::result::Result<T, Error>;
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::ContextCreation(e) => e.source(),
-            Error::Context(e) => e.source(),
-            Error::Font(e) => e.source(),
+            Error::ContextCreation(err) => err.source(),
+            Error::Context(err) => err.source(),
+            Error::Font(err) => err.source(),
         }
     }
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Error::ContextCreation(ref err) => write!(f, "Error creating GL context; {}", err),
-            Error::Context(ref err) => write!(f, "Error operating on render context; {}", err),
-            Error::Font(ref err) => err.fmt(f),
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::ContextCreation(err) => write!(f, "Error creating GL context; {}", err),
+            Error::Context(err) => write!(f, "Error operating on render context; {}", err),
+            Error::Font(err) => err.fmt(f),
         }
     }
 }
@@ -118,7 +118,7 @@ fn create_gl_window(
         .build_windowed(window, event_loop)?;
 
     // Make the context current so OpenGL operations can run
-    let windowed_context = unsafe { windowed_context.make_current().map_err(|(_, e)| e)? };
+    let windowed_context = unsafe { windowed_context.make_current().map_err(|(_, err)| err)? };
 
     Ok(windowed_context)
 }

--- a/alacritty/src/window.rs
+++ b/alacritty/src/window.rs
@@ -61,22 +61,14 @@ pub enum Error {
 }
 
 /// Result of fallible operations concerning a Window.
-type Result<T> = ::std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, Error>;
 
-impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
-        match *self {
-            Error::ContextCreation(ref err) => Some(err),
-            Error::Context(ref err) => Some(err),
-            Error::Font(ref err) => Some(err),
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::ContextCreation(ref _err) => "Error creating gl context",
-            Error::Context(ref _err) => "Error operating on render context",
-            Error::Font(ref err) => err.description(),
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::ContextCreation(e) => e.source(),
+            Error::Context(e) => e.source(),
+            Error::Font(e) => e.source(),
         }
     }
 }
@@ -92,19 +84,19 @@ impl fmt::Display for Error {
 }
 
 impl From<glutin::CreationError> for Error {
-    fn from(val: glutin::CreationError) -> Error {
+    fn from(val: glutin::CreationError) -> Self {
         Error::ContextCreation(val)
     }
 }
 
 impl From<glutin::ContextError> for Error {
-    fn from(val: glutin::ContextError) -> Error {
+    fn from(val: glutin::ContextError) -> Self {
         Error::Context(val)
     }
 }
 
 impl From<font::Error> for Error {
-    fn from(val: font::Error) -> Error {
+    fn from(val: font::Error) -> Self {
         Error::Font(val)
     }
 }
@@ -171,7 +163,7 @@ impl Window {
             }
         }
 
-        Ok(Window { current_mouse_cursor, mouse_visible: true, windowed_context })
+        Ok(Self { current_mouse_cursor, mouse_visible: true, windowed_context })
     }
 
     pub fn set_inner_size(&mut self, size: LogicalSize) {
@@ -307,7 +299,7 @@ impl Window {
     }
 
     #[cfg(windows)]
-    pub fn set_urgent(&self, _is_urgent: bool) {}
+    pub const fn set_urgent(&self, _is_urgent: bool) {}
 
     pub fn set_outer_position(&self, pos: LogicalPosition) {
         self.window().set_outer_position(pos);

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -15,7 +15,7 @@
 //! Rasterization powered by FreeType and FontConfig
 use std::cmp::{min, Ordering};
 use std::collections::HashMap;
-use std::fmt;
+use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
 use freetype::freetype_sys;
@@ -46,7 +46,7 @@ struct Face {
 }
 
 impl fmt::Debug for Face {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("Face")
             .field("ft_face", &self.ft_face)
             .field("key", &self.key)
@@ -670,21 +670,21 @@ pub enum Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::FreeType(e) => e.source(),
+            Error::FreeType(err) => err.source(),
             _ => None,
         }
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Error::FreeType(e) => e.fmt(f),
-            Error::MissingFont(e) => write!(
+            Error::FreeType(err) => err.fmt(f),
+            Error::MissingFont(err) => write!(
                 f,
                 "Couldn't find a font with {}\n\tPlease check the font config in your \
                  alacritty.yml.",
-                e
+                err
             ),
             Error::FontNotLoaded => f.write_str("Tried to use a font that hasn't been loaded"),
             Error::MissingSizeMetrics => {

--- a/font/src/ft/mod.rs
+++ b/font/src/ft/mod.rs
@@ -668,32 +668,23 @@ pub enum Error {
 }
 
 impl std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match *self {
-            Error::FreeType(ref err) => Some(err),
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::FreeType(e) => e.source(),
             _ => None,
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::FreeType(ref err) => err.description(),
-            Error::MissingFont(ref _desc) => "Couldn't find the requested font",
-            Error::FontNotLoaded => "Tried to operate on font that hasn't been loaded",
-            Error::MissingSizeMetrics => "Tried to get size metrics from a face without a size",
         }
     }
 }
 
 impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match *self {
-            Error::FreeType(ref err) => err.fmt(f),
-            Error::MissingFont(ref desc) => write!(
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::FreeType(e) => e.fmt(f),
+            Error::MissingFont(e) => write!(
                 f,
                 "Couldn't find a font with {}\n\tPlease check the font config in your \
                  alacritty.yml.",
-                desc
+                e
             ),
             Error::FontNotLoaded => f.write_str("Tried to use a font that hasn't been loaded"),
             Error::MissingSizeMetrics => {

--- a/winpty/src/windows.rs
+++ b/winpty/src/windows.rs
@@ -80,8 +80,8 @@ impl Display for Error {
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        &self.message
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
     }
 }
 


### PR DESCRIPTION
- Display::fmt instead of Error::description
- Error::source instead of Error::cause
- Adjacent linting opportunities performed.